### PR TITLE
Move CI to self-hosted NVIDIA GPU runner (utk)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,20 @@
+# Code owners. Last matching pattern wins. Enforced on PRs to branches with
+# "Require review from Code Owners" enabled (see the main branch protection rule).
+
+# Default: any maintainer may approve.
 * @fabio-miranda @GMMULLER
+
+# CI / deploy workflows (docker-compose.yml + deploy.yml) — @fabio-miranda only.
+/.github/workflows/                                          @fabio-miranda
+
+# The CODEOWNERS file itself — so ownership can't be changed without sign-off.
+/.github/CODEOWNERS                                          @fabio-miranda
+
+# Test harness entry points (DB/browser wiring, the workflow e2e suite).
+/utk_curio/backend/tests/conftest.py                         @fabio-miranda
+/utk_curio/backend/tests/test_frontend/test_workflows.py     @fabio-miranda
+
+# Build / compose stack — prod + CI isolation depend on these.
+/docker-compose.yml                                          @fabio-miranda
+/docker-compose.deploy.yml                                   @fabio-miranda
+/Dockerfile                                                  @fabio-miranda

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,33 @@ name: Deploy
 #        CURIO_PORT_2000=2010
 #        CURIO_PORT_5002=5012
 #        CURIO_PORT_8080=8090
+#
+#   6. Self-hosted GPU CI runner (for .github/workflows/docker-compose.yml,
+#      which runs ONLY on this box — the WebGPU compute examples 06/07 need
+#      real hardware WebGPU that GitHub-hosted runners lack). On `utk`:
+#        a. Verify the NVIDIA GPU is usable headless:
+#             lspci | grep -E 'VGA|3D'; ls -l /dev/dri; nvidia-smi
+#             vulkaninfo --summary   # must name the NVIDIA device, NOT llvmpipe
+#        b. Install GPU userspace + browser (as root):
+#             apt-get install -y vulkan-tools   # plus the NVIDIA driver + ICD
+#             # google-chrome-stable — the e2e suite uses real system Chrome
+#             # (conftest.py _find_system_chrome), not bundled Chromium.
+#        c. Ensure the `deploy` user's env does NOT set VK_ICD_FILENAMES
+#           (it would pin Mesa lavapipe -> software WebGPU and the run would
+#           fail the CURIO_REQUIRE_HARDWARE_WEBGPU assertion).
+#        d. Install the Actions runner as `deploy`, registered to this repo
+#           with labels `gpu,curio`, in a runner group scoped to THIS repo
+#           only, under systemd (recommended --ephemeral):
+#             sudo -iu deploy
+#             mkdir ~/actions-runner && cd ~/actions-runner
+#             # download + ./config.sh --url https://github.com/urban-toolkit/curio \
+#             #   --token <repo runner token> --labels gpu,curio --ephemeral
+#        e. SECURITY (public repo + self-hosted): Settings -> Actions -> require
+#           approval for ALL outside-collaborator/fork PRs; scope the runner
+#           group to this repo. The workflow's `if:` guard already prevents the
+#           job from running on fork PRs, so untrusted code never executes here.
+#      The CI stack runs as `docker compose -p curio-ci` on remapped ports
+#      (2020/5022/8100), fully isolated from the prod curio/curio-dev stacks.
 
 on:
   push:

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -25,36 +25,80 @@ on:
       - 'package-lock.json'
       - 'packages/**'
       - 'docs/examples/**'
-  # workflow_dispatch:  # Run manually from Actions tab or: gh workflow run docker-compose.yml
+  workflow_dispatch:  # Run manually from the Actions tab or: gh workflow run docker-compose.yml
+
+# Least privilege: the job needs only to read the checked-out code. It must
+# NOT have access to deploy/Tailscale secrets (see deploy.yml).
+permissions:
+  contents: read
+
+# The self-hosted runner on `utk` shares one GPU and a fixed set of CI ports.
+# Never let two runs execute concurrently or they fight over the GPU/ports.
+concurrency:
+  group: utk-ci
+  cancel-in-progress: false
 
 jobs:
-  test-compose:
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
+  test-gpu:
+    # Runs on the self-hosted runner on `utk` (NVIDIA GPU), registered with
+    # these labels. There is no GitHub-hosted fallback: the WebGPU compute
+    # examples (06/07) require real hardware WebGPU, which a GPU-less
+    # ubuntu-latest runner cannot provide.
+    runs-on: [self-hosted, linux, gpu, curio]
+    timeout-minutes: 90
+
+    # SECURITY (public repo + self-hosted): fork PRs must never execute on
+    # `utk`. Run only for push / workflow_dispatch / same-repo PRs. Fork PRs
+    # are skipped entirely (they get no CI; a maintainer pushes the branch).
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+
+    env:
+      # Hardware WebGPU path (see conftest.py browser_type_launch_args).
+      CURIO_WEBGPU_BACKEND: hardware
+      CURIO_REQUIRE_HARDWARE_WEBGPU: "1"
+      # Isolation from prod on the same host: distinct compose project
+      # (-p curio-ci below) + remapped host ports so the CI stack never
+      # collides with prod `curio` (2000/5002/8080) or `curio-dev`
+      # (2010/5012/8090). docker-compose.yml honors these env vars.
+      CURIO_CONTAINER_NAME: curio-ci
+      CURIO_PORT_2000: "2020"
+      CURIO_PORT_5002: "5022"
+      CURIO_PORT_8080: "8100"
+      BACKEND_URL: "http://localhost:5022"
+      # Host-side Playwright targets the remapped ports (utils.py
+      # e2e_existing_servers / _backend_base_url_for_config read these).
+      CURIO_E2E_HOST: localhost
+      CURIO_E2E_BACKEND_PORT: "5022"
+      CURIO_E2E_SANDBOX_PORT: "2020"
+      CURIO_E2E_FRONTEND_PORT: "8100"
+      FLASK_SANDBOX_HOST: localhost
+      FLASK_SANDBOX_PORT: "2020"
 
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
 
       - name: 🔨 Build all service images in parallel
-        run: docker compose -p curio build --parallel
+        run: docker compose -p curio-ci build --parallel
 
       - name: ▶️ Start containers
-        run: docker compose -p curio up -d
+        run: docker compose -p curio-ci up -d
 
       - name: 🧪 Wait for services to become healthy
         shell: bash
         run: |
           set -euo pipefail
-          echo "Waiting for curio to be healthy..."
+          echo "Waiting for curio-ci to be healthy..."
 
           timeout 240 bash -euo pipefail -c '
             while true; do
-              cid="$(docker compose -p curio ps -a -q curio | head -n1 || true)"
+              cid="$(docker compose -p curio-ci ps -a -q curio | head -n1 || true)"
 
               if [[ -z "${cid}" ]]; then
-                echo "Still waiting... (curio container not created yet)"
-                docker compose -p curio ps -a || true
+                echo "Still waiting... (curio-ci container not created yet)"
+                docker compose -p curio-ci ps -a || true
                 sleep 2
                 continue
               fi
@@ -63,20 +107,20 @@ jobs:
               health="$(docker inspect --format "{{if .State.Health}}{{.State.Health.Status}}{{else}}no-healthcheck{{end}}" "${cid}" 2>/dev/null || true)"
 
               if [[ "${health}" == "healthy" ]]; then
-                echo "curio is healthy."
+                echo "curio-ci is healthy."
                 break
               fi
 
               # If there is no Docker HEALTHCHECK, accept "running"
               if [[ "${health}" == "no-healthcheck" && "${state}" == "running" ]]; then
-                echo "curio is running (no healthcheck)."
+                echo "curio-ci is running (no healthcheck)."
                 break
               fi
 
               # If it crashed, fail fast with logs
               if [[ "${state}" == "exited" ]]; then
-                echo "curio exited. Logs:"
-                docker compose -p curio logs --no-color --tail=200 curio || true
+                echo "curio-ci exited. Logs:"
+                docker compose -p curio-ci logs --no-color --tail=200 curio || true
                 exit 1
               fi
 
@@ -87,12 +131,12 @@ jobs:
 
       - name: 🧪 Run backend unit tests
         run: |
-          docker compose -p curio exec curio \
+          docker compose -p curio-ci exec -T curio \
             bash scripts/test.sh --backend-only --use-existing
 
       - name: 🧪 Run sandbox unit tests
         run: |
-          docker compose -p curio exec curio \
+          docker compose -p curio-ci exec -T curio \
             bash scripts/test.sh --sandbox-only --use-existing
 
       - name: 🐍 Set up Python (for e2e)
@@ -102,55 +146,16 @@ jobs:
 
       - name: 🔧 Give .curio/ permissions for host-side tests
         run: |
-          # Docker creates .curio/ as root; the host runner needs write
-          # access to create .curio/playwright/expected/ for programmatic
-          # ground-truth data.
-          sudo chmod -R a+rwx .curio/ 2>/dev/null || mkdir -p .curio/playwright/expected
+          # Docker creates .curio/ as root; the host runner needs write access
+          # to create .curio/playwright/expected/. The runner user (deploy) has
+          # no sudo, so fix perms via a throwaway container (deploy.yml pattern).
+          docker run --rm -v "$PWD/.curio:/c" alpine chmod -R a+rwx /c \
+            || mkdir -p .curio/playwright/expected
 
-      - name: 📈 Resource snapshot (before e2e)
+      - name: 🎭 Run e2e tests (full matrix, hardware WebGPU)
         run: |
-          echo "=== free -h ==="
-          free -h
-          echo "=== df -h ==="
-          df -h
-          echo "=== docker system df ==="
-          docker system df || true
-          echo "=== docker stats (no-stream) ==="
-          docker stats --no-stream || true
-          echo "=== top (snapshot) ==="
-          top -bn1 | head -30 || true
-
-      - name: 🎭 Run e2e tests
-        run: |
-          # Background sampler: streams a resource snapshot every 30 s to the
-          # step log so we can see RAM/disk trajectory if the runner dies
-          # mid-step (the failing run lost step-10 logs entirely after the
-          # runner went silent).
-          (
-            while true; do
-              echo "=== SAMPLER $(date -u +%H:%M:%S) ==="
-              free -h | sed -n '1,3p'
-              df -h / | tail -1
-              docker stats --no-stream --format 'table {{.Name}}\t{{.MemUsage}}\t{{.CPUPerc}}' 2>/dev/null || true
-              sleep 30
-            done
-          ) &
-          SAMPLER_PID=$!
-          trap "kill $SAMPLER_PID 2>/dev/null || true" EXIT
           bash scripts/test.sh --e2e-only --use-existing \
             --allure-dir "$GITHUB_WORKSPACE/allure-results"
-
-      - name: 📈 Resource snapshot (after e2e)
-        if: always()
-        run: |
-          echo "=== free -h ==="
-          free -h
-          echo "=== df -h ==="
-          df -h
-          echo "=== docker system df ==="
-          docker system df || true
-          echo "=== docker stats (no-stream) ==="
-          docker stats --no-stream || true
 
       - name: 📊 Install Allure CLI
         if: always()
@@ -174,7 +179,7 @@ jobs:
 
       - name: Check frontend availability
         run: |
-          curl --fail http://localhost:8080 || (echo "Frontend not reachable" && exit 1)
+          curl --fail http://localhost:8100 || (echo "Frontend not reachable" && exit 1)
 
       - name: Jest frontend unit tests
         run: |
@@ -182,4 +187,5 @@ jobs:
           docker run --rm curio-frontend-test npm test
 
       - name: 🧹 Tear down containers
-        run: docker compose -p curio down
+        if: always()
+        run: docker compose -p curio-ci down -v --remove-orphans

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -167,11 +167,7 @@ jobs:
 
       - name: 🎭 Run e2e tests (full matrix, hardware WebGPU)
         run: |
-          # TEMPORARY: scoped to the 5 examples that failed the first hardware
-          # run (4 data-pool timeouts + 08 spatial-join). Remove --workflows to
-          # restore the full 01-11 matrix once these are green.
           bash scripts/test.sh --e2e-only --use-existing \
-            --workflows 08-autark-spatial-join-regression.json \
             --allure-dir "$GITHUB_WORKSPACE/allure-results"
 
       - name: 📊 Install Allure CLI

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -154,7 +154,11 @@ jobs:
 
       - name: 🎭 Run e2e tests (full matrix, hardware WebGPU)
         run: |
+          # TEMPORARY: first run scoped to the GPU-compute example 07 to verify
+          # hardware WebGPU works on the runner before the full ~30 min matrix.
+          # Remove --workflows once 07 passes to run the full 01-11 matrix.
           bash scripts/test.sh --e2e-only --use-existing \
+            --workflows 07-autark-gpu-shader.json \
             --allure-dir "$GITHUB_WORKSPACE/allure-results"
 
       - name: 📊 Install Allure CLI

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -203,16 +203,25 @@ jobs:
           docker build --target frontend_builder -t curio-frontend-test .
           docker run --rm curio-frontend-test npm test
 
-      - name: 📋 Capture container logs (sandbox/backend autk-db errors)
+      - name: 📋 Capture sandbox/backend logs (autk-db errors)
         if: always()
-        run: docker compose -p curio-ci logs --no-color --tail=8000 > "$GITHUB_WORKSPACE/container-logs.txt" 2>&1 || true
+        run: |
+          docker compose -p curio-ci logs --no-color --tail=8000 > "$GITHUB_WORKSPACE/container-logs.txt" 2>&1 || true
+          # The real autk-db worker stderr ([execJs] ...) goes to
+          # .curio/messages.log (root-owned, on the mounted workspace); read it
+          # out via a root container so the runner user can upload it.
+          docker run --rm -v "$PWD:/w" -w /w alpine sh -c \
+            'echo "=== .curio/messages.log ==="; cat .curio/messages.log 2>/dev/null; echo; echo "=== per-session messages.log ==="; find .curio -name messages.log -exec sh -c "echo \"--- {} ---\"; cat {}" \; 2>/dev/null' \
+            > "$GITHUB_WORKSPACE/curio-messages.txt" 2>&1 || true
 
-      - name: 📤 Upload container logs
+      - name: 📤 Upload sandbox logs
         if: always()
         uses: actions/upload-artifact@v6
         with:
           name: container-logs
-          path: container-logs.txt
+          path: |
+            container-logs.txt
+            curio-messages.txt
           retention-days: 7
 
       - name: 🧹 Tear down containers

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -171,7 +171,7 @@ jobs:
           # run (4 data-pool timeouts + 08 spatial-join). Remove --workflows to
           # restore the full 01-11 matrix once these are green.
           bash scripts/test.sh --e2e-only --use-existing \
-            --workflows Interaction_Autark.json,Regression.json,06-autark-what-if-shadow-study.json,07-autark-gpu-shader.json,08-autark-spatial-join-regression.json \
+            --workflows 08-autark-spatial-join-regression.json \
             --allure-dir "$GITHUB_WORKSPACE/allure-results"
 
       - name: 📊 Install Allure CLI
@@ -202,6 +202,18 @@ jobs:
         run: |
           docker build --target frontend_builder -t curio-frontend-test .
           docker run --rm curio-frontend-test npm test
+
+      - name: 📋 Capture container logs (sandbox/backend autk-db errors)
+        if: always()
+        run: docker compose -p curio-ci logs --no-color --tail=8000 > "$GITHUB_WORKSPACE/container-logs.txt" 2>&1 || true
+
+      - name: 📤 Upload container logs
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: container-logs
+          path: container-logs.txt
+          retention-days: 7
 
       - name: 🧹 Tear down containers
         if: always()

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -58,6 +58,9 @@ jobs:
       # Hardware WebGPU path (see conftest.py browser_type_launch_args).
       CURIO_WEBGPU_BACKEND: hardware
       CURIO_REQUIRE_HARDWARE_WEBGPU: "1"
+      # autk-grammar data pools parse city-scale PBFs server-side; give the
+      # data-table render a larger budget than the 30s default on this host.
+      CURIO_E2E_DATAPOOL_TIMEOUT_MS: "120000"
       # Isolation from prod on the same host: distinct compose project
       # (-p curio-ci below) + remapped host ports so the CI stack never
       # collides with prod `curio` (2000/5002/8080) or `curio-dev`
@@ -164,7 +167,11 @@ jobs:
 
       - name: 🎭 Run e2e tests (full matrix, hardware WebGPU)
         run: |
+          # TEMPORARY: scoped to the 5 examples that failed the first hardware
+          # run (4 data-pool timeouts + 08 spatial-join). Remove --workflows to
+          # restore the full 01-11 matrix once these are green.
           bash scripts/test.sh --e2e-only --use-existing \
+            --workflows Interaction_Autark.json,Regression.json,06-autark-what-if-shadow-study.json,07-autark-gpu-shader.json,08-autark-spatial-join-regression.json \
             --allure-dir "$GITHUB_WORKSPACE/allure-results"
 
       - name: 📊 Install Allure CLI

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -78,12 +78,14 @@ jobs:
 
     steps:
       # On the persistent self-hosted runner, the previous run's container
-      # writes .curio/ into the workspace as root, which the runner user
-      # (deploy) cannot delete — that breaks actions/checkout's clean. Reclaim
-      # it via a throwaway root container BEFORE checkout runs. (Runs in the
-      # leftover workspace from the prior run; a no-op on a fresh checkout.)
+      # writes files into the workspace as root (.curio/, instance/*.db, ...),
+      # which the runner user (deploy) cannot delete — that fatally breaks
+      # actions/checkout's clean. Chown the whole workspace back to the runner
+      # user via a throwaway root container BEFORE checkout runs, so it can
+      # clean any container-created artifact. (Runs in the leftover workspace
+      # from the prior run; a no-op on a fresh runner.)
       - name: 🧹 Reclaim root-owned workspace files (self-hosted)
-        run: docker run --rm -v "$PWD:/w" -w /w alpine rm -rf /w/.curio 2>/dev/null || true
+        run: docker run --rm -v "$PWD:/w" -w /w alpine chown -R "$(id -u):$(id -g)" /w 2>/dev/null || true
 
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -198,6 +200,7 @@ jobs:
         if: always()
         run: |
           docker compose -p curio-ci down -v --remove-orphans || true
-          # Hand the container-written (root-owned) .curio/ back so it doesn't
-          # accumulate root-owned; the pre-checkout step is the real safety net.
-          docker run --rm -v "$PWD:/w" -w /w alpine rm -rf /w/.curio 2>/dev/null || true
+          # Hand the container-written (root-owned) files back to the runner
+          # user so they don't accumulate; the pre-checkout step is the real
+          # safety net for the next run.
+          docker run --rm -v "$PWD:/w" -w /w alpine chown -R "$(id -u):$(id -g)" /w 2>/dev/null || true

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -154,11 +154,7 @@ jobs:
 
       - name: 🎭 Run e2e tests (full matrix, hardware WebGPU)
         run: |
-          # TEMPORARY: first run scoped to the GPU-compute example 07 to verify
-          # hardware WebGPU works on the runner before the full ~30 min matrix.
-          # Remove --workflows once 07 passes to run the full 01-11 matrix.
           bash scripts/test.sh --e2e-only --use-existing \
-            --workflows 07-autark-gpu-shader.json \
             --allure-dir "$GITHUB_WORKSPACE/allure-results"
 
       - name: 📊 Install Allure CLI

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -77,6 +77,14 @@ jobs:
       FLASK_SANDBOX_PORT: "2020"
 
     steps:
+      # On the persistent self-hosted runner, the previous run's container
+      # writes .curio/ into the workspace as root, which the runner user
+      # (deploy) cannot delete — that breaks actions/checkout's clean. Reclaim
+      # it via a throwaway root container BEFORE checkout runs. (Runs in the
+      # leftover workspace from the prior run; a no-op on a fresh checkout.)
+      - name: 🧹 Reclaim root-owned workspace files (self-hosted)
+        run: docker run --rm -v "$PWD:/w" -w /w alpine rm -rf /w/.curio 2>/dev/null || true
+
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
 
@@ -188,4 +196,8 @@ jobs:
 
       - name: 🧹 Tear down containers
         if: always()
-        run: docker compose -p curio-ci down -v --remove-orphans
+        run: |
+          docker compose -p curio-ci down -v --remove-orphans || true
+          # Hand the container-written (root-owned) .curio/ back so it doesn't
+          # accumulate root-owned; the pre-checkout step is the real safety net.
+          docker run --rm -v "$PWD:/w" -w /w alpine rm -rf /w/.curio 2>/dev/null || true

--- a/utk_curio/backend/tests/conftest.py
+++ b/utk_curio/backend/tests/conftest.py
@@ -247,22 +247,44 @@ def browser_type_launch_args(browser_type_launch_args):
     headless = browser_type_launch_args.get("headless", True)
 
     if sys.platform.startswith("linux"):
-        # Software WebGPU recipe for the GPU-less Linux CI runner. Only
-        # take effect when running truly headless (CI / no DISPLAY);
-        # a developer on a real Linux desktop with a GPU keeps the
-        # hardware path. Force *new* headless and Chrome's SwiftShader
-        # software adapter (Dawn over SwiftShader's Vulkan ICD).
+        # Linux headless WebGPU. The backend is selected by
+        # ``CURIO_WEBGPU_BACKEND`` (default ``swiftshader``):
+        #
+        #   hardware   — the self-hosted GPU runner on ``utk`` (NVIDIA). Let
+        #     Dawn pick the real hardware Vulkan adapter; do NOT pass any
+        #     SwiftShader flag (that would force the software adapter and
+        #     defeat the point). The compute examples 06/07 only run here.
+        #
+        #   swiftshader (default) — a GPU-less host (local dev). Force Chrome's
+        #     bundled SwiftShader software adapter so the *map* examples still
+        #     render; the compute examples crash software WebGPU and are not
+        #     expected to run on this path.
+        #
+        # In both cases force *new* headless (Playwright's default
+        # ``headless=True`` launches Chrome's old headless, which has no WebGPU
+        # at all). ``headless`` is set to ``False`` so Playwright does not
+        # inject the old ``--headless``; ``--headless=new`` drives it instead.
         if headless:
             headless = False  # prevent Playwright's old --headless
-            base_args = [
-                "--headless=new",
-                "--enable-unsafe-webgpu",
-                "--enable-unsafe-swiftshader",
-                "--use-webgpu-adapter=swiftshader",
-                "--use-angle=swiftshader",
-                "--enable-features=Vulkan",
-                "--ignore-gpu-blocklist",
-            ]
+            backend = os.environ.get("CURIO_WEBGPU_BACKEND", "swiftshader")
+            if backend == "hardware":
+                base_args = [
+                    "--headless=new",
+                    "--enable-unsafe-webgpu",
+                    "--ignore-gpu-blocklist",
+                    "--enable-features=Vulkan",
+                    "--use-angle=vulkan",
+                ]
+            else:
+                base_args = [
+                    "--headless=new",
+                    "--enable-unsafe-webgpu",
+                    "--enable-unsafe-swiftshader",
+                    "--use-webgpu-adapter=swiftshader",
+                    "--use-angle=swiftshader",
+                    "--enable-features=Vulkan",
+                    "--ignore-gpu-blocklist",
+                ]
 
     launch_args = {
         **browser_type_launch_args,

--- a/utk_curio/backend/tests/test_frontend/test_workflows.py
+++ b/utk_curio/backend/tests/test_frontend/test_workflows.py
@@ -165,12 +165,17 @@ class TestWorkflowCanvas:
                             out.adapter = null;
                             return out;
                         }
-                        let info = null;
-                        try {
-                            info = adapter.requestAdapterInfo
-                                ? await adapter.requestAdapterInfo()
-                                : null;
-                        } catch (e) { info = { error: String(e) }; }
+                        // Prefer the synchronous `adapter.info` property
+                        // (populated in current Chrome); fall back to the
+                        // deprecated requestAdapterInfo() for older builds.
+                        let info = adapter.info || null;
+                        if (!info) {
+                            try {
+                                info = adapter.requestAdapterInfo
+                                    ? await adapter.requestAdapterInfo()
+                                    : null;
+                            } catch (e) { info = { error: String(e) }; }
+                        }
                         out.adapter = {
                             info: info ? {
                                 vendor: info.vendor,
@@ -204,7 +209,48 @@ class TestWorkflowCanvas:
             self.__class__._webgpu_diagnostics_logged = True
             # Stash on the page so dump_browser_log can include it.
             self.page._curio_webgpu_diagnostics = diagnostics  # type: ignore[attr-defined]
+        self._assert_hardware_webgpu(diagnostics)
         return diagnostics
+
+    @staticmethod
+    def _assert_hardware_webgpu(diagnostics: dict) -> None:
+        """When ``CURIO_REQUIRE_HARDWARE_WEBGPU=1`` (the self-hosted GPU
+        runner), fail fast if the browser did not get a *real hardware*
+        WebGPU adapter — so a misconfigured runner (e.g. a stray
+        ``VK_ICD_FILENAMES`` pinning Mesa lavapipe, or a missing NVIDIA Vulkan
+        ICD) can't silently run the 06/07 compute examples on software and
+        pass for the wrong reason. The hardware launch path
+        (``CURIO_WEBGPU_BACKEND=hardware``) passes no SwiftShader flag, so a
+        GPU-less host yields a *null* adapter here rather than a software one.
+        """
+        if os.environ.get("CURIO_REQUIRE_HARDWARE_WEBGPU") != "1":
+            return
+        adapter = diagnostics.get("adapter")
+        info = (adapter or {}).get("info") or {}
+        desc = " ".join(
+            str(info.get(k, "")) for k in ("vendor", "architecture", "device", "description")
+        ).lower()
+        is_software = any(s in desc for s in ("llvmpipe", "swiftshader", "lavapipe", "software"))
+        device = diagnostics.get("device")
+        device_ok = isinstance(device, dict) and device.get("ok") is True
+        dump = json.dumps(diagnostics)
+        assert adapter is not None, (
+            "CURIO_REQUIRE_HARDWARE_WEBGPU=1 but requestAdapter() returned no adapter "
+            f"(WebGPU unavailable on the GPU runner). Diagnostics: {dump}"
+        )
+        assert adapter.get("isFallbackAdapter") is not True, (
+            "CURIO_REQUIRE_HARDWARE_WEBGPU=1 but the WebGPU adapter is a software "
+            f"fallback (isFallbackAdapter=true). Diagnostics: {dump}"
+        )
+        assert not is_software, (
+            "CURIO_REQUIRE_HARDWARE_WEBGPU=1 but the WebGPU adapter looks like a software "
+            f"renderer ({desc!r}). Ensure VK_ICD_FILENAMES is unset and the NVIDIA Vulkan "
+            f"ICD is installed. Diagnostics: {dump}"
+        )
+        assert device_ok, (
+            "CURIO_REQUIRE_HARDWARE_WEBGPU=1 but requestDevice() did not succeed. "
+            f"Diagnostics: {dump}"
+        )
 
     def _read_code_node_error_text(self, node_el) -> str | None:
         """Return the error message text from a code node's inline output

--- a/utk_curio/backend/tests/test_frontend/test_workflows.py
+++ b/utk_curio/backend/tests/test_frontend/test_workflows.py
@@ -450,7 +450,14 @@ class TestWorkflowCanvas:
                 except Exception:
                     pass
                 data_table = node_el.locator("td.MuiTableCell-root")
-                data_table.first.wait_for(state="visible", timeout=30000)
+                # The pool shows data from an upstream node; for autk-grammar
+                # examples that data section parses city-scale PBFs server-side,
+                # which can run well past the default 30s on a busy host.
+                # Env-tunable so the GPU runner can grant a larger budget.
+                data_table.first.wait_for(
+                    state="visible",
+                    timeout=int(os.environ.get("CURIO_E2E_DATAPOOL_TIMEOUT_MS", "30000")),
+                )
                 assert data_table.count() >= 1, (
                     f"DataPool node {node.id} ({node.type}) is missing its "
                     f"data table"

--- a/utk_curio/frontend/urban-workflows/src/adapters/node/autkGrammarBehavior.tsx
+++ b/utk_curio/frontend/urban-workflows/src/adapters/node/autkGrammarBehavior.tsx
@@ -1566,7 +1566,18 @@ function resolveDataSourceUrls(spec: any, forBackend = false): any {
     // section runs there), force the loopback host to 127.0.0.1 — node's fetch
     // can stall on `localhost` resolving to IPv6 ::1. The /file/ route is
     // unauthenticated, so the node fetch needs no token.
-    if (forBackend) backendUrl = backendUrl.replace(/:\/\/localhost(:|\/|$)/, '://127.0.0.1$1');
+    if (forBackend) {
+        backendUrl = backendUrl.replace(/:\/\/localhost(:|\/|$)/, '://127.0.0.1$1');
+        // The sandbox is co-located with the backend in the SAME container, so
+        // it reaches it on the backend's fixed *internal* port (5002). Any host
+        // port remapping (e.g. CI on a shared host publishes 5002 as 5022 to
+        // avoid colliding with another stack) does NOT apply inside the
+        // container — fetching the host-mapped port from in-container yields
+        // "fetch failed" and the OSM/PBF data load comes back empty. Force the
+        // internal port for a loopback backend; a public BACKEND_URL (prod) has
+        // no 127.0.0.1 host and is left unchanged.
+        backendUrl = backendUrl.replace(/^(https?:\/\/127\.0\.0\.1):\d+/, '$1:5002');
+    }
     const urlFields = ['pbfFileUrl', 'csvFileUrl', 'jsonFileUrl', 'geojsonFileUrl'];
     const isAbsolute = (url: string) => /^[a-z][a-z\d+\-.]*:/i.test(url);
 


### PR DESCRIPTION
Runs the e2e suite on the utk GPU runner so the WebGPU compute examples (06/07) execute on real hardware. Single self-hosted job, prod-isolated via -p curio-ci + remapped ports, fork-guarded. First run scoped to example 07 to verify hardware WebGPU before un-scoping the full matrix.