### PR TITLE
Delete sandbox/docker-compose.yaml

### DIFF
--- a/sandbox/docker-compose.yaml
+++ b/sandbox/docker-compose.yaml
@@ -1,9 +1,0 @@
-version: '3.8'
-
-services:
-  api:
-    build: .
-    ports:
-      - 2000:2000
-    volumes:
-      - .:/app


### PR DESCRIPTION
This removes the unused sandbox/docker-compose.yaml file. Its functionality is fully handled by the root-level docker-compose.yml, and there are no references to this file elsewhere in the repository. Cleaning it up improves repo clarity and reduces confusion.