### PR TITLE
optimized DataPool node performance

### DIFF
--- a/utk_curio/frontend/urban-workflows/src/services/api.ts
+++ b/utk_curio/frontend/urban-workflows/src/services/api.ts
@@ -22,8 +22,42 @@ export async function fetchData(fileName: string, vega: boolean = false) {
         console.log(`Fetched data`, jsonData);
 
         return jsonData;
-    } catch (error) {
-        console.error("Error:", error.message);
+    } catch (error: unknown) {
+        console.error("Error:", error instanceof Error ? error.message : String(error));
+        throw error;
+    }
+}
+
+/**
+ * Fetches a preview version of the data (first 100 rows) for display purposes.
+ * This is more efficient than fetching the entire dataset when only displaying data.
+ * 
+ * @param fileName - The name of the file to fetch
+ * @returns The preview data with metadata about row counts
+ */
+export async function fetchPreviewData(fileName: string) {
+    try {
+        // Use the correct backend URL
+        const backendUrl = process.env.BACKEND_URL || 'http://localhost:5002';
+        const url = `${backendUrl}/get-preview?fileName=${encodeURIComponent(fileName)}`;
+        console.log(`[fetchPreviewData] Fetching preview from ${url}`);
+        
+        const response = await fetch(url, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            throw new Error(`Failed to fetch preview ${url}: ${response.statusText}`);
+        }
+
+        const jsonData = await response.json();
+        console.log(`[fetchPreviewData] Fetched preview data:`, jsonData);
+
+        return jsonData;
+    } catch (error: unknown) {
+        console.error("[fetchPreviewData] Error:", error instanceof Error ? error.message : String(error));
         throw error;
     }
 }


### PR DESCRIPTION
# Describe your changes

Optimization of DataPool node performance by implementing a preview system for table display. This reduces data transfer for the display portion of DataPool functionality, while interaction processing still requires full dataset transfer to frontend.

**Scope of Changes:**
- **Display Layer**: Now uses preview data (first 100 rows) instead of full dataset for table rendering.
- **Interaction Layer**: Unchanged, still transfers full dataset for interaction processing and node communication.
- **Performance Impact**: Reduces data transfer for display purposes.

**Note**: This is a **partial solution** to issue #39. The complete solution would require moving interaction processing to the backend, which seemed too complex without having more clarity from the team. This change provides immediate performance improvement for display while preserving all existing functionality. I will be working on moving interaction processing to the backend and adding unit tests for DataPoolBox.tsx soon!

# Issue resolved by this PR (if any)
- Issue Number: #39 
- Link: #39 

# Type of change (Check all that apply)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Other: 

# Parts of Curio impacted by this PR:
- [x] Frontend
- [x] Backend
- [ ] Sandbox

# Testing
- [ ] Unit Tests
- [x] Manual Testing (please provide details below)

- Verified table display shows identical appearance to before (first 100 rows)
- Confirmed all interactions and node-to-node communication preserved
- Ran the manual tests in /tests directory

# Screenshots (if relevant)

# Checklist (Check all that apply)
- [x] I have manually loaded each .json test from the `tests/` folder into Curio, ran all the nodes one by one, and checked that they run without errors and give the expected results
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules