### PR TITLE
Download feature added in Data Export Box

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -35,6 +35,16 @@ This document is meant for **undergraduate students** involved in UTK, Curio, an
 
 Curio uses UTK while Urbanite builds on Curio with LLM-powered capabilities. If you would like to learn more about the design and research behind these tools, please see the research papers linked in each repository.
 
+
+> "We have seen that computer programming is an art, because it applies accumulated knowledge to the world, because it requires skill and ingenuity, and especially because it produces objects of beauty. A programmer who subconsciously views himself as an artist will enjoy what he does and will do it better."  
+> — Donald Knuth
+
+As you code for Curio, remember that things not working is a normal, expected part of programming. Debugging is not just about fixing mistakes; it is how programmers learn, understand, and improve their work. Each error you encounter is an opportunity to clarify your thinking, discover how the systems and frameworks truly work, and refine your design. **This is the craft you are developing.** Treat debugging and refinement as part of your learning, not interruptions to it.
+
+As you learn, consider reading [Peter Norvig’s "Teach Yourself Programming in Ten Years"](https://norvig.com/21-days.html). Norvig emphasizes that programming is not about shortcuts or overnight mastery but about learning deeply, practicing consistently, and staying curious while building meaningful systems. Likewise, Donald Knuth, one of the most respected computer scientists, describes programming as an art that requires creativity, skill, and the pursuit of clarity and beauty in your work. You can read his classic perspective in ["Computer Programming as an Art"](https://dl.acm.org/doi/pdf/10.1145/1283920.1283929).
+
+When your code breaks or your pipeline fails, take a breath: this is not a reason for frustration, but an invitation to engage with programming and strengthen your ability to think, debug, and build effectively.
+
 ## 2. Core Technologies
 
 Curio is built using **React** and **TypeScript**. For an overview of React, see [this tutorial](https://react.dev/learn) and [this tutorial](https://beta.reactjs.org/learn).

--- a/utk_curio/frontend/urban-workflows/src/components/DataExportBox.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/DataExportBox.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import { useRef } from "react";
 import { Handle, Position } from "reactflow";
 import BoxEditor from "./editing/BoxEditor";
 
@@ -28,7 +27,7 @@ function DataExportBox({ data, isConnectable }) {
   
   const [downloadFormat, setDownloadFormat] = useState<string>("csv");
   const [code, setCode] = useState<string>("");
-  
+
   const sendCode = async () => {
     // Set output to "exec" to trigger loading spinner in the UI
     setOutput({ code: "exec", content: "", outputType: downloadFormat });


### PR DESCRIPTION
# Describe your changes
Added export format selection (csv, json, geojson) to DataExportBox with dynamic download support for both dataframe and geodataframe, including flattened CSV output for geospatial data.

# Issue resolved by this PR (if any)
 - Issue Number: 23
 - Link: https://github.com/urban-toolkit/curio/issues/23

# Type of change (Check all that apply)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Other: 

# Parts of Curio impacted by this PR:
- [x] Frontend
- [ ] Backend
- [ ] Sandbox

# Testing
 - [ ] Unit Tests
 - [x] Manual Testing (please provide details below)

# Screenshots (if relevant)

https://github.com/user-attachments/assets/833b25a9-c1f0-441e-9acb-4dcd595c1a59


# Checklist (Check all that apply)
- [x] I have manually loaded each .json test from the `tests/` folder into Curio, ran all the nodes one by one, and checked that they run without errors and give the expected results
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

