### PR TITLE
Fix Data Export output error

### DIFF
--- a/utk_curio/sandbox/util/parsers.py
+++ b/utk_curio/sandbox/util/parsers.py
@@ -45,6 +45,8 @@ def validate_output(data, boxType):
     if boxType in ['DATA_LOADING', 'DATA_CLEANING', 'DATA_TRANSFORMATION']:
         check_valid_output(data, boxType)
     elif boxType == 'DATA_EXPORT':
+        if data.get('dataType') in ['', None]:
+            return
         raise Exception(f'{boxType} does not support output')
 
 


### PR DESCRIPTION
# Describe your changes
Added a conditional check in the validate_output function to allow DATA_EXPORT nodes to silently pass when no output is returned from the user code. Specifically, the function now checks whether data.get('dataType') is empty or None, and skips raising an exception in such cases.

# Issue resolved by this PR (if any)
 - Issue Number: https://github.com/urban-toolkit/curio/issues/54
 - Link: https://github.com/urban-toolkit/curio/issues/54

# Type of change (Check all that apply)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Other: 

# Parts of Curio impacted by this PR:
- [ ] Frontend
- [ ] Backend
- [x] Sandbox

# Testing
 - [ ] Unit Tests
 - [x] Manual Testing (please provide details below)

# Screenshots (if relevant)
<img width="1161" alt="Screenshot 2025-07-08 at 7 35 54 PM" src="https://github.com/user-attachments/assets/b8a43b47-dddb-4001-a992-1f9d794b08ee" />
<img width="1157" alt="Screenshot 2025-07-08 at 7 36 07 PM" src="https://github.com/user-attachments/assets/ff9c98de-53a5-460f-bbcc-4e6d3004b41a" />


# Checklist (Check all that apply)
- [x] I have manually loaded each .json test from the `tests/` folder into Curio, ran all the nodes one by one, and checked that they run without errors and give the expected results
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

