### PR TITLE
Added three tab system for errors, output, and warnings. (Version one)

### DIFF
--- a/IMPLEMENTATION_GUIDE.md
+++ b/IMPLEMENTATION_GUIDE.md
@@ -1,0 +1,272 @@
+# Implementation Guide: Adding Three Tabs to Your Node
+
+## Overview
+This guide shows you how to implement three tabs in your node following your supervisor's guidance about using BoxEditor and components from the editing folder.
+
+## Key Principles (Following Supervisor's Guidance)
+
+### 1. **Receive Results from Backend**
+- Modify the `useEffect` where you process `data.input` or `output.content`
+- This is where you transform your backend data into tab content
+- Example location: ```72:150:utk_curio/frontend/urban-workflows/src/components/DataPoolBox.tsx```
+
+### 2. **Use Components from Editing Folder**
+- **DO NOT** use inheritance
+- **DO** use the `BoxEditor` component from `./editing/BoxEditor`
+- **DO** create a custom `ContentComponent` that uses Bootstrap tabs
+- **DO** pass your `ContentComponent` to `BoxEditor` via the `contentComponent` prop
+
+## Implementation Steps
+
+### Step 1: Import Required Dependencies
+```typescript
+import BoxEditor from "./editing/BoxEditor";
+import Tabs from "react-bootstrap/Tabs";
+import Tab from "react-bootstrap/Tab";
+```
+
+### Step 2: Add State for Tab Management
+```typescript
+const [activeTab, setActiveTab] = useState<string>("0");
+const [tabData, setTabData] = useState<any[]>([]);
+```
+
+### Step 3: Process Backend Data (Key Location)
+```typescript
+useEffect(() => {
+    const processDataAsync = async () => {
+        try {
+            // Process your input data here
+            let processedData = data.input;
+            
+            // Create three different views of your data
+            const tab1Data = {
+                title: "Summary View",
+                content: processedData.summary || "No summary available",
+                type: "summary"
+            };
+            
+            const tab2Data = {
+                title: "Detailed View", 
+                content: processedData.details || "No details available",
+                type: "details"
+            };
+            
+            const tab3Data = {
+                title: "Analysis View",
+                content: processedData.analysis || "No analysis available", 
+                type: "analysis"
+            };
+
+            // Set the tab data
+            setTabData([tab1Data, tab2Data, tab3Data]);
+            
+            // Update output
+            setOutput({ 
+                code: "success", 
+                content: JSON.stringify([tab1Data, tab2Data, tab3Data], null, 2) 
+            });
+            
+            // Notify downstream
+            data.outputCallback(data.nodeId, [tab1Data, tab2Data, tab3Data]);
+            
+        } catch (error) {
+            console.error("Error processing data:", error);
+            setTabData([]);
+            setOutput({ code: "error", content: "Failed to process data." });
+        }
+    };
+
+    processDataAsync();
+}, [data.input, data.newPropagation]);
+```
+
+### Step 4: Create Content Component
+```typescript
+const ContentComponent = ({
+    tabData,
+    activeTab,
+}: {
+    tabData: any[];
+    activeTab: string;
+}) => {
+    const renderTabContent = (data: any) => {
+        switch (data.type) {
+            case "summary":
+                return (
+                    <div style={{ padding: "15px" }}>
+                        <h4>Summary</h4>
+                        <p>{data.content}</p>
+                    </div>
+                );
+                
+            case "details":
+                return (
+                    <div style={{ padding: "15px" }}>
+                        <h4>Detailed Information</h4>
+                        <div style={{ 
+                            backgroundColor: "#f8f9fa", 
+                            padding: "10px", 
+                            borderRadius: "5px",
+                            fontFamily: "monospace",
+                            fontSize: "12px"
+                        }}>
+                            {data.content}
+                        </div>
+                    </div>
+                );
+                
+            case "analysis":
+                return (
+                    <div style={{ padding: "15px" }}>
+                        <h4>Analysis Results</h4>
+                        <div style={{ 
+                            border: "1px solid #dee2e6", 
+                            padding: "10px", 
+                            borderRadius: "5px" 
+                        }}>
+                            {data.content}
+                        </div>
+                    </div>
+                );
+                
+            default:
+                return (
+                    <div style={{ padding: "15px", textAlign: "center", color: "#666" }}>
+                        No data available for this tab.
+                    </div>
+                );
+        }
+    };
+
+    return (
+        <div style={{ height: "100%", display: "flex", flexDirection: "column" }}>
+            <Tabs
+                id="three-tabs"
+                activeKey={activeTab}
+                onSelect={(k) => setActiveTab(k || "0")}
+                className="mb-3"
+                style={{ flexShrink: 0 }}
+            >
+                {Array.isArray(tabData) && tabData.length > 0 ? (
+                    tabData.map((tab, index) => (
+                        <Tab 
+                            eventKey={index.toString()} 
+                            title={tab.title} 
+                            key={index}
+                            style={{ flex: 1, overflow: "auto" }}
+                        >
+                            <div style={{ 
+                                height: "calc(100vh - 200px)", 
+                                overflowY: "auto",
+                                padding: "10px"
+                            }}>
+                                {renderTabContent(tab)}
+                            </div>
+                        </Tab>
+                    ))
+                ) : (
+                    <Tab eventKey="0" title="No Data">
+                        <div style={{ 
+                            padding: "20px", 
+                            textAlign: "center", 
+                            color: "#666",
+                            height: "calc(100vh - 200px)"
+                        }}>
+                            No data available. Please check your input.
+                        </div>
+                    </Tab>
+                )}
+            </Tabs>
+        </div>
+    );
+};
+```
+
+### Step 5: Use BoxEditor with Content Component
+```typescript
+<BoxEditor
+    customWidgetsCallback={customWidgetsCallback}
+    contentComponent={
+        <ContentComponent
+            tabData={tabData}
+            activeTab={activeTab}
+        />
+    }
+    setSendCodeCallback={(_: any) => {}}
+    code={false} // Set to true if you need code editing
+    grammar={false} // Set to true if you need grammar editing
+    widgets={true} // Set to true if you need custom widgets
+    provenance={false} // Set to true if you need provenance
+    setOutputCallback={setOutput}
+    data={data}
+    output={output}
+    boxType={BoxType.YOUR_BOX_TYPE} // Replace with your box type
+    defaultValue={""}
+    readOnly={false}
+/>
+```
+
+## Pattern from DataPoolBox
+
+The DataPoolBox example shows the exact pattern:
+
+1. **Data Processing**: ```72:150:utk_curio/frontend/urban-workflows/src/components/DataPoolBox.tsx```
+2. **Content Component**: ```672:890:utk_curio/frontend/urban-workflows/src/components/DataPoolBox.tsx```
+3. **BoxEditor Usage**: ```850:890:utk_curio/frontend/urban-workflows/src/components/DataPoolBox.tsx```
+
+## Key Differences for Three Fixed Tabs
+
+Instead of dynamic tabs based on data, you create three fixed tabs:
+
+```typescript
+<Tabs
+    id="data-tabs"
+    activeKey={activeTab}
+    onSelect={(k) => setActiveTab(k || "0")}
+    className="mb-3"
+>
+    {/* Tab 1: Summary View */}
+    <Tab eventKey="0" title="Summary">
+        <div style={{ padding: "15px" }}>
+            <h4>Summary View</h4>
+            <p>This tab shows a summary of the data.</p>
+            <ContentComponent tabData={tabData} activeTab={activeTab} />
+        </div>
+    </Tab>
+    
+    {/* Tab 2: Detailed View */}
+    <Tab eventKey="1" title="Details">
+        <div style={{ padding: "15px" }}>
+            <h4>Detailed View</h4>
+            <p>This tab shows detailed information.</p>
+            <ContentComponent tabData={tabData} activeTab={activeTab} />
+        </div>
+    </Tab>
+    
+    {/* Tab 3: Analysis View */}
+    <Tab eventKey="2" title="Analysis">
+        <div style={{ padding: "15px" }}>
+            <h4>Analysis View</h4>
+            <p>This tab shows analysis results.</p>
+            <ContentComponent tabData={tabData} activeTab={activeTab} />
+        </div>
+    </Tab>
+</Tabs>
+```
+
+## Important Notes
+
+1. **BoxEditor Integration**: The `BoxEditor` component handles the tab navigation and layout automatically
+2. **Content Component**: Your custom content goes in the `contentComponent` prop
+3. **State Management**: Use `activeTab` and `tabData` to manage tab state
+4. **Backend Integration**: Process your data in the `useEffect` and create tab content there
+5. **Reusability**: The `ContentComponent` can be reused across different tabs with different data
+
+## Files Created
+
+- `example_three_tabs_implementation.tsx` - Basic implementation
+- `example_data_pool_style_tabs.tsx` - Following DataPoolBox pattern exactly
+- `IMPLEMENTATION_GUIDE.md` - This guide
+
+Follow this pattern to implement your three tabs while adhering to your supervisor's guidance about using BoxEditor and avoiding inheritance. 

