### PR TITLE
Improvements of the test cases #88

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -20,10 +20,11 @@ on:
 jobs:
   test-compose:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: 🔨 Build all service images in parallel
         run: docker compose -p curio build --parallel
@@ -85,16 +86,26 @@ jobs:
             python -m unittest discover -s utk_curio/sandbox/tests -t . -p "test_*.py" -v
 
       - name: 🐍 Set up Python (for e2e)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
+
+      - name: 🔧 Give .curio/ permissions for host-side tests
+        run: |
+          # Docker creates .curio/ as root; the host runner needs write
+          # access to create .curio/playwright/expected/ for programmatic
+          # ground-truth data.
+          sudo chmod -R a+rwx .curio/ 2>/dev/null || mkdir -p .curio/playwright/expected
 
       - name: 🎭 Install Playwright and run e2e tests
         run: |
           pip install -r requirements.txt
           python -m playwright install chromium
           cd utk_curio/backend
-          CURIO_E2E_USE_EXISTING=1 PYTHONPATH="$GITHUB_WORKSPACE" \
+          # Hard cap so a stuck browser/test cannot burn the whole job budget (see job timeout-minutes).
+          timeout -k 10 3600 env \
+            PYTHONUNBUFFERED=1 \
+            CURIO_E2E_USE_EXISTING=1 PYTHONPATH="$GITHUB_WORKSPACE" \
             python -m pytest tests/test_frontend/ -v \
               --alluredir="$GITHUB_WORKSPACE/allure-results"
 
@@ -112,7 +123,7 @@ jobs:
 
       - name: 📤 Upload Allure report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: allure-report
           path: allure-report

--- a/.github/workflows/publish-pip-to-pypi.yml
+++ b/.github/workflows/publish-pip-to-pypi.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: 📥 Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: 🐍 Set up Python
       uses: actions/setup-python@v5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,5 @@ services:
     volumes:
       - ./templates:/app/templates
       - ./data:/app/data
+      # Share sandbox .data files with the host so Playwright (runs on host in CI) can read them
+      - ./.curio:/app/.curio

--- a/utk_curio/backend/tests/test_frontend/fixtures.py
+++ b/utk_curio/backend/tests/test_frontend/fixtures.py
@@ -1,6 +1,8 @@
 import os
 import sys
+import json
 import time
+import tempfile
 import pytest
 import subprocess
 from signal import SIGINT
@@ -15,7 +17,9 @@ from .utils import (
     e2e_existing_servers,
     base_url,
     upload_workflow,
+    seed_node_code,
 )
+from .workflow_spec import CODE_TYPES
 
 
 # ---------------------------------------------------------------------------
@@ -186,11 +190,32 @@ def workflow_frontend(frontend_server, workflow_page):
 
 @pytest.fixture(scope="class")
 def loaded_workflow(request, workflow_frontend, workflow_page):
-    """Upload the workflow once and expose spec + page to the class."""
+    """Upload the workflow once and expose spec + page to the class.
+
+    The uploaded JSON has deterministic random seeds injected into every
+    node's code so that browser-side execution matches the programmatic
+    expected-data generation (see ``execute_workflow_programmatically``).
+    The original *spec* (un-seeded) is kept for content assertions — they
+    use a substring check so the seed prefix doesn't break them.
+    """
     from .workflow_spec import parse_workflow
 
     workflow_file = request.param
     spec = parse_workflow(workflow_file)
+
+    # Build a seeded copy of the workflow JSON for the browser upload
+    with open(workflow_file, "r") as f:
+        wf_data = json.load(f)
+    for node_json in wf_data["dataflow"]["nodes"]:
+        content = node_json.get("content", "")
+        if content.strip() and node_json.get("type") in CODE_TYPES:
+            node_json["content"] = seed_node_code(content)
+    seeded_tmp = tempfile.NamedTemporaryFile(
+        suffix=".json", delete=False, mode="w",
+    )
+    json.dump(wf_data, seeded_tmp)
+    seeded_tmp.close()
+
     debug_log(
         "fixtures.py:loaded_workflow",
         "About to upload_workflow",
@@ -202,12 +227,13 @@ def loaded_workflow(request, workflow_frontend, workflow_page):
         },
         "H3,H4",
     )
-    upload_workflow(workflow_page, workflow_frontend, workflow_file, spec.nodes_count)
+    upload_workflow(
+        workflow_page, workflow_frontend, seeded_tmp.name, spec.nodes_count,
+    )
     request.cls.spec = spec
     request.cls.page = workflow_page
     yield
-    # Keep the browser open after all tests for this workflow finish.
-    # Only active in --headed mode (set CURIO_PAUSE_AFTER=1 to enable).
+    os.unlink(seeded_tmp.name)
     if os.environ.get("CURIO_PAUSE_AFTER"):
         input("Tests done — press Enter to close the browser...")
 

--- a/utk_curio/backend/tests/test_frontend/test_workflows.py
+++ b/utk_curio/backend/tests/test_frontend/test_workflows.py
@@ -9,6 +9,9 @@ from .utils import (
     load_dot_data,
     strip_volatile_keys,
     execute_workflow_programmatically,
+    dot_data_to_vega_values,
+    save_expected_svg,
+    compare_svg_structure,
 )
 from .workflow_spec import NodeSpec, CODE_EDITOR_TYPES
 
@@ -550,21 +553,112 @@ class TestWorkflowCanvas:
                 
                 
                 # ----------------------------------------------------------
-                # TODO: Test the created SVG Vega-Lite visualizations
+                # Test created SVG Vega-Lite visualizations
                 # ----------------------------------------------------------
-                # Verify Vega-Lite visualization is rendered correctly
-                # get the previous node data from saved .data file
-                # Get the grammar json content from the dataflow json
-                # programatically generate the vega lite svg vis
-                # if node.category == "grammar":
-                #     # Get the grammar json content from the dataflow json
-                #     grammar_json = self.spec.nodes.find(node.id).content
-                #     assert grammar_json is not None, (
-                #         f"Node {node.id} ({node.type}) is missing its "
-                #         f"grammar json"
-                #     )
-                #     compile the grammar json using a vega-lite compiler
-                #     assert the visualization is rendered correctly
+                if node.category == "grammar" and node.type == "VIS_VEGA":
+                    vega_container_id = f"vega{node.id}"
+
+                    # A -- Verify SVG exists and is non-empty
+                    svg_locator = node_el.locator(f"#{vega_container_id} svg")
+                    svg_locator.first.wait_for(state="visible", timeout=15000)
+                    assert svg_locator.count() >= 1, (
+                        f"Grammar node {node.id} ({node.type}) is missing "
+                        f"its rendered SVG inside #{vega_container_id}"
+                    )
+
+                    # B -- Re-compile the spec programmatically and save
+                    #      the expected SVG (mirrors .data baseline pattern)
+                    spec_json = json.loads(
+                        node.content.replace("\r\n", "\n").replace("\r", "\n")
+                    )
+
+                    upstream_ids = self.spec.upstream_nodes(node.id)
+                    vega_values: list[dict] = []
+                    for uid in upstream_ids:
+                        candidate = uid
+                        visited: set[str] = set()
+                        while candidate and candidate not in expected_map:
+                            visited.add(candidate)
+                            parents = self.spec.upstream_nodes(candidate)
+                            candidate = next(
+                                (p for p in parents if p not in visited),
+                                None,
+                            )
+                        if candidate and candidate in expected_map:
+                            upstream_data = load_dot_data(
+                                expected_map[candidate]
+                            )
+                            vega_values = dot_data_to_vega_values(upstream_data)
+                            break
+
+                    container_dims = self.page.evaluate(
+                        """(containerId) => {
+                            const el = document.getElementById(containerId);
+                            if (!el) return null;
+                            return {
+                                width: el.clientWidth,
+                                height: el.clientHeight
+                            };
+                        }""",
+                        vega_container_id,
+                    )
+
+                    expected_svg = self.page.evaluate(
+                        """({ spec, values, dims }) => {
+                            const vega = window.__curio_vega;
+                            const lite = window.__curio_vegaLite;
+                            if (!vega || !lite) return null;
+                            spec.data = { values: values, name: 'data' };
+                            spec.width = dims ? dims.width : 300;
+                            spec.height = dims ? dims.height : 200;
+                            const vegaSpec = lite.compile(spec).spec;
+                            const view = new vega.View(vega.parse(vegaSpec))
+                                .renderer('svg')
+                                .initialize(document.createElement('div'));
+                            return view.runAsync().then(() => view.toSVG());
+                        }""",
+                        {
+                            "spec": spec_json,
+                            "values": vega_values,
+                            "dims": container_dims,
+                        },
+                    )
+                    assert expected_svg is not None, (
+                        f"Grammar node {node.id} ({node.type}): "
+                        f"programmatic Vega-Lite re-compilation returned null "
+                        f"(window.__curio_vega / __curio_vegaLite missing?)"
+                    )
+
+                    dataflow_name = os.path.splitext(
+                        os.path.basename(self.spec.filepath)
+                    )[0]
+                    save_expected_svg(dataflow_name, node.id, expected_svg)
+
+                    # C -- Extract the actual SVG from the DOM
+                    actual_svg = self.page.evaluate(
+                        """(containerId) => {
+                            const el = document.getElementById(containerId);
+                            if (!el) return null;
+                            const svg = el.querySelector('svg');
+                            return svg ? svg.outerHTML : null;
+                        }""",
+                        vega_container_id,
+                    )
+                    assert actual_svg is not None, (
+                        f"Grammar node {node.id} ({node.type}): "
+                        f"could not extract SVG from #{vega_container_id}"
+                    )
+
+                    # D -- Structural comparison
+                    diffs = compare_svg_structure(
+                        actual_svg,
+                        expected_svg,
+                    )
+                    assert not diffs, (
+                        f"Grammar node {node.id} ({node.type}) SVG "
+                        f"structural mismatch:\n"
+                        + "\n".join(f"  - {d}" for d in diffs)
+                    )
 
         self._save_screenshot(request)
 

--- a/utk_curio/backend/tests/test_frontend/test_workflows.py
+++ b/utk_curio/backend/tests/test_frontend/test_workflows.py
@@ -3,7 +3,13 @@ import re
 import json
 import time
 
-from .utils import save_workflow_test_screenshot
+from .utils import (
+    save_workflow_test_screenshot,
+    get_shared_data_dir,
+    load_dot_data,
+    strip_volatile_keys,
+    execute_workflow_programmatically,
+)
 from .workflow_spec import NodeSpec, CODE_EDITOR_TYPES
 
 """
@@ -366,6 +372,9 @@ class TestWorkflowCanvas:
                     f"grammar editor"
                 )
                 # TODO: check if the grammar is rendered inside the editor
+                # Verify the json loaded into the grammar editor matches the
+                # workflow JSON content. 
+                # Grammar editor renders a JSONEditorReact component.
 
             elif node.category == "datapool":
                 data_tabs = node_el.locator("#data-tabs-tab-0")
@@ -388,11 +397,17 @@ class TestWorkflowCanvas:
 
     def test_node_execution(self, loaded_workflow, request):
         """Click the play button on each executable node in topological
-        order and verify that the output status shows *Done*."""
-        # First: run all playable nodes end-to-end
+        order and verify that the output status shows *Done*.
+
+        Before touching the browser, the workflow is executed
+        programmatically (in-process, seeded) to produce expected
+        ``.data`` files.  After the browser run the two sets of files
+        are compared.
+        """
+        expected_map = execute_workflow_programmatically(self.spec, seed=42)
+
         self._execute_all_playable_nodes()
 
-        # Then: assert every playable node ended with "Done"
         for node in self.spec.nodes:
             if not node.has_play_button:
                 continue
@@ -408,9 +423,9 @@ class TestWorkflowCanvas:
                 f"after full workflow execution"
             )
 
-            # ================================================================
+            # ---------------------------------------------------------------
             # Check output tab is active and rendered correctly
-            # ================================================================
+            # ---------------------------------------------------------------
 
             # wait for output tab to be visible
             output_tab = node_el.locator(
@@ -486,7 +501,11 @@ class TestWorkflowCanvas:
                         f"Node {node.id} ({node.type}) is not missing its "
                         f"warning heading"
                     )
-                    # its content should be a text with the output file path following the pattern: <uuid_regex>.data
+
+                    # ------------------------------------------------------------------------
+                    # Test the output tab pane content.
+                    # ------------------------------------------------------------------------
+                    # it should be a text with the output file path following the pattern: <uuid_regex>.data
                     output_content = tab_content.locator("div").filter(
                         has_text=re.compile(r"Saved to file\:\s\w+_\w+.data$")
                     )
@@ -496,9 +515,56 @@ class TestWorkflowCanvas:
                         f"output content"
                     )
 
-                    # TODO check .data file content
-                    # we should read the .data file content and check if it matches the ground truth data 
-                    # we should retrieve the ground truth data from the disk
+                    # Verify .data file content against programmatic execution
+                    data_file_name = output_content.first.evaluate(
+                        r"""(el) => {
+                            const match = el.textContent.match(/Saved to file:\s(\w+_\w+\.data)$/);
+                            return match ? match[1] : null;
+                        }"""
+                    )
+                    assert data_file_name is not None, (
+                        f"Node {node.id} ({node.type}) is missing its data file path"
+                    )
+
+                    data_file_path = os.path.join(get_shared_data_dir(), data_file_name)
+                    assert os.path.exists(data_file_path), (
+                        f"Node {node.id} ({node.type}) is missing its data file"
+                    )
+
+                    if node.id in expected_map:
+                        actual = strip_volatile_keys(load_dot_data(data_file_path))
+                        expected = strip_volatile_keys(
+                            load_dot_data(expected_map[node.id])
+                        )
+                        if actual != expected:
+                            diff_keys = [
+                                k for k in set(actual) | set(expected)
+                                if actual.get(k) != expected.get(k)
+                            ]
+                            raise AssertionError(
+                                f"Node {node.id} ({node.type}) data file content "
+                                f"does not match the programmatic execution. "
+                                f"Differing top-level keys: {diff_keys}"
+                            )
+                
+                
+                
+                # ----------------------------------------------------------
+                # TODO: Test the created SVG Vega-Lite visualizations
+                # ----------------------------------------------------------
+                # Verify Vega-Lite visualization is rendered correctly
+                # get the previous node data from saved .data file
+                # Get the grammar json content from the dataflow json
+                # programatically generate the vega lite svg vis
+                # if node.category == "grammar":
+                #     # Get the grammar json content from the dataflow json
+                #     grammar_json = self.spec.nodes.find(node.id).content
+                #     assert grammar_json is not None, (
+                #         f"Node {node.id} ({node.type}) is missing its "
+                #         f"grammar json"
+                #     )
+                #     compile the grammar json using a vega-lite compiler
+                #     assert the visualization is rendered correctly
 
         self._save_screenshot(request)
 
@@ -515,11 +581,12 @@ class TestWorkflowCanvas:
 
             node_el = self._node_locator(node)
 
-            # ================================================================
+            # ---------------------------------------------------------------
             # Check provenance graph is rendered correctly
-            # ================================================================
+            # ---------------------------------------------------------------
 
-            # If the node has a provenance tab, check if the provenance graph is rendered correctly
+            # If the node has a provenance tab, 
+            # check if the provenance graph is rendered correctly
             provenance_tab = node_el.locator(
                 '.nav-link[data-rr-ui-event-key="provenance"]'
             )

--- a/utk_curio/backend/tests/test_frontend/utils.py
+++ b/utk_curio/backend/tests/test_frontend/utils.py
@@ -2,6 +2,10 @@ import os
 import re
 import json
 import time
+import zlib
+import shutil
+import textwrap
+from pathlib import Path
 from io import BytesIO
 from urllib.request import urlopen, Request
 from urllib.error import URLError
@@ -18,6 +22,210 @@ REPO_ROOT = os.path.abspath(
 WORKFLOW_SCREENSHOT_EXPECTED_DIR = os.path.join(
     REPO_ROOT, "docs", "examples", "flows", "expected_outputs"
 )
+
+
+
+def get_shared_data_dir() -> str:
+    """Directory where ``save_memory_mapped_file`` writes ``.data`` blobs.
+
+    Matches ``utk_curio/sandbox/util/parsers.py`` (``CURIO_LAUNCH_CWD`` +
+    ``CURIO_SHARED_DATA``). Defaults ``CURIO_LAUNCH_CWD`` to the repo root
+    so host-side Playwright resolves the same path as ``curio start`` when the
+    subprocess uses ``cwd`` = repo root (and matches Docker once ``./.curio`` is
+    bind-mounted to ``/app/.curio``).
+    """
+    launch_dir = Path(
+        os.environ.get("CURIO_LAUNCH_CWD", REPO_ROOT)
+    ).resolve()
+    shared_disk_path = os.environ.get("CURIO_SHARED_DATA", "./.curio/data/")
+    lod_dir = (launch_dir / Path(shared_disk_path)).resolve()
+    return str(lod_dir)
+
+
+# ---------------------------------------------------------------------------
+# .data file helpers (zlib-compressed JSON, same format as parsers.py)
+# ---------------------------------------------------------------------------
+
+def load_dot_data(path: str) -> dict:
+    """Read a ``.data`` file (zlib-compressed JSON) and return the parsed dict."""
+    with open(path, "rb") as f:
+        return json.loads(zlib.decompress(f.read()).decode("utf-8"))
+
+
+def save_dot_data(path: str, data: dict) -> None:
+    """Write *data* as zlib-compressed JSON to *path*."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    compressed = zlib.compress(json.dumps(data, ensure_ascii=False).encode("utf-8"))
+    with open(path, "wb") as f:
+        f.write(compressed)
+
+
+def strip_volatile_keys(data: dict) -> dict:
+    """Return a shallow copy of *data* without per-run metadata (``filename``)."""
+    stripped = {**data}
+    stripped.pop("filename", None)
+    return stripped
+
+
+# ---------------------------------------------------------------------------
+# Deterministic seeding for reproducible programmatic execution
+# ---------------------------------------------------------------------------
+
+_SEED_PREFIX = (
+    "import numpy as _np; _np.random.seed({seed}); "
+    "import random as _rnd; _rnd.seed({seed})\n"
+)
+
+
+def seed_node_code(code: str, seed: int = 42) -> str:
+    """Prepend deterministic random-seed lines to *code*.
+
+    Uses underscore-prefixed aliases (``_np``, ``_rnd``) so the seed
+    imports never shadow the user's own ``import numpy as np``.
+    """
+    return _SEED_PREFIX.format(seed=seed) + code
+
+
+_WIDGET_RE = re.compile(r"\[!!\s*(.*?)\s*!!\]")
+
+
+def resolve_widget_placeholders(code: str) -> str:
+    """Replace ``[!! name$type$default !!]`` widget markers with defaults.
+
+    The frontend resolves these before sending code to the sandbox; the
+    programmatic executor must do the same.
+    """
+    def _replace(m):
+        parts = m.group(1).split("$")
+        if len(parts) >= 3:
+            return parts[2]
+        return m.group(0)
+    return _WIDGET_RE.sub(_replace, code)
+
+
+PLAYWRIGHT_EXPECTED_DIR = os.path.join(
+    REPO_ROOT, ".curio", "playwright", "expected"
+)
+
+
+def _ensure_parsers_env():
+    """Ensure ``CURIO_LAUNCH_CWD`` and ``CURIO_SHARED_DATA`` are set.
+
+    ``save_memory_mapped_file`` uses ``CURIO_SHARED_DATA`` with
+    ``Path.relative_to`` and requires an absolute path.  When the test
+    process is *not* started via ``curio start`` (e.g. ``CURIO_E2E_USE_EXISTING``
+    in CI) these variables may be absent.
+    """
+    if "CURIO_LAUNCH_CWD" not in os.environ:
+        os.environ["CURIO_LAUNCH_CWD"] = REPO_ROOT
+    if "CURIO_SHARED_DATA" not in os.environ:
+        os.environ["CURIO_SHARED_DATA"] = str(
+            Path(os.path.join(REPO_ROOT, ".curio", "data")).resolve()
+        )
+
+
+def execute_workflow_programmatically(spec, seed: int = 42) -> dict[str, str]:
+    """Execute every code node in-process and return *{node_id: expected_path}*.
+
+    Mirrors the sandbox ``python_wrapper.txt`` flow — load upstream data,
+    call user code, serialise via ``parseOutput`` / ``save_memory_mapped_file``
+    — but runs entirely inside the test process.  Results are copied to
+    ``.curio/playwright/expected/<workflow>/`` for later comparison with the
+    browser-produced ``.data`` files.
+    """
+    _ensure_parsers_env()
+
+    from utk_curio.sandbox.util.parsers import (
+        parseInput,
+        parseOutput,
+        save_memory_mapped_file,
+        load_memory_mapped_file,
+        checkIOType,
+    )
+
+    outputs: dict[str, dict] = {}   # node_id → {"path": ..., "dataType": ...}
+    expected: dict[str, str] = {}   # node_id → absolute path in expected dir
+
+    dataflow_name = os.path.splitext(os.path.basename(spec.filepath))[0]
+    dest_dir = os.path.join(PLAYWRIGHT_EXPECTED_DIR, dataflow_name)
+    os.makedirs(dest_dir, exist_ok=True)
+
+    # User code uses relative paths (e.g. "docs/examples/data/…") that are
+    # resolved from the repo root — the same CWD the sandbox uses via
+    # CURIO_LAUNCH_CWD.  Switch CWD for the duration of execution.
+    original_cwd = os.getcwd()
+    os.chdir(REPO_ROOT)
+    try:
+        for node in spec.topo_sorted_nodes():
+            # Non-code nodes: propagate upstream output without execution
+            if node.category != "code":
+                upstreams = spec.upstream_nodes(node.id)
+                if len(upstreams) == 1 and upstreams[0] in outputs:
+                    outputs[node.id] = outputs[upstreams[0]]
+                elif len(upstreams) > 1:
+                    outputs[node.id] = {
+                        "path": [outputs[uid] for uid in upstreams if uid in outputs],
+                        "dataType": "outputs",
+                    }
+                continue
+
+            # --- resolve input (mirrors python_wrapper.txt lines 30-49) ---
+            upstreams = spec.upstream_nodes(node.id)
+            if not upstreams:
+                incoming = ""
+            elif len(upstreams) == 1:
+                up = outputs[upstreams[0]]
+                if up.get("dataType") == "outputs":
+                    incoming = []
+                    for elem in up["path"]:
+                        raw = load_memory_mapped_file(elem["path"])
+                        incoming.append(parseInput(raw))
+                else:
+                    raw = load_memory_mapped_file(up["path"])
+                    incoming = parseInput(raw)
+            else:
+                incoming = []
+                for uid in upstreams:
+                    raw = load_memory_mapped_file(outputs[uid]["path"])
+                    incoming.append(parseInput(raw))
+
+            # --- exec seeded user code ---
+            resolved = resolve_widget_placeholders(node.content)
+            seeded = seed_node_code(resolved, seed)
+
+            # Provide the same top-level imports as python_wrapper.txt
+            import warnings as _w; _w.filterwarnings("ignore")
+            import rasterio, geopandas, pandas, mmap, hashlib, ast  # noqa: F811
+            ns: dict = {
+                "warnings": _w, "rasterio": rasterio,
+                "gpd": geopandas, "geopandas": geopandas,
+                "pd": pandas, "pandas": pandas,
+                "json": json, "mmap": mmap, "zlib": zlib, "os": os,
+                "time": time, "hashlib": hashlib, "ast": ast,
+            }
+            exec(
+                "def userCode(arg):\n" + textwrap.indent(seeded, "    "),
+                ns,
+            )
+            result = ns["userCode"](incoming)
+
+            # --- serialise exactly like the sandbox ---
+            parsed = parseOutput(result)
+            checkIOType(parsed, node.type, False)
+            rel_path = save_memory_mapped_file(parsed)
+
+            outputs[node.id] = {"path": rel_path, "dataType": parsed["dataType"]}
+
+            gt_path = os.path.join(dest_dir, f"{dataflow_name}_{node.id}.data")
+            shutil.copy2(
+                os.path.join(get_shared_data_dir(), rel_path),
+                gt_path,
+            )
+            expected[node.id] = gt_path
+    finally:
+        os.chdir(original_cwd)
+
+    return expected
 
 
 def _capture_full_page(page: Page):

--- a/utk_curio/backend/tests/test_frontend/utils.py
+++ b/utk_curio/backend/tests/test_frontend/utils.py
@@ -108,6 +108,139 @@ PLAYWRIGHT_EXPECTED_DIR = os.path.join(
 )
 
 
+# ---------------------------------------------------------------------------
+# Vega-Lite SVG helpers
+# ---------------------------------------------------------------------------
+
+def dot_data_to_vega_values(data: dict) -> list[dict]:
+    """Convert a ``.data`` dict to the row-oriented list that Vega expects.
+
+    Mirrors the frontend ``parseDataframe`` / ``parseGeoDataframe`` functions
+    in ``src/utils/parsing.ts``.
+
+    The ``dataframe`` format can be either dict-of-dicts (``to_dict()``)
+    or dict-of-lists (``to_dict(orient='list')``); both are handled.
+    """
+    dtype = data.get("dataType")
+    raw = data.get("data", {})
+    if dtype == "dataframe":
+        columns = list(raw.keys())
+        first_col = raw[columns[0]]
+        if isinstance(first_col, dict):
+            keys = list(first_col.keys())
+        else:
+            keys = list(range(len(first_col)))
+        return [
+            {col: raw[col][k] for col in columns}
+            for k in keys
+        ]
+    elif dtype == "geodataframe":
+        return [f["properties"] for f in raw.get("features", [])]
+    return []
+
+
+def save_expected_svg(dataflow_name: str, node_id: str, svg_content: str) -> str:
+    """Save a programmatically generated expected SVG to
+    ``.curio/playwright/expected/<dataflow_name>/<node_id>.svg``.
+
+    Returns the absolute path of the saved file.
+    """
+    dest_dir = os.path.join(PLAYWRIGHT_EXPECTED_DIR, dataflow_name)
+    os.makedirs(dest_dir, exist_ok=True)
+    path = os.path.join(dest_dir, f"{node_id}.svg")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(svg_content)
+    return path
+
+
+def load_expected_svg(dataflow_name: str, node_id: str) -> str | None:
+    """Load a previously saved expected SVG, or return ``None``."""
+    path = os.path.join(PLAYWRIGHT_EXPECTED_DIR, dataflow_name, f"{node_id}.svg")
+    if not os.path.isfile(path):
+        return None
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def compare_svg_structure(
+    actual_svg: str,
+    expected_svg: str,
+) -> list[str]:
+    """Structurally compare two Vega-rendered SVG strings.
+
+    Returns an empty list when the two SVGs are structurally equivalent.
+
+    The comparison walks the ``<g>`` element tree and checks that both
+    SVGs share the same hierarchy of ``class``, ``role``, and
+    ``aria-roledescription`` attributes at every level.
+    """
+    import xml.etree.ElementTree as ET
+
+    SVG_NS = "http://www.w3.org/2000/svg"
+
+    _STRUCTURAL_ATTRS = ("class", "role", "aria-roledescription")
+
+    def _parse(svg_str: str, label: str):
+        try:
+            return ET.fromstring(svg_str), []
+        except ET.ParseError as e:
+            return None, [f"{label} SVG is not valid XML: {e}"]
+
+    def _sig(el) -> str:
+        """Structural signature of an element: tag + key attributes."""
+        tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+        parts = [tag]
+        for attr in _STRUCTURAL_ATTRS:
+            val = el.get(attr)
+            if val:
+                parts.append(f"{attr}={val}")
+        return "|".join(parts)
+
+    def _g_children(el):
+        """Return direct ``<g>`` children of *el*."""
+        return [
+            ch for ch in el
+            if ch.tag == f"{{{SVG_NS}}}g" or ch.tag == "g"
+        ]
+
+    def _compare_g_tree(actual_el, expected_el, path: str, diffs: list):
+        """Recursively compare ``<g>`` sub-trees by structural signature."""
+        actual_gs = _g_children(actual_el)
+        expected_gs = _g_children(expected_el)
+
+        if len(actual_gs) != len(expected_gs):
+            diffs.append(
+                f"At {path}: <g> child count differs — "
+                f"actual={len(actual_gs)}, expected={len(expected_gs)}"
+            )
+            return
+
+        for i, (a_g, e_g) in enumerate(zip(actual_gs, expected_gs)):
+            a_sig = _sig(a_g)
+            e_sig = _sig(e_g)
+            child_path = f"{path}/g[{i}]"
+            if a_sig != e_sig:
+                diffs.append(
+                    f"At {child_path}: signature mismatch — "
+                    f"actual=({a_sig}), expected=({e_sig})"
+                )
+            else:
+                _compare_g_tree(a_g, e_g, child_path, diffs)
+
+    diffs: list[str] = []
+
+    actual_root, errs = _parse(actual_svg, "Actual")
+    if errs:
+        return errs
+    expected_root, errs = _parse(expected_svg, "Expected")
+    if errs:
+        return errs
+
+    _compare_g_tree(actual_root, expected_root, "svg", diffs)
+
+    return diffs
+
+
 def _ensure_parsers_env():
     """Ensure ``CURIO_LAUNCH_CWD`` and ``CURIO_SHARED_DATA`` are set.
 

--- a/utk_curio/backend/tests/test_frontend/workflow_spec.py
+++ b/utk_curio/backend/tests/test_frontend/workflow_spec.py
@@ -112,6 +112,17 @@ class WorkflowSpec:
         """
         return sum(1 for e in self.edges if e.get("type") == "Interaction")
 
+    def upstream_nodes(self, node_id: str) -> list[str]:
+        """Return source node IDs feeding into *node_id* (data-flow edges only).
+
+        Interaction edges are excluded because they carry selection state,
+        not data.
+        """
+        return [
+            e["source"] for e in self.edges
+            if e["target"] == node_id and e.get("type") != "Interaction"
+        ]
+
     def topo_sorted_nodes(self) -> list:
         """Return nodes in topological (dependency) order using Kahn's algorithm.
 

--- a/utk_curio/frontend/urban-workflows/src/hook/useVega.ts
+++ b/utk_curio/frontend/urban-workflows/src/hook/useVega.ts
@@ -12,6 +12,11 @@ import { useFlowContext } from "../providers/FlowProvider";
 const vega = require("vega");
 const lite = require("vega-lite");
 
+if (typeof window !== 'undefined') {
+  (window as any).__curio_vega = vega;
+  (window as any).__curio_vegaLite = lite;
+}
+
 export const useVega = ({ data, code }: { data: any; code: string; }) => {
   const [interactions, _setInteractions] = useState<any>({}); // {signal: {type: point/interval, data: }} // if type point data contains list of object ids. If type is interval data is an object where each key is an attribute with intervals or lists
 
@@ -274,6 +279,7 @@ export const useVega = ({ data, code }: { data: any; code: string; }) => {
           let interactedElementsPoint: number[] = []; // id of the elements interacted with point/hover
 
           if (signalAttributes.length == 0) {
+            // no interaction
             let previousValue = interactionsRef.current[parsedAttr[0]];
 
             let type = VisInteractionType.UNDETERMINED;


### PR DESCRIPTION
# Describe your changes

 - **Test the created data in the backend:** It programatically run all computation nodes using topological order: The programmatic execution runs in the test process (test_workflows.py) by importing the sandbox parsers and using exec() — no HTTP calls needed. The browser execution still goes through the sandbox as normal but with seeded workflow code. The core function is the execute_workflow_programmatically() in utils.py. The programmatic generate data files are being saved as .curio/playwright/expected/<dataflow_name>/<comp_node_id>.data
  
 - **Test the created SVG Vega-Lite visualizations:** After workflow execution, VIS_VEGA (grammar) nodes render an SVG chart inside #vega{nodeId} using the Vega SVG renderer. Then test proccess verifiies the VEGA visualizations are correct by:
    1. Extracting the upstream `.data` file (already verified by prior test code)
    2. Getting the Vega-Lite spec from `node.content`
    3. Re-compiling the spec with the same data via the frontend Vega compiler
    4. Comparing the actual rendered SVG against this expected SVG.
    5. The programmatic generate SVG Vega vizzes are being saved as .curio/playwright/expected/<dataflow_name>/<vega_node_id>.svg 

<img width="1218" height="417" alt="Screenshot 2026-03-27 at 18 30 29" src="https://github.com/user-attachments/assets/6899a8e2-a7de-489f-8e1d-539071d08cc2" />


# Issue resolved by this PR (if any)
 - Issue Number: 88
 - Link: https://github.com/urban-toolkit/curio/issues/88


