### PR TITLE
Fix CI e2e OOM: reap orphaned Chrome GPU processes between workflow classes

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -188,9 +188,8 @@ jobs:
           SAMPLER_PID=$!
           trap "kill $SAMPLER_PID 2>/dev/null || true" EXIT
           # DIAGNOSTIC (temporary): Firefox + lavapipe on the 2 GPU-compute
-          # examples (06/07) that crash Chrome's SwiftShader. Install the
-          # Firefox browser here (playwright pip is available at this point).
-          python -m playwright install --with-deps firefox
+          # examples (06/07) that crash Chrome's SwiftShader. test.sh installs
+          # the Firefox browser itself (playwright pip is available there).
           bash scripts/test.sh --e2e-only --use-existing \
             --workflows 06-autark-what-if-shadow-study.json,07-autark-gpu-shader.json \
             --allure-dir "$GITHUB_WORKSPACE/allure-results"

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -187,7 +187,7 @@ jobs:
           # --disable-gpu-watchdog lets slow software compute complete.
           # Revert to the full matrix once confirmed.
           bash scripts/test.sh --e2e-only --use-existing \
-            --workflows 06-autark-what-if-shadow-study.json,07-autark-gpu-shader.json,Interaction_Vega_Autark.json \
+            --workflows 06-autark-what-if-shadow-study.json \
             --allure-dir "$GITHUB_WORKSPACE/allure-results"
 
       - name: 📈 Resource snapshot (after e2e)

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -70,26 +70,16 @@ jobs:
           swapon --show
           free -h
 
-      - name: 🦊 Set up Firefox + lavapipe for WebGPU compute (DIAG)
+      - name: 🧪 Install Chrome Dev channel (newer SwiftShader)
         run: |
-          # Chrome's bundled SwiftShader crashes on the compute passes in
-          # 06/07. Firefox's WebGPU is wgpu (Rust) over the *system* Vulkan
-          # loader, so it can run them on Mesa lavapipe (more conformant
-          # software Vulkan). Install lavapipe + Playwright Firefox and route
-          # the e2e suite through Firefox (PYTEST_ADDOPTS=--browser firefox).
-          sudo apt-get update
-          sudo apt-get install -y mesa-vulkan-drivers vulkan-tools
-          ICD=$(ls /usr/share/vulkan/icd.d/lvp_icd*.json 2>/dev/null | head -1)
-          echo "lavapipe ICD: ${ICD:-NOT FOUND}"
-          echo "VK_ICD_FILENAMES=$ICD" >> "$GITHUB_ENV"
-          echo "PYTEST_ADDOPTS=--browser firefox" >> "$GITHUB_ENV"
-          # Firefox runs WebGPU in a sandboxed GPU process that strips env vars,
-          # so VK_ICD_FILENAMES never reaches wgpu and requestAdapter() returns
-          # null. Disabling the GPU sandbox lets the process inherit the Vulkan
-          # ICD path and enumerate the lavapipe adapter.
-          echo "MOZ_DISABLE_GPU_SANDBOX=1" >> "$GITHUB_ENV"
-          VK_ICD_FILENAMES="$ICD" vulkaninfo --summary 2>/dev/null \
-            | grep -iE "deviceName|driverName" | head || true
+          # The stock Chrome (stable) bundles a SwiftShader whose GPU process
+          # crashes on 06/07's compute. Chrome Dev ships a newer SwiftShader
+          # that runs 06's compute to completion (the failure then moves to a
+          # post-compute device loss on the map node, attacked via flags).
+          wget -q https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb
+          sudo apt-get install -y ./google-chrome-unstable_current_amd64.deb
+          echo "CURIO_CHROME_PATH=/usr/bin/google-chrome-unstable" >> "$GITHUB_ENV"
+          /usr/bin/google-chrome-unstable --version || true
 
       - name: 🔨 Build all service images in parallel
         run: docker compose -p curio build --parallel
@@ -192,9 +182,11 @@ jobs:
           ) &
           SAMPLER_PID=$!
           trap "kill $SAMPLER_PID 2>/dev/null || true" EXIT
-          # DIAGNOSTIC (temporary): Firefox + lavapipe on the 2 GPU-compute
-          # examples (06/07) that crash Chrome's SwiftShader. test.sh installs
-          # the Firefox browser itself (playwright pip is available there).
+          # DIAGNOSTIC (temporary): Chrome Dev + --in-process-gpu on the 2
+          # GPU-compute examples (06/07), with a generous AUTK timeout so the
+          # slow software compute finishes. Tests whether in-process GPU keeps
+          # the WebGPU adapter alive across the compute->map device teardown.
+          export CURIO_E2E_AUTK_TIMEOUT_MS=600000
           bash scripts/test.sh --e2e-only --use-existing \
             --workflows 06-autark-what-if-shadow-study.json,07-autark-gpu-shader.json \
             --allure-dir "$GITHUB_WORKSPACE/allure-results"

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -70,22 +70,16 @@ jobs:
           swapon --show
           free -h
 
-      - name: 🌋 Install Mesa lavapipe (software Vulkan)
+      - name: 🧪 Install Chrome Dev channel (newer SwiftShader)
         run: |
-          # Chrome's bundled SwiftShader renders maps but its GPU process
-          # crashes on the WebGPU compute passes in examples 06/07. Mesa
-          # lavapipe is a more conformant software Vulkan; point the host
-          # Chrome's Dawn/Vulkan backend at it (CURIO_WEBGPU_BACKEND=vulkan,
-          # VK_ICD_FILENAMES pins the loader to lavapipe) to run those
-          # compute shaders for real on the GPU-less runner.
-          sudo apt-get update
-          sudo apt-get install -y mesa-vulkan-drivers vulkan-tools
-          ICD=$(ls /usr/share/vulkan/icd.d/lvp_icd*.json 2>/dev/null | head -1)
-          echo "lavapipe ICD: ${ICD:-NOT FOUND}"
-          echo "VK_ICD_FILENAMES=$ICD" >> "$GITHUB_ENV"
-          echo "CURIO_WEBGPU_BACKEND=vulkan" >> "$GITHUB_ENV"
-          VK_ICD_FILENAMES="$ICD" vulkaninfo --summary 2>/dev/null \
-            | grep -iE "deviceName|driverName|apiVersion|GPU id" | head || true
+          # The runner's stock Chrome (stable) bundles a SwiftShader whose GPU
+          # process crashes on the WebGPU compute passes in examples 06/07.
+          # The Dev channel ships a newer SwiftShader/Dawn that may run them.
+          # Point the e2e host Chrome at it via CURIO_CHROME_PATH.
+          wget -q https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb
+          sudo apt-get install -y ./google-chrome-unstable_current_amd64.deb
+          echo "CURIO_CHROME_PATH=/usr/bin/google-chrome-unstable" >> "$GITHUB_ENV"
+          /usr/bin/google-chrome-unstable --version || true
 
       - name: 🔨 Build all service images in parallel
         run: docker compose -p curio build --parallel

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -36,6 +36,40 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
 
+      - name: 🧹 Reclaim runner disk headroom
+        run: |
+          # Free the large preinstalled toolchains we never use so the 24 GB
+          # swapfile (next step) and the docker build cache have ample disk.
+          # NB: do NOT touch /opt/hostedtoolcache — setup-python lives there.
+          echo "=== before ==="; df -h /
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/share/boost \
+            /usr/local/share/powershell \
+            /usr/share/swift \
+            /opt/hostedtoolcache/CodeQL 2>/dev/null || true
+          sudo docker image prune -af 2>/dev/null || true
+          echo "=== after ==="; df -h /
+
+      - name: 💾 Add swap space
+        run: |
+          # Software WebGPU (SwiftShader) rendering of the heaviest example
+          # (09-heterogeneous-data-linked-views) peaks ~12 GB in the browser
+          # plus a ~6 GB sandbox compute spike, exceeding the 16 GB runner and
+          # tripping the OOM killer. A large swapfile lets the peak survive on
+          # disk (slower, but the 120 min job timeout absorbs it). Replaces the
+          # runner's stock ~4 GB swap with 24 GB → ~40 GB total virtual memory.
+          sudo swapoff -a || true
+          sudo fallocate -l 24G /swapfile \
+            || sudo dd if=/dev/zero of=/swapfile bs=1M count=24576
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          swapon --show
+          free -h
+
       - name: 🔨 Build all service images in parallel
         run: docker compose -p curio build --parallel
 

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -70,6 +70,23 @@ jobs:
           swapon --show
           free -h
 
+      - name: 🌋 Install Mesa lavapipe (software Vulkan)
+        run: |
+          # Chrome's bundled SwiftShader renders maps but its GPU process
+          # crashes on the WebGPU compute passes in examples 06/07. Mesa
+          # lavapipe is a more conformant software Vulkan; point the host
+          # Chrome's Dawn/Vulkan backend at it (CURIO_WEBGPU_BACKEND=vulkan,
+          # VK_ICD_FILENAMES pins the loader to lavapipe) to run those
+          # compute shaders for real on the GPU-less runner.
+          sudo apt-get update
+          sudo apt-get install -y mesa-vulkan-drivers vulkan-tools
+          ICD=$(ls /usr/share/vulkan/icd.d/lvp_icd*.json 2>/dev/null | head -1)
+          echo "lavapipe ICD: ${ICD:-NOT FOUND}"
+          echo "VK_ICD_FILENAMES=$ICD" >> "$GITHUB_ENV"
+          echo "CURIO_WEBGPU_BACKEND=vulkan" >> "$GITHUB_ENV"
+          VK_ICD_FILENAMES="$ICD" vulkaninfo --summary 2>/dev/null \
+            | grep -iE "deviceName|driverName|apiVersion|GPU id" | head || true
+
       - name: 🔨 Build all service images in parallel
         run: docker compose -p curio build --parallel
 

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -70,16 +70,21 @@ jobs:
           swapon --show
           free -h
 
-      - name: 🧪 Install Chrome Dev channel (newer SwiftShader)
+      - name: 🦊 Set up Firefox + lavapipe for WebGPU compute (DIAG)
         run: |
-          # The runner's stock Chrome (stable) bundles a SwiftShader whose GPU
-          # process crashes on the WebGPU compute passes in examples 06/07.
-          # The Dev channel ships a newer SwiftShader/Dawn that may run them.
-          # Point the e2e host Chrome at it via CURIO_CHROME_PATH.
-          wget -q https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb
-          sudo apt-get install -y ./google-chrome-unstable_current_amd64.deb
-          echo "CURIO_CHROME_PATH=/usr/bin/google-chrome-unstable" >> "$GITHUB_ENV"
-          /usr/bin/google-chrome-unstable --version || true
+          # Chrome's bundled SwiftShader crashes on the compute passes in
+          # 06/07. Firefox's WebGPU is wgpu (Rust) over the *system* Vulkan
+          # loader, so it can run them on Mesa lavapipe (more conformant
+          # software Vulkan). Install lavapipe + Playwright Firefox and route
+          # the e2e suite through Firefox (PYTEST_ADDOPTS=--browser firefox).
+          sudo apt-get update
+          sudo apt-get install -y mesa-vulkan-drivers vulkan-tools
+          ICD=$(ls /usr/share/vulkan/icd.d/lvp_icd*.json 2>/dev/null | head -1)
+          echo "lavapipe ICD: ${ICD:-NOT FOUND}"
+          echo "VK_ICD_FILENAMES=$ICD" >> "$GITHUB_ENV"
+          echo "PYTEST_ADDOPTS=--browser firefox" >> "$GITHUB_ENV"
+          VK_ICD_FILENAMES="$ICD" vulkaninfo --summary 2>/dev/null \
+            | grep -iE "deviceName|driverName" | head || true
 
       - name: 🔨 Build all service images in parallel
         run: docker compose -p curio build --parallel
@@ -182,12 +187,12 @@ jobs:
           ) &
           SAMPLER_PID=$!
           trap "kill $SAMPLER_PID 2>/dev/null || true" EXIT
-          # DIAGNOSTIC (temporary): scope to the 3 GPU-compute examples that
-          # fail with "device lost: external Instance" to test whether
-          # --disable-gpu-watchdog lets slow software compute complete.
-          # Revert to the full matrix once confirmed.
+          # DIAGNOSTIC (temporary): Firefox + lavapipe on the 2 GPU-compute
+          # examples (06/07) that crash Chrome's SwiftShader. Install the
+          # Firefox browser here (playwright pip is available at this point).
+          python -m playwright install --with-deps firefox
           bash scripts/test.sh --e2e-only --use-existing \
-            --workflows 06-autark-what-if-shadow-study.json \
+            --workflows 06-autark-what-if-shadow-study.json,07-autark-gpu-shader.json \
             --allure-dir "$GITHUB_WORKSPACE/allure-results"
 
       - name: 📈 Resource snapshot (after e2e)

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -83,6 +83,11 @@ jobs:
           echo "lavapipe ICD: ${ICD:-NOT FOUND}"
           echo "VK_ICD_FILENAMES=$ICD" >> "$GITHUB_ENV"
           echo "PYTEST_ADDOPTS=--browser firefox" >> "$GITHUB_ENV"
+          # Firefox runs WebGPU in a sandboxed GPU process that strips env vars,
+          # so VK_ICD_FILENAMES never reaches wgpu and requestAdapter() returns
+          # null. Disabling the GPU sandbox lets the process inherit the Vulkan
+          # ICD path and enumerate the lavapipe adapter.
+          echo "MOZ_DISABLE_GPU_SANDBOX=1" >> "$GITHUB_ENV"
           VK_ICD_FILENAMES="$ICD" vulkaninfo --summary 2>/dev/null \
             | grep -iE "deviceName|driverName" | head || true
 

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -171,7 +171,12 @@ jobs:
           ) &
           SAMPLER_PID=$!
           trap "kill $SAMPLER_PID 2>/dev/null || true" EXIT
+          # DIAGNOSTIC (temporary): scope to the 3 GPU-compute examples that
+          # fail with "device lost: external Instance" to test whether
+          # --disable-gpu-watchdog lets slow software compute complete.
+          # Revert to the full matrix once confirmed.
           bash scripts/test.sh --e2e-only --use-existing \
+            --workflows 06-autark-what-if-shadow-study.json,07-autark-gpu-shader.json,Interaction_Vega_Autark.json \
             --allure-dir "$GITHUB_WORKSPACE/allure-results"
 
       - name: 📈 Resource snapshot (after e2e)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -203,6 +203,11 @@ if [[ $RUN_E2E -eq 1 ]]; then
   echo ""
   echo "==> Installing Playwright browser..."
   python -m playwright install chromium
+  # DIAG: also install Firefox when the suite is routed through it, to test
+  # WebGPU compute on Firefox's wgpu (over system Vulkan / lavapipe).
+  if [[ "${PYTEST_ADDOPTS:-}" == *"--browser firefox"* ]]; then
+    python -m playwright install --with-deps firefox
+  fi
 
   PYTEST_ARGS="-v"
   [[ $HEADED -eq 1 ]]    && PYTEST_ARGS="$PYTEST_ARGS --headed"

