### PR TITLE
Remove automatic 'flask db migrate' from backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,6 @@ ENV FLASK_RUN_HOST=0.0.0.0
 ENV FLASK_RUN_PORT=5002
 ENV FLASK_APP=server.py
 RUN FLASK_APP=server.py flask db upgrade
-RUN FLASK_APP=server.py flask db migrate -m "Migration"
+
 EXPOSE 5002
 CMD ["python", "server.py"]


### PR DESCRIPTION
Running `flask db migrate` during image build can lead to inconsistent  or unintended migrations. This command is intended for development only  to detect schema changes and generate migration scripts.

Instead, only `flask db upgrade` should be used in Docker to apply  pre-existing migrations, ensuring safer and reproducible builds.