### PR TITLE
Docker compose Typo Error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     ports:
       - "5002:5002"
     environment:
-      - FLAS_RUN_HOST=0.0.0.0
+      - FLASK_RUN_HOST=0.0.0.0
       - FLASK_RUN_PORT=5002
       - FLASK_APP=server.py
     volumes:


### PR DESCRIPTION
The docker Compose is having a typo error, fixed that as a patch