--- a/example_data_pool_style_tabs.tsx
+++ b/example_data_pool_style_tabs.tsx
@@ -1,0 +1,328 @@
+import React, { useState, useEffect, useRef } from "react";
+import { Handle, Position } from "reactflow";
+
+import CSS from "csstype";
+
+// Bootstrap
+import "bootstrap/dist/css/bootstrap.min.css";
+import { BoxType, ResolutionType, VisInteractionType } from "../constants";
+
+import "./Box.css"
+import { BoxContainer } from "./styles";
+
+// mui
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import { IPropagation, useFlowContext } from "../providers/FlowProvider";
+import DescriptionModal from "./DescriptionModal";
+import TemplateModal from "./TemplateModal";
+import { Template } from "../providers/TemplateProvider";
+import { useProvenanceContext } from "../providers/ProvenanceProvider";
+import BoxEditor from "./editing/BoxEditor";
+import { OutputIcon } from "./edges/OutputIcon";
+import { InputIcon } from "./edges/InputIcon";
+
+import { fetchData, fetchPreviewData } from '../services/api';
+import Tabs from "react-bootstrap/Tabs";
+import Tab from "react-bootstrap/Tab";
+
+function YourNodeWithThreeTabs({ data, isConnectable }) {
+    const [templateData, setTemplateData] = useState<Template | any>({});
+    const [output, setOutput] = useState<{ code: string; content: string }>({
+        code: "",
+        content: "",
+    }); // stores the output produced by the last update of this box
+    const [outputTable, setOutputTable] = useState<any[]>([]); // stores the output in a format used by the table
+
+    const [showDescriptionModal, setDescriptionModal] = useState(false);
+    const { workflowNameRef } = useFlowContext();
+    const { boxExecProv } = useProvenanceContext();
+
+    const dataInputBypass = useRef(false);
+
+    const promptDescription = () => {
+        setDescriptionModal(true);
+    };
+
+    const closeDescription = () => {
+        setDescriptionModal(false);
+    };
+
+    const iconStyle: CSS.Properties = {
+        fontSize: "1.5em",
+        color: "#888787",
+    };
+
+    const [activeTab, setActiveTab] = useState<string>("0"); // Track the active tab
+    const [tabData, setTabData] = useState<any[]>([]); // Store data for each tab
+
+    // This is where you receive results from the backend
+    useEffect(() => {
+        const processDataAsync = async () => {
+            try {
+                // Normalize input wrappers: handle merge outputs
+                let wrappers: any[] = [];
+                if (data.input && typeof data.input === 'object') {
+                    if (data.input.dataType === 'outputs' && Array.isArray(data.input.data)) {
+                        wrappers = data.input.data;
+                    } else {
+                        wrappers = [data.input];
+                    }
+                }
+
+                // Fetch each wrapper by filename or path
+                const fetched = await Promise.all(
+                    wrappers.map(async (w) => {
+                        const fileId = w.filename ?? w.path;
+                        if (!fileId) return null;
+                        try {
+                            return await fetchData(fileId);
+                        } catch (err) {
+                            console.error('Fetch failed for', fileId, err);
+                            return null;
+                        }
+                    })
+                );
+
+                // Filter out nulls
+                const tabd = (fetched.filter((x) => x != null) as any[]);
+                setTabData(tabd);
+
+                // Local output (string)
+                setOutput({ code: 'success', content: JSON.stringify(tabd, null, 2) });
+
+                // Notify downstream of raw array
+                data.outputCallback(data.nodeId, tabd);
+            } catch (error) {
+                console.error('Error processing data asynchronously:', error);
+                setTabData([]);
+                setOutput({ code: 'error', content: 'Failed to process data.' });
+            }
+        };
+        processDataAsync();
+    }, [data.input, data.newPropagation]);
+
+    const createTable = (output: any) => {
+        let tableData = [];
+
+        if (output && output.dataType === "dataframe") {
+            let columns = Object.keys(output.data);
+            let dfIndices = Object.keys(output.data[columns[0]]);
+
+            for (let i = 0; i < dfIndices.length; i++) {
+                let element: any = {};
+
+                for (const column of columns) {
+                    element[column] = output.data[column][dfIndices[i]];
+                }
+
+                tableData.push(element);
+            }
+        } else if (output && output.dataType === "geodataframe" && output.data.features.length > 0) {
+            let columns = Object.keys(output.data.features[0].properties);
+
+            for (let i = 0; i < output.data.features.length; i++) {
+                let element: any = {};
+
+                for (const column of columns) {
+                    element[column] = output.data.features[i].properties[column];
+                }
+
+                tableData.push(element);
+            }
+        }
+
+        return tableData;
+    };
+
+    useEffect(() => {
+        setOutputTable(createTable(output.content));
+    }, [output]);
+
+    const shortenString = (str: string) => {
+        if (str.length > 15) {
+            return str.slice(0, 15) + "...";
+        } else {
+            return str;
+        }
+    };
+
+    const customWidgetsCallback = (div: HTMLElement) => {
+        // Add any custom widgets/controls here if needed
+        const label = document.createElement("label");
+        label.textContent = "Custom Control: ";
+        div.appendChild(label);
+        
+        const select = document.createElement("select");
+        select.innerHTML = `
+            <option value="option1">Option 1</option>
+            <option value="option2">Option 2</option>
+            <option value="option3">Option 3</option>
+        `;
+        div.appendChild(select);
+    };
+
+    const ContentComponent = ({
+        tabData,
+        activeTab,
+    }: {
+        tabData: any[];
+        activeTab: string;
+    }) => {
+        const displayTable = tabData[parseInt(activeTab)] || {};
+
+        const tableData = createTable(displayTable);
+
+        return (
+            <div
+                className="nowheel"
+                style={{ overflowY: "auto", height: "100%" }}
+            >
+                <TableContainer component={Paper}>
+                    <Table aria-label="simple table">
+                        {tableData.length > 0 ? (
+                            <TableHead>
+                                <TableRow>
+                                    {Object.keys(tableData[0]).map((column, index) => (
+                                        <TableCell
+                                            style={{ fontWeight: "bold" }}
+                                            key={`cell_header_${index}`}
+                                            align="right"
+                                        >
+                                            {column}
+                                        </TableCell>
+                                    ))}
+                                </TableRow>
+                            </TableHead>
+                        ) : null}
+
+                        <TableBody>
+                            {tableData.slice(0, 100).map((row: any, index: any) => (
+                                <TableRow
+                                    key={`row_${index}`}
+                                    sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+                                >
+                                    {Object.keys(row).map((column, columnIndex) => (
+                                        <TableCell
+                                            key={`cell_${columnIndex}_${index}`}
+                                            align="right"
+                                        >
+                                            {row[column] != undefined && row[column] != null
+                                                ? shortenString(row[column].toString())
+                                                : "null"}
+                                        </TableCell>
+                                    ))}
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            </div>
+        );
+    };
+
+    return (
+        <>
+            {/* Incoming data that will overwrite anything that is inside the pool */}
+            <Handle
+                type="target"
+                position={Position.Left}
+                id="in"
+                isConnectable={isConnectable}
+            />
+            {/* Data going to the next node (replication of incoming data) */}
+            <Handle
+                type="source"
+                position={Position.Right}
+                id="out"
+                isConnectable={isConnectable}
+            />
+            {/* Used to connect visualizations. Data flows in both ways */}
+            <Handle
+                type="source"
+                position={Position.Top}
+                id="in/out"
+                isConnectable={isConnectable}
+            />
+            <BoxContainer
+                nodeId={data.nodeId}
+                data={data}
+                templateData={templateData}
+                setOutputCallback={setOutput}
+                promptDescription={promptDescription}
+            >
+                <InputIcon type="1" />
+
+                <DescriptionModal
+                    nodeId={data.nodeId}
+                    boxType={BoxType.DATA_POOL} // Replace with your box type
+                    name={templateData.name}
+                    description={templateData.description}
+                    accessLevel={templateData.accessLevel}
+                    show={showDescriptionModal}
+                    handleClose={closeDescription}
+                    custom={templateData.custom}
+                />
+
+                <BoxEditor
+                    customWidgetsCallback={customWidgetsCallback}
+                    contentComponent={
+                        <Tabs
+                            id="data-tabs"
+                            activeKey={activeTab}
+                            onSelect={(k) => setActiveTab(k || "0")}
+                            className="mb-3"
+                        >
+                            {/* Tab 1: Summary View */}
+                            <Tab eventKey="0" title="Summary">
+                                <div style={{ padding: "15px" }}>
+                                    <h4>Summary View</h4>
+                                    <p>This tab shows a summary of the data.</p>
+                                    <ContentComponent tabData={tabData} activeTab={activeTab} />
+                                </div>
+                            </Tab>
+                            
+                            {/* Tab 2: Detailed View */}
+                            <Tab eventKey="1" title="Details">
+                                <div style={{ padding: "15px" }}>
+                                    <h4>Detailed View</h4>
+                                    <p>This tab shows detailed information.</p>
+                                    <ContentComponent tabData={tabData} activeTab={activeTab} />
+                                </div>
+                            </Tab>
+                            
+                            {/* Tab 3: Analysis View */}
+                            <Tab eventKey="2" title="Analysis">
+                                <div style={{ padding: "15px" }}>
+                                    <h4>Analysis View</h4>
+                                    <p>This tab shows analysis results.</p>
+                                    <ContentComponent tabData={tabData} activeTab={activeTab} />
+                                </div>
+                            </Tab>
+                        </Tabs>
+                    }
+                    setSendCodeCallback={(_: any) => {}}
+                    code={false}
+                    grammar={false}
+                    widgets={true}
+                    provenance={false}
+                    setOutputCallback={setOutput}
+                    data={data}
+                    output={output}
+                    boxType={BoxType.DATA_POOL} // Replace with your box type
+                    defaultValue={""}
+                    readOnly={false}
+                />
+
+                <OutputIcon type="1" />
+            </BoxContainer>
+        </>
+    );
+}
+
+export default YourNodeWithThreeTabs; 

--- a/example_three_tabs_implementation.tsx
+++ b/example_three_tabs_implementation.tsx
@@ -1,0 +1,288 @@
+import React, { useState, useEffect, useRef } from "react";
+import { Handle, Position } from "reactflow";
+import BoxEditor from "./editing/BoxEditor";
+
+// Bootstrap
+import "bootstrap/dist/css/bootstrap.min.css";
+import { BoxType } from "../constants";
+import "./Box.css"
+
+import { Template, useTemplateContext } from "../providers/TemplateProvider";
+import { BoxContainer } from "./styles";
+import CSS from "csstype";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
+
+import TemplateModal from "./TemplateModal";
+import DescriptionModal from "./DescriptionModal";
+import { useUserContext } from "../providers/UserProvider";
+import { OutputIcon } from "./edges/OutputIcon";
+import { InputIcon } from "./edges/InputIcon";
+
+// Import Bootstrap tabs
+import Tabs from "react-bootstrap/Tabs";
+import Tab from "react-bootstrap/Tab";
+
+function YourNodeWithThreeTabs({ data, isConnectable }) {
+    const [output, setOutput] = useState<{ code: string; content: string }>({
+        code: "",
+        content: "",
+    });
+    const [templateData, setTemplateData] = useState<Template | any>({});
+    const [showDescriptionModal, setDescriptionModal] = useState(false);
+    
+    // State for managing tabs
+    const [activeTab, setActiveTab] = useState<string>("0");
+    const [tabData, setTabData] = useState<any[]>([]);
+
+    const { editUserTemplate } = useTemplateContext();
+    const { user } = useUserContext();
+
+    // This is where you receive results from the backend
+    // Modify this useEffect to process your data and create tab content
+    useEffect(() => {
+        const processDataAsync = async () => {
+            try {
+                // Process your input data here
+                let processedData = data.input;
+                
+                // Example: Create three different views of your data
+                const tab1Data = {
+                    title: "Summary View",
+                    content: processedData.summary || "No summary available",
+                    type: "summary"
+                };
+                
+                const tab2Data = {
+                    title: "Detailed View", 
+                    content: processedData.details || "No details available",
+                    type: "details"
+                };
+                
+                const tab3Data = {
+                    title: "Analysis View",
+                    content: processedData.analysis || "No analysis available", 
+                    type: "analysis"
+                };
+
+                // Set the tab data
+                setTabData([tab1Data, tab2Data, tab3Data]);
+                
+                // Update output
+                setOutput({ 
+                    code: "success", 
+                    content: JSON.stringify([tab1Data, tab2Data, tab3Data], null, 2) 
+                });
+                
+                // Notify downstream
+                data.outputCallback(data.nodeId, [tab1Data, tab2Data, tab3Data]);
+                
+            } catch (error) {
+                console.error("Error processing data:", error);
+                setTabData([]);
+                setOutput({ code: "error", content: "Failed to process data." });
+            }
+        };
+
+        processDataAsync();
+    }, [data.input, data.newPropagation]);
+
+    const promptDescription = () => {
+        setDescriptionModal(true);
+    };
+
+    const closeDescription = () => {
+        setDescriptionModal(false);
+    };
+
+    const iconStyle: CSS.Properties = {
+        fontSize: "1.5em",
+        color: "#888787",
+    };
+
+    // Custom widgets callback for any additional controls
+    const customWidgetsCallback = (div: HTMLElement) => {
+        // Add any custom widgets/controls here if needed
+        const label = document.createElement("label");
+        label.textContent = "Custom Control: ";
+        div.appendChild(label);
+        
+        const select = document.createElement("select");
+        select.innerHTML = `
+            <option value="option1">Option 1</option>
+            <option value="option2">Option 2</option>
+            <option value="option3">Option 3</option>
+        `;
+        div.appendChild(select);
+    };
+
+    // Content Component with three tabs
+    const ContentComponent = ({
+        tabData,
+        activeTab,
+    }: {
+        tabData: any[];
+        activeTab: string;
+    }) => {
+        const currentTabData = tabData[parseInt(activeTab)] || {};
+
+        const renderTabContent = (data: any) => {
+            switch (data.type) {
+                case "summary":
+                    return (
+                        <div style={{ padding: "15px" }}>
+                            <h4>Summary</h4>
+                            <p>{data.content}</p>
+                            {/* Add summary-specific components here */}
+                        </div>
+                    );
+                    
+                case "details":
+                    return (
+                        <div style={{ padding: "15px" }}>
+                            <h4>Detailed Information</h4>
+                            <div style={{ 
+                                backgroundColor: "#f8f9fa", 
+                                padding: "10px", 
+                                borderRadius: "5px",
+                                fontFamily: "monospace",
+                                fontSize: "12px"
+                            }}>
+                                {data.content}
+                            </div>
+                        </div>
+                    );
+                    
+                case "analysis":
+                    return (
+                        <div style={{ padding: "15px" }}>
+                            <h4>Analysis Results</h4>
+                            <div style={{ 
+                                border: "1px solid #dee2e6", 
+                                padding: "10px", 
+                                borderRadius: "5px" 
+                            }}>
+                                {data.content}
+                            </div>
+                        </div>
+                    );
+                    
+                default:
+                    return (
+                        <div style={{ padding: "15px", textAlign: "center", color: "#666" }}>
+                            No data available for this tab.
+                        </div>
+                    );
+            }
+        };
+
+        return (
+            <div style={{ height: "100%", display: "flex", flexDirection: "column" }}>
+                <Tabs
+                    id="three-tabs"
+                    activeKey={activeTab}
+                    onSelect={(k) => setActiveTab(k || "0")}
+                    className="mb-3"
+                    style={{ flexShrink: 0 }}
+                >
+                    {Array.isArray(tabData) && tabData.length > 0 ? (
+                        tabData.map((tab, index) => (
+                            <Tab 
+                                eventKey={index.toString()} 
+                                title={tab.title} 
+                                key={index}
+                                style={{ flex: 1, overflow: "auto" }}
+                            >
+                                <div style={{ 
+                                    height: "calc(100vh - 200px)", 
+                                    overflowY: "auto",
+                                    padding: "10px"
+                                }}>
+                                    {renderTabContent(tab)}
+                                </div>
+                            </Tab>
+                        ))
+                    ) : (
+                        <Tab eventKey="0" title="No Data">
+                            <div style={{ 
+                                padding: "20px", 
+                                textAlign: "center", 
+                                color: "#666",
+                                height: "calc(100vh - 200px)"
+                            }}>
+                                No data available. Please check your input.
+                            </div>
+                        </Tab>
+                    )}
+                </Tabs>
+            </div>
+        );
+    };
+
+    return (
+        <>
+            {/* Input handle */}
+            <Handle
+                type="target"
+                position={Position.Left}
+                id="in"
+                isConnectable={isConnectable}
+            />
+            
+            {/* Output handle */}
+            <Handle
+                type="source"
+                position={Position.Right}
+                id="out"
+                isConnectable={isConnectable}
+            />
+            
+            <BoxContainer
+                nodeId={data.nodeId}
+                data={data}
+                templateData={templateData}
+                setOutputCallback={setOutput}
+                promptDescription={promptDescription}
+            >
+                <InputIcon type="1" />
+
+                <DescriptionModal
+                    nodeId={data.nodeId}
+                    boxType={BoxType.YOUR_BOX_TYPE} // Replace with your box type
+                    name={templateData.name}
+                    description={templateData.description}
+                    accessLevel={templateData.accessLevel}
+                    show={showDescriptionModal}
+                    handleClose={closeDescription}
+                    custom={templateData.custom}
+                />
+
+                {/* This is the key part - using BoxEditor with contentComponent */}
+                <BoxEditor
+                    customWidgetsCallback={customWidgetsCallback}
+                    contentComponent={
+                        <ContentComponent
+                            tabData={tabData}
+                            activeTab={activeTab}
+                        />
+                    }
+                    setSendCodeCallback={(_: any) => {}}
+                    code={false} // Set to true if you need code editing
+                    grammar={false} // Set to true if you need grammar editing
+                    widgets={true} // Set to true if you need custom widgets
+                    provenance={false} // Set to true if you need provenance
+                    setOutputCallback={setOutput}
+                    data={data}
+                    output={output}
+                    boxType={BoxType.YOUR_BOX_TYPE} // Replace with your box type
+                    defaultValue={""}
+                    readOnly={false}
+                />
+
+                <OutputIcon type="1" />
+            </BoxContainer>
+        </>
+    );
+}
+
+export default YourNodeWithThreeTabs; 

--- a/utk_curio/frontend/urban-workflows/src/components/Box.css
+++ b/utk_curio/frontend/urban-workflows/src/components/Box.css
@@ -53,3 +53,22 @@
   border-radius: 50%;
   top: 40px !important;
 }
+
+.error-traceback-scroll {
+  max-height: 100%;
+  overflow-y: auto;
+  background: #ffebee;
+  border-radius: 8px;
+  padding: 16px;
+  font-family: monospace;
+  color: #b71c1c;
+}
+.my-error-node .error-traceback-scroll {
+  max-height: 100%;
+  overflow-y: auto;
+  background: #ffebee;
+  border-radius: 8px;
+  padding: 16px;
+  font-family: monospace;
+  color: #b71c1c;
+}

--- a/utk_curio/frontend/urban-workflows/src/components/COMMON_ERRORS.ts
+++ b/utk_curio/frontend/urban-workflows/src/components/COMMON_ERRORS.ts
@@ -1,0 +1,12 @@
+export const COMMON_ERRORS: Record<string, string> = {
+  NameError: "🧠 NameError: You might be using a variable that hasn’t been defined yet.",
+  SyntaxError: "📝 SyntaxError: There's an issue with your code's syntax.",
+  TypeError: "🔢 TypeError: You might be using the wrong type of value somewhere.",
+  ValueError: "🎯 ValueError: The value you're using is not what was expected.",
+  IndexError: "📦 IndexError: You're trying to access an index that doesn't exist.",
+  KeyError: "🔑 KeyError: A dictionary key you’re looking for doesn't exist.",
+  AttributeError: "🧩 AttributeError: You're trying to access something that doesn’t exist on that object.",
+  ZeroDivisionError: "🧮 ZeroDivisionError: You can’t divide by zero.",
+  ImportError: "📥 ImportError: Something went wrong while importing a module.",
+  IndentationError: "📏 IndentationError: Your code is not indented properly.",
+};

--- a/utk_curio/frontend/urban-workflows/src/components/DataPoolBox.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/DataPoolBox.tsx
@@ -223,13 +223,22 @@ function DataPoolBox({ data, isConnectable }) {
 
                 return mapTypes;
             };
+            //data array error - James
+            /*let typesInput: string[] = [];
 
-            let typesInput: string[] = [];
 
             if (data.input != "") typesInput = data.input.dataType;//getType([data.input]);
 
             let typesOuput: string[] = [...typesInput];
-
+            */
+           let typesInput: string[] = [];
+            if (data.input && data.input.dataType) {
+            typesInput = Array.isArray(data.input.dataType)
+                ? data.input.dataType
+                : [data.input.dataType];
+            }
+            let typesOuput: string[] = [...typesInput];
+            //end data array error - James 
             boxExecProv(
                 startTime,
                 startTime,
@@ -251,19 +260,14 @@ function DataPoolBox({ data, isConnectable }) {
             let parsedOutput = output;
             // parsedOutput.data = parsedOutput.data;
             // console.log("Creating table", parsedOutput);
-
             if (parsedOutput.dataType == "dataframe") {
                 let columns = Object.keys(parsedOutput.data);
                 let dfIndices = Object.keys(parsedOutput.data[columns[0]]);
-
                 for (let i = 0; i < dfIndices.length; i++) {
                     let element: any = {};
-
                     for (const column of columns) {
-                        element[column] =
-                            parsedOutput.data[column][dfIndices[i]];
+                        element[column] = parsedOutput.data[column][dfIndices[i]];
                     }
-
                     tableData.push(element);
                 }
             }
@@ -879,6 +883,7 @@ function DataPoolBox({ data, isConnectable }) {
                     boxType={BoxType.DATA_POOL}
                     defaultValue={""}
                     readOnly={false}
+                    fullscreen={""}
                 />
 
                 <OutputIcon type="1" />

--- a/utk_curio/frontend/urban-workflows/src/components/MainCanvas.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/MainCanvas.tsx
@@ -36,7 +36,6 @@ import { useProvenanceContext } from "../providers/ProvenanceProvider";
 import { buttonStyle } from "./styles";
 import { ToolsMenu, UpMenu } from "components/menus";
 import UniDirectionalEdge from "./edges/UniDirectionalEdge";
-
 import "./MainCanvas.css";
 
 export function MainCanvas() {
@@ -93,7 +92,6 @@ export function MainCanvas() {
 
     const [fileMenuOpen, setFileMenuOpen] = useState(false);
     const closeFileMenu = () => setFileMenuOpen(false);
-
     return (
         <div
             style={{ width: "100vw", height: "100vh" }}
@@ -237,6 +235,8 @@ export function MainCanvas() {
                 <Background />
                 <Controls />
             </ReactFlow>
+            <input hidden type="file" name="file" id="file" />
+
         </div>
     );
 }

--- a/utk_curio/frontend/urban-workflows/src/components/editing/BoxEditor.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/editing/BoxEditor.tsx
@@ -260,7 +260,7 @@ function BoxEditor({
 
                                 <Tab.Pane
                                     eventKey="output"
-                                    style={{ height: "100%" }}
+                                    style={{ height: "100%", overflowY: "auto" }}
                                 >
                                     {outputId != undefined ? (
                                         <div

--- a/utk_curio/frontend/urban-workflows/src/components/menus/nodes/ToolsMenu.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/menus/nodes/ToolsMenu.tsx
@@ -17,7 +17,7 @@ import {
 import { Tooltip, OverlayTrigger } from "react-bootstrap";
 import styles from "./ToolsMenu.module.css";
 
-function DraggableTool({ boxType, icon, tooltip }: { boxType: BoxType; icon: any; tooltip: string }) {
+function DraggableTool({ boxType, icon, tooltip, tutorialID}: { boxType: BoxType; icon: any; tooltip: string; tutorialID?: string }) {//added ID to pass
     return (
         <OverlayTrigger
             placement="right"
@@ -25,6 +25,7 @@ function DraggableTool({ boxType, icon, tooltip }: { boxType: BoxType; icon: any
             overlay={<Tooltip>{tooltip}</Tooltip>}
         >
             <div
+                id={tutorialID}//added this
                 className={styles.optionStyle}
                 draggable
                 onDragStart={(event) => {
@@ -42,16 +43,16 @@ export default function ToolsMenu() {
     return (
         <div>
             <div className={styles.containerStyle}>
-                <DraggableTool boxType={BoxType.DATA_LOADING} icon={faUpload} tooltip="Data Load" />
-                <DraggableTool boxType={BoxType.DATA_EXPORT} icon={faDownload} tooltip="Data Export" />
-                <DraggableTool boxType={BoxType.COMPUTATION_ANALYSIS} icon={faMagnifyingGlassChart} tooltip="Data Analysis" />
-                <DraggableTool boxType={BoxType.DATA_TRANSFORMATION} icon={faDatabase} tooltip="Data Transformation" />
-                <DraggableTool boxType={BoxType.DATA_CLEANING} icon={faBroom} tooltip="Data Cleaning" />
-                <DraggableTool boxType={BoxType.DATA_POOL} icon={faServer} tooltip="Data Pool" />
-                <DraggableTool boxType={BoxType.VIS_UTK} icon={faCube} tooltip="3D Visualization (UTK)" />
-                <DraggableTool boxType={BoxType.VIS_VEGA} icon={faChartLine} tooltip="2D Plot (Vega-Lite)" />
-                <DraggableTool boxType={BoxType.VIS_IMAGE} icon={faImage} tooltip="Image" />
-                <DraggableTool boxType={BoxType.MERGE_FLOW} icon={faCodeMerge} tooltip="Merge Flow" />
+                <DraggableTool tutorialID = 'step-one' boxType={BoxType.DATA_LOADING} icon={faUpload} tooltip="Data Load" />
+                <DraggableTool tutorialID = 'step-two' boxType={BoxType.DATA_EXPORT} icon={faDownload} tooltip="Data Export" />
+                <DraggableTool tutorialID = 'step-three' boxType={BoxType.COMPUTATION_ANALYSIS} icon={faMagnifyingGlassChart} tooltip="Data Analysis" />
+                <DraggableTool tutorialID = 'step-four' boxType={BoxType.DATA_TRANSFORMATION} icon={faDatabase} tooltip="Data Transformation" />
+                <DraggableTool tutorialID = 'step-five' boxType={BoxType.DATA_CLEANING} icon={faBroom} tooltip="Data Cleaning" />
+                <DraggableTool tutorialID = 'step-six' boxType={BoxType.DATA_POOL} icon={faServer} tooltip="Data Pool" />
+                <DraggableTool tutorialID = 'step-seven' boxType={BoxType.VIS_UTK} icon={faCube} tooltip="3D Visualization (UTK)" />
+                <DraggableTool tutorialID = 'step-eight' boxType={BoxType.VIS_VEGA} icon={faChartLine} tooltip="2D Plot (Vega-Lite)" />
+                <DraggableTool tutorialID = 'step-nine' boxType={BoxType.VIS_IMAGE} icon={faImage} tooltip="Image" />
+                <DraggableTool tutorialID = 'step-ten' boxType={BoxType.MERGE_FLOW} icon={faCodeMerge} tooltip="Merge Flow" />
             </div>
         </div>
     );
@@ -61,4 +62,3 @@ const overlayTriggerProps = {
     show: 120,
     hide: 10,
 };
-

--- a/utk_curio/frontend/urban-workflows/src/components/menus/top/UpMenu.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/menus/top/UpMenu.tsx
@@ -9,6 +9,8 @@ import clsx from 'clsx';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faDatabase, faFileImport, faFileExport } from "@fortawesome/free-solid-svg-icons";
 import logo from 'assets/curio.png';
+import introJs from 'intro.js';//new import
+import "intro.js/introjs.css";//this too
 
 export default function UpMenu({
     setDashBoardMode,
@@ -25,6 +27,7 @@ export default function UpMenu({
 }) {
     const [isEditing, setIsEditing] = useState(false);
     const [trillProvenanceOpen, setTrillProvenanceOpen] = useState(false);
+    const [tutorialOpen, setTutorialOpen] = useState(false);
     const [datasetsOpen, setDatasetsOpen] = useState(false);
     const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -62,6 +65,17 @@ export default function UpMenu({
             setIsEditing(false);
         }
     };
+    //James new defintions made here
+
+    const closeTutorial = () => {
+        setTutorialOpen(false);
+    }
+
+    const openTutorial = () => {
+        setTutorialOpen(true);
+    }
+
+    //James new defintions end
 
     const exportTrill = (e:any) => {
         let trill_spec = TrillGenerator.generateTrill(nodes, edges, workflowNameRef.current);
@@ -140,6 +154,75 @@ export default function UpMenu({
         };
     }, [fileMenuOpen]);
 
+    //New code here James
+
+     useEffect(() => {
+        if(tutorialOpen){
+            const intro = introJs();
+
+        intro.setOptions({
+            steps: [
+        {
+            intro: "Welcome to Curio! An IDE used for urban analytics. Let's take a tour!"
+        },
+        {
+          element: '#step-one',  
+          intro: 'This is a Data Loading node. You can code an array for basic sets of data, or load in a file. Then add your code to add it to a dataframe to return.'
+        },
+        {
+          element: '#step-two',  
+          intro: 'Ignore data export. It will soon be retired.'
+        },
+        {
+          element: '#step-three',  
+          intro: 'This is a data analysis node: It performs calculations on the loaded data in order to prepare it for visualization.'
+        },
+        {
+          element: '#step-four',  
+          intro: 'The Data Transformation Node can select different parts of your data to narrow down the focus of your analysis.'
+        },
+        {
+          element: '#step-five',  
+          intro: 'This is a Data Cleaning Node. You can polish your data by removing outliers, fill in missing values, etc. It can also create identifiers for your data.'
+        },
+        {
+          element: '#step-six',  
+          intro: 'This is a data pool node: It is used for displaying data on a grid.'
+        },
+        {
+          element: '#step-seven',  
+          intro: 'This is a 3D Visualization node: It is used to display data in a 3D form. The "grammar" section is code for json files.'
+        },
+        {
+          element: '#step-eight',  
+          intro: 'This is a vega lite node: It is used to display data in any 2D form, like various graphs. The "grammar" section is code for json files.'
+        },
+        {
+          element: '#step-nine',  
+          intro: 'The image node shows a gallary of images.'
+        },
+        {
+          element: '#step-ten',  
+          intro: 'This is a merge flow box. Use it to merge multiple pieces of data into one. It can take up to 5 inputs. Red handles indicate that there is not an edge for the handle. Green indicates that there is an edge. One handle may not have multiple edges.'
+        },
+        {
+          element: '#step-final',  
+          intro: 'Drag and drop nodes into your environment. Now get started!'
+        }
+        ],
+        
+        showStepNumbers: false,
+        showProgress: false,
+        exitOnOverlayClick: false,
+        tooltipClass: "custom-intro-tooltip" ,
+    });
+        intro.start();
+        setTutorialOpen(false);
+        }
+    }, [tutorialOpen]);
+
+    //new code end
+
     return (
         <>
             <div className={clsx(styles.menuBar, "nowheel", "nodrag")}>
@@ -179,6 +262,8 @@ export default function UpMenu({
                         Dashboard Mode
                 </button>
                 <button className={styles.button} onClick={openTrillProvenanceModal}>Provenance</button>
+                <button className={styles.button} onClick={openTutorial}>Tutorial</button>
+                
             </div>
             {/* Right-side top menu */}
             <div className={styles.rightSide}>

--- a/utk_curio/frontend/urban-workflows/webpack.config.js
+++ b/utk_curio/frontend/urban-workflows/webpack.config.js
@@ -44,6 +44,10 @@ module.exports = {
         enforce: "pre",
         test: /\.js$/,
         loader: "source-map-loader",
+        exclude: [
+          /node_modules\/intro\.js/,
+          /node_modules/
+        ],
       },
       {
         test: /\.(png|jpe?g|gif|svg)$/i,


### PR DESCRIPTION
# Describe your changes
Made a three tab system for errors, warning, and output. Made friendly errors too - and made them appear one at a time. Note this is version one. Only one node - computational analysis - got updated to the three tab system. I am looking into changing other tabs that also have Python functionality. There is a text file attached that will help me implement the new features.

# Issue resolved by this PR (if any)
 - Issue Number:
 - Link:

# Type of change (Check all that apply)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Other: 

# Parts of Curio impacted by this PR:
- [ X] Frontend
- [ ] Backend
- [X] Sandbox

# Testing
 - [ ] Unit Tests
 - [ ] Manual Testing (please provide details below)

# Screenshots (if relevant)


# Checklist (Check all that apply)
- [ ] I have manually loaded each .json test from the `tests/` folder into Curio, ran all the nodes one by one, and checked that they run without errors and give the expected results
- [X ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