--- a/utk_curio/backend/tests/conftest.py
+++ b/utk_curio/backend/tests/conftest.py
@@ -266,6 +266,15 @@ def browser_type_launch_args(browser_type_launch_args):
                 # spill its shared memory to /tmp (disk) instead so the
                 # SwiftShader software-WebGPU buffers don't pin RAM toward OOM.
                 "--disable-dev-shm-usage",
+                # SwiftShader software *compute* (e.g. the shadow/road-table
+                # passes in examples 06/07) is far slower than hardware and
+                # overruns Chrome's GPU watchdog, which then kills the GPU
+                # process mid-compute -> "device lost: external Instance" and a
+                # renderer that can't re-acquire an adapter. Disable the
+                # watchdog so slow software compute runs to completion, and
+                # don't let Chrome give up respawning the GPU process.
+                "--disable-gpu-watchdog",
+                "--disable-gpu-process-crash-limit",
             ]
 
     launch_args = {

--- a/utk_curio/backend/tests/conftest.py
+++ b/utk_curio/backend/tests/conftest.py
@@ -196,8 +196,14 @@ def _find_system_chrome() -> str | None:
 
 
 @pytest.fixture(scope="session")
-def browser_type_launch_args(browser_type_launch_args):
+def browser_type_launch_args(browser_type_launch_args, browser_type):
     """Configure browser launch options.
+
+    Firefox path (CI experiment): Firefox's WebGPU is ``wgpu`` (Rust) over
+    the *system* Vulkan loader, so it can use Mesa lavapipe (installed in
+    CI, pinned via ``VK_ICD_FILENAMES``) for the software *compute* passes
+    that Chrome's bundled SwiftShader crashes on. We just enable the API
+    via prefs and skip all the Chrome-specific flags / ``executable_path``.
 
     Points ``executable_path`` at the system Google Chrome instead of
     Playwright's bundled Chromium. Playwright's bundled Chromium on
@@ -249,6 +255,19 @@ def browser_type_launch_args(browser_type_launch_args):
     from ``http://localhost:8080`` (a secure context), satisfying
     WebGPU's secure-context requirement.
     """
+    if browser_type.name == "firefox":
+        return {
+            **browser_type_launch_args,
+            "headless": browser_type_launch_args.get("headless", True),
+            "firefox_user_prefs": {
+                "dom.webgpu.enabled": True,
+                "gfx.webgpu.force-enabled": True,
+                "gfx.webgpu.ignore-blocklist": True,
+                # Allow wgpu to pick a software (lavapipe) Vulkan adapter.
+                "gfx.webrender.all": True,
+            },
+        }
+
     base_args = [
         "--enable-unsafe-webgpu",
         "--enable-unsafe-swiftshader",

--- a/utk_curio/backend/tests/conftest.py
+++ b/utk_curio/backend/tests/conftest.py
@@ -298,6 +298,14 @@ def browser_type_launch_args(browser_type_launch_args, browser_type):
                 "--disable-gpu-watchdog",
                 "--disable-gpu-process-crash-limit",
                 "--enable-features=Vulkan",
+                # On Chrome Dev, 06's compute now *completes*, but the WebGPU
+                # device is torn down at the compute->map boundary and the
+                # software adapter doesn't come back ("device lost: external
+                # Instance" -> requestAdapter() null on the map node). Running
+                # the GPU in-process removes the separate GPU process whose
+                # teardown invalidates the adapter, so a destroyed device no
+                # longer kills WebGPU for the rest of the page.
+                "--in-process-gpu",
             ]
             # Two software-WebGPU backends, selected by CURIO_WEBGPU_BACKEND:
             #   swiftshader (default) — Chrome's bundled SwiftShader Vulkan.

--- a/utk_curio/backend/tests/conftest.py
+++ b/utk_curio/backend/tests/conftest.py
@@ -262,6 +262,10 @@ def browser_type_launch_args(browser_type_launch_args):
                 "--use-angle=swiftshader",
                 "--enable-features=Vulkan",
                 "--ignore-gpu-blocklist",
+                # The runner's /dev/shm is RAM-backed and small; let Chrome
+                # spill its shared memory to /tmp (disk) instead so the
+                # SwiftShader software-WebGPU buffers don't pin RAM toward OOM.
+                "--disable-dev-shm-usage",
             ]
 
     launch_args = {

--- a/utk_curio/backend/tests/conftest.py
+++ b/utk_curio/backend/tests/conftest.py
@@ -149,7 +149,16 @@ def _find_system_chrome() -> str | None:
 
     Returns ``None`` when Chrome is not found, in which case the
     caller falls back to bundled Chromium.
+
+    ``CURIO_CHROME_PATH`` overrides discovery entirely — used in CI to
+    test a specific Chrome build (e.g. the Dev channel, whose newer
+    SwiftShader/Dawn may handle software-WebGPU compute that the stable
+    build crashes on).
     """
+    override = os.environ.get("CURIO_CHROME_PATH")
+    if override and os.path.isfile(override):
+        return override
+
     candidates: list[str] = []
     if sys.platform == "win32":
         program_files = os.environ.get("ProgramFiles", r"C:\Program Files")

--- a/utk_curio/backend/tests/conftest.py
+++ b/utk_curio/backend/tests/conftest.py
@@ -254,28 +254,39 @@ def browser_type_launch_args(browser_type_launch_args):
         # software adapter (Dawn over SwiftShader's Vulkan ICD).
         if headless:
             headless = False  # prevent Playwright's old --headless
-            base_args = [
+            # Flags common to both software backends.
+            common = [
                 "--headless=new",
                 "--enable-unsafe-webgpu",
-                "--enable-unsafe-swiftshader",
-                "--use-webgpu-adapter=swiftshader",
-                "--use-angle=swiftshader",
-                "--enable-features=Vulkan",
                 "--ignore-gpu-blocklist",
                 # The runner's /dev/shm is RAM-backed and small; let Chrome
                 # spill its shared memory to /tmp (disk) instead so the
-                # SwiftShader software-WebGPU buffers don't pin RAM toward OOM.
+                # software-WebGPU buffers don't pin RAM toward OOM.
                 "--disable-dev-shm-usage",
-                # SwiftShader software *compute* (e.g. the shadow/road-table
-                # passes in examples 06/07) is far slower than hardware and
-                # overruns Chrome's GPU watchdog, which then kills the GPU
-                # process mid-compute -> "device lost: external Instance" and a
-                # renderer that can't re-acquire an adapter. Disable the
-                # watchdog so slow software compute runs to completion, and
-                # don't let Chrome give up respawning the GPU process.
+                # Software compute (e.g. the shadow/road-table passes in
+                # examples 06/07) is far slower than hardware; keep the GPU
+                # watchdog from killing the process mid-compute, and don't let
+                # Chrome give up respawning the GPU process on a crash.
                 "--disable-gpu-watchdog",
                 "--disable-gpu-process-crash-limit",
+                "--enable-features=Vulkan",
             ]
+            # Two software-WebGPU backends, selected by CURIO_WEBGPU_BACKEND:
+            #   swiftshader (default) — Chrome's bundled SwiftShader Vulkan.
+            #     Renders maps fine but its GPU process crashes on the compute
+            #     shaders in 06/07 ("device lost: external Instance").
+            #   vulkan — Mesa lavapipe system Vulkan (installed in CI, pinned
+            #     via VK_ICD_FILENAMES). A more conformant software Vulkan that
+            #     should survive the compute passes SwiftShader crashes on.
+            backend = os.environ.get("CURIO_WEBGPU_BACKEND", "swiftshader")
+            if backend == "vulkan":
+                base_args = common + ["--use-angle=vulkan"]
+            else:
+                base_args = common + [
+                    "--enable-unsafe-swiftshader",
+                    "--use-webgpu-adapter=swiftshader",
+                    "--use-angle=swiftshader",
+                ]
 
     launch_args = {
         **browser_type_launch_args,

--- a/utk_curio/backend/tests/test_frontend/conftest.py
+++ b/utk_curio/backend/tests/test_frontend/conftest.py
@@ -1,4 +1,7 @@
 import os
+import shutil
+import subprocess
+import sys
 
 import pytest
 from playwright.sync_api import Browser, BrowserType
@@ -20,6 +23,41 @@ from .fixtures import _clean_db
 # Re-launching Chromium between workflow classes drops it back to baseline
 # at the cost of ~5 s × workflow_count of startup overhead.
 
+
+def _reap_orphaned_chrome() -> None:
+    """Best-effort kill of Chrome child processes left after ``close()``.
+
+    Under Chrome's *new* headless on the GPU-less Linux CI runner (see the
+    Linux WebGPU branch in the root conftest), software WebGPU runs in a
+    separate **GPU process** that holds the SwiftShader render/compute
+    buffers. ``browser.close()`` tears down the browser process but does
+    not always reap that GPU process (nor the utility/crashpad helpers),
+    so across the ~25 workflow classes their buffers accumulate and the
+    runner OOM-kills the pytest process mid-suite. Reaping the orphans
+    after each class returns the host to baseline.
+
+    CI-only and Linux-only: gated on ``CI`` so it never touches a
+    developer's desktop Chrome. Best-effort — failures are ignored.
+    """
+    if not sys.platform.startswith("linux"):
+        return
+    if not os.environ.get("CI"):
+        return
+    if not shutil.which("pkill"):
+        return
+    for pattern in (
+        "--type=gpu-process",
+        "--type=utility",
+        "chrome_crashpad_handler",
+    ):
+        subprocess.run(
+            ["pkill", "-9", "-f", pattern],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+
 @pytest.fixture(scope="class")
 def browser(
     browser_type: "BrowserType",
@@ -28,6 +66,7 @@ def browser(
     launched = browser_type.launch(**browser_type_launch_args)
     yield launched
     launched.close()
+    _reap_orphaned_chrome()
 
 # ------------------------------------------------------------------ #
 # Workflow scenario discovery

--- a/utk_curio/backend/tests/test_frontend/test_workflows.py
+++ b/utk_curio/backend/tests/test_frontend/test_workflows.py
@@ -282,9 +282,18 @@ class TestWorkflowCanvas:
         worst case. The old 5-min budget dated from the Overpass era (a remote,
         throttled OSM endpoint), which has since been removed — a node that now
         runs past this budget is hung, not slow, so fail it.
+
+        AUTK_GRAMMAR is the exception: a node may also run a WebGPU *compute*
+        section (e.g. example 06's shadow/sunlight passes). On a real GPU that
+        finishes in seconds, but on the GPU-less CI runner it falls back to
+        Chrome's software WebGPU (SwiftShader), where the same compute is
+        legitimately slow -- not hung. So it gets a generous, env-tunable
+        ceiling (CURIO_E2E_AUTK_TIMEOUT_MS); the high default costs nothing on
+        dev hosts where the node finishes fast.
         """
+        if node.type == "AUTK_GRAMMAR":
+            return int(os.environ.get("CURIO_E2E_AUTK_TIMEOUT_MS", "600000"))
         if node.type in {
-            "AUTK_GRAMMAR",
             "DATA_LOADING",
             "DATA_TRANSFORMATION",
             "COMPUTATION_ANALYSIS",


### PR DESCRIPTION
Builds on the new-headless + SwiftShader WebGPU fix already on main. Reaps Chrome's orphaned GPU/utility/crashpad child processes after each class teardown (CI/Linux only) and adds --disable-dev-shm-usage, so the full e2e matrix no longer accumulates SwiftShader buffers to OOM. Full-matrix validation run.