### PR TITLE
This PR fixes a mismatch in the environment variable reference used to configure the sandbox port in backend/config.py.

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -24,5 +24,5 @@ class Config:
     FRONTEND_RELATIVE_PATH = (os.environ.get('FRONTEND_RELATIVE_PATH') or
                                 '../urban-workflows')
     FRONTEND_PORT = os.environ.get('FRONTEND_PORT') or 3000
-    SANDBOX_PORT = os.environ.get('FRONTEND_PORT') or 2000
+    SANDBOX_PORT = os.environ.get('SANDBOX_PORT') or 2000
 


### PR DESCRIPTION
The variable SANDBOX_PORT is being assigned using:


SANDBOX_PORT = int(os.getenv("FRONTEND_PORT", 2000))  # Incorrect
This mistakenly pulls from FRONTEND_PORT, which is semantically unrelated and may cause the sandbox to run on an unintended port.

 Fix:
Replaced it with the correct environment variable:


SANDBOX_PORT = int(os.getenv("SANDBOX_PORT", 2000))  #  Correct