### PR TITLE
Merge node fix

### DIFF
--- a/utk_curio/frontend/urban-workflows/src/components/MergeFlowBox.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/MergeFlowBox.tsx
@@ -12,7 +12,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
 import { useUserContext } from "../providers/UserProvider";
 
-function MergeFlowBox({ data, isConnectable }) {
+function MergeFlowBox({ data, isConnectable }: { data: any; isConnectable: boolean }) {
     const [output, setOutput] = useState<{ code: string; content: string }>({
         code: "",
         content: JSON.stringify({ data: [], dataType: "outputs" }),
@@ -64,15 +64,24 @@ function MergeFlowBox({ data, isConnectable }) {
 
         let newOutput: any = { data: [], dataType: "outputs" };
 
-        if (Array.isArray(data.input) && data.input.length > 0) {
-            for (const input of data.input) {
-                if (input != "" && input != undefined) {
-                    newOutput.data.push(input);
-                }
+        if (Array.isArray(data.input)) {
+            // Process primary input [0] then secondary input [1]
+            const primaryInput = data.input[0];
+            const secondaryInput = data.input[1];
+            
+            if (primaryInput !== undefined && primaryInput !== "") {
+                newOutput.data.push(primaryInput);
             }
-
-            setOutput({ code: "success", content: newOutput });
-            data.outputCallback(data.nodeId, newOutput);
+            
+            if (secondaryInput !== undefined && secondaryInput !== "") {
+                newOutput.data.push(secondaryInput);
+            }
+            
+            // Only trigger output callback if we have at least one valid input
+            if (newOutput.data.length > 0) {
+                setOutput({ code: "success", content: newOutput });
+                data.outputCallback(data.nodeId, newOutput);
+            }
         }
     }, [data.input]);
 

--- a/utk_curio/frontend/urban-workflows/src/providers/FlowProvider.tsx
+++ b/utk_curio/frontend/urban-workflows/src/providers/FlowProvider.tsx
@@ -138,9 +138,6 @@ const FlowProvider = ({ children }: { children: ReactNode }) => {
         _setWorkflowName(data);
     };
 
-    const showMergeNodeGuidance = () => {
-        console.info("🔗 Merge Node Guide: Connect primary data to TOP-LEFT input ('in'), secondary data to BOTTOM-LEFT input ('in_2'). Position matters for predictable processing!");
-    };
 
     useEffect(() => {
         addWorkflow(workflowNameRef.current);
@@ -663,11 +660,8 @@ const FlowProvider = ({ children }: { children: ReactNode }) => {
                         (edge.targetHandle === "in" || edge.targetHandle === "in_2")
                     );
                     
-                    // Show guidance if this is the first connection
-                    if (existingConnections.length === 0) {
-                        showMergeNodeGuidance();
-                    } else if (existingConnections.length >= 2) {
-                        alert("Merge node can only accept 2 input connections (primary and secondary data)");
+                    if (existingConnections.length >= 2) {
+                        alert("Connection Limit Reached!\n\nMerge nodes can only accept 2 input connections:\n• TOP-LEFT input = Primary data\n• BOTTOM-LEFT input = Secondary data\n\nPlease remove an existing connection first.");
                         allowConnection = false;
                     }
                 }


### PR DESCRIPTION
# Describe your changes

This PR fixes inconsistent merge node behavior by introducing position-based input handling. Previously, merge nodes used a loop-based approach that led to unpredictable input ordering. Now:

- in (top-left) is always the primary input.
- in_2 (bottom-left) is always the secondary input.

**Key Improvements**
- Replaced loop-based logic with explicit positional merging.
- Prevented invalid states by disallowing more than two inputs.
- Improved TypeScript typings and input handling in FlowProvider.

**Note:** This fix applies to new connections only. Existing workflows with incorrect merge node setups may need manual updates.

Thanks to @tuanduc8t1 for identifying this, it's an important UX issue.



# Issue resolved by this PR (if any)
 - Issue Number: N/A
 - Link: User experience improvement raised by [@ducnt2406](https://github.com/ducnt2406)

# Type of change (Check all that apply)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Other: 

# Parts of Curio impacted by this PR:
- [x] Frontend
- [ ] Backend
- [ ] Sandbox

# Testing
 - [ ] Unit Tests
 - [x] Manual Testing (please provide details below)


# Screenshots (if relevant)
<img width="453" alt="Screenshot 2025-07-09 at 16 44 42" src="https://github.com/user-attachments/assets/6f405e27-e77a-468e-96db-95af1010cf76" />
<img width="1512" alt="Screenshot 2025-07-09 at 16 44 54" src="https://github.com/user-attachments/assets/06c4329a-2f84-404b-940e-7346433916eb" />



# Checklist (Check all that apply)
- [x] I have manually loaded each .json test from the `tests/` folder into Curio, ran all the nodes one by one, and checked that they run without errors and give the expected results
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules