### PR TITLE
FiX UI overlap when using parameter bindings

### DIFF
--- a/utk_curio/frontend/urban-workflows/src/components/VegaBox.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/VegaBox.tsx
@@ -297,7 +297,10 @@ function VegaBox({ data, isConnectable }) {
           const container = document.getElementById("vega" + data.nodeId);
           const parentContainer = container?.parentElement;
           if (parentContainer) {
+            // Check if the container has any elements with the class 'vega-bind'
             const hasBindings = container.querySelector('.vega-bind') !== null;
+            
+            // Dynamically adjust the padding of the parent container based on the presence of bindings
             parentContainer.style.paddingBottom = hasBindings ? '25px' : '';
           }
         });

--- a/utk_curio/frontend/urban-workflows/src/components/VegaBox.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/VegaBox.tsx
@@ -293,7 +293,14 @@ function VegaBox({ data, isConnectable }) {
           .initialize("#vega" + data.nodeId)
           .hover();
 
-        view.runAsync();
+        view.runAsync().then(() => {
+          const container = document.getElementById("vega" + data.nodeId);
+          const parentContainer = container?.parentElement;
+          if (parentContainer) {
+            const hasBindings = container.querySelector('.vega-bind') !== null;
+            parentContainer.style.paddingBottom = hasBindings ? '25px' : '';
+          }
+        });
 
         setCurrentView(view);
 


### PR DESCRIPTION
# Describe your changes
Updated the VegaBox component to apply dynamic padding based on the presence of .vega-bind. This resolves UI overlapping when using parameter bindings.

# Issue resolved by this PR (if any)
 - Issue Number: 48
 - Link: https://github.com/urban-toolkit/curio/issues/48

# Type of change (Check all that apply)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Other: 

# Parts of Curio impacted by this PR:
- [x] Frontend
- [ ] Backend
- [ ] Sandbox

# Testing
 - [ ] Unit Tests
 - [x] Manual Testing (please refer to screenshots section)

# Screenshots (if relevant)
<img width="684" alt="Screenshot 2025-07-07 at 2 57 00 PM" src="https://github.com/user-attachments/assets/63cd5401-c0ff-45d2-bad1-f1f4d22b250e" />
<img width="677" alt="Screenshot 2025-07-07 at 2 57 09 PM" src="https://github.com/user-attachments/assets/f5404b1e-7853-47c0-93ce-59fc0693c650" />

https://github.com/user-attachments/assets/2b7112a1-5ef8-4c74-817f-d29a9a32e2de

# Checklist (Check all that apply)
- [x] I have manually loaded each .json test from the `tests/` folder into Curio, ran all the nodes one by one, and checked that they run without errors and give the expected results
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

