### PR TITLE
Switch data loading and data export min icon

### DIFF
--- a/frontend/urban-workflows/src/components/styles.tsx
+++ b/frontend/urban-workflows/src/components/styles.tsx
@@ -212,9 +212,9 @@ export const BoxContainer = ({
         } else if (boxType === BoxType.DATA_CLEANING) {
             return faBroom;
         } else if (boxType === BoxType.DATA_EXPORT) {
-            return faDownload;
-        } else if (boxType === BoxType.DATA_LOADING) {
             return faUpload;
+        } else if (boxType === BoxType.DATA_LOADING) {
+            return faDownload;
         } else if (boxType === BoxType.DATA_POOL) {
             return faServer;
         } else if (boxType === BoxType.DATA_TRANSFORMATION) {


### PR DESCRIPTION
When the data loading module window is minimized using the "-" button on the top left, the icon shown in the minimized box didn't match the icon for data loading in the module panel. The icon in the module panel for data loading is the download icon but its minimized box showed the upload icon. Similarly, the icon on the module panel for data export is the upload icon but its minimized box showed the download icon. 

For instance, the minimized module in this screenshot is actually the data loading module, but the icon, when compared with the icons in the module panel on the left, matches that of the data export module.
<img width="667" alt="Screenshot 2025-04-24 at 16 43 25" src="https://github.com/user-attachments/assets/20f142df-25f1-484a-a014-21f972a8bf94" />

This PR fixes this by simply swapping the minimized module icons for data loading and data export.