### PR TITLE
Fix the defects found by the recorded user-test sessions

### DIFF
--- a/docs/schemas/trill.v1.json
+++ b/docs/schemas/trill.v1.json
@@ -462,7 +462,7 @@
         "id": { "type": "string", "description": "Copy of dataflow.provenance_id. Emitted only when that field exists." },
         "latest": {
           "type": "string",
-          "description": "Key into 'versions' naming the currently loaded snapshot, formatted '<name>_<timestamp>'. Empty string when there is no history. A value beginning 'undefined_' means dataflow.name was missing when the version was cut."
+          "description": "Key into 'versions' naming the currently loaded snapshot, formatted '<name>_<timestamp>' and, when two versions are cut in the same millisecond, '<name>_<timestamp>_<n>' from n=2. Empty string when there is no history. A value beginning 'undefined_' means dataflow.name was missing when the version was cut."
         },
         "graph": { "$ref": "#/$defs/provenanceGraph" },
         "versions": {
@@ -497,7 +497,7 @@
       "required": ["id", "label", "timestamp", "preview"],
       "additionalProperties": true,
       "properties": {
-        "id": { "type": "string", "description": "'<name>_<timestamp>', matching a key in dataflowProvenance.versions." },
+        "id": { "type": "string", "description": "'<name>_<timestamp>', or '<name>_<timestamp>_<n>' when that base was already taken, matching a key in dataflowProvenance.versions. Unique within one graph: ids collided before the suffix existed, so files written by older builds may repeat one." },
         "label": { "type": "string", "description": "'<name> (<timestamp>)', for display in the provenance window." },
         "timestamp": { "type": "integer", "minimum": 0, "description": "Epoch milliseconds, rendered as a date in the provenance window." },
         "preview": { "$ref": "#/$defs/graphPreview" }
@@ -509,7 +509,7 @@
       "required": ["id", "source", "target", "label"],
       "additionalProperties": true,
       "properties": {
-        "id": { "type": "string", "description": "'<sourceVersion>_to_<targetVersion>'." },
+        "id": { "type": "string", "description": "'<sourceVersion>_to_<targetVersion>'. Source and target are always different; older builds could emit a self-loop when two version ids collided." },
         "source": { "type": "string", "description": "Version this change started from." },
         "target": { "type": "string", "description": "Version this change produced." },
         "label": { "type": "string", "description": "Human-readable description of the change, e.g. 'Node added'." }

--- a/packages/curio.builtin@1/integrity.json
+++ b/packages/curio.builtin@1/integrity.json
@@ -1,6 +1,6 @@
 {
   "sha256": {
     "README.md": "29ed7eab4ae50e86d448be4f9986e53cfd7808036438be21d2cf095ae987d123",
-    "manifest.json": "6f4df58969fc56626413da46d5a06e2fcb4f39edaf6c8a641fd1dd2d13799537"
+    "manifest.json": "8aab938e48421350b0f69a7662d85ec0a28fbe2fc2d617c7e23302dd07d158f1"
   }
 }

--- a/packages/curio.builtin@1/manifest.json
+++ b/packages/curio.builtin@1/manifest.json
@@ -77,7 +77,8 @@
       "label": "Data Export",
       "behavior": "data-export",
       "outputPorts": [],
-      "paletteOrder": 1
+      "paletteOrder": 1,
+      "tutorialId": "step-export"
     },
     {
       "category": "data",
@@ -218,7 +219,8 @@
           ]
         }
       ],
-      "paletteOrder": 10
+      "paletteOrder": 10,
+      "tutorialId": "step-summary"
     },
     {
       "category": "computation",
@@ -258,7 +260,8 @@
           ]
         }
       ],
-      "paletteOrder": 11
+      "paletteOrder": 11,
+      "tutorialId": "step-js"
     },
     {
       "badge": "VEGA",
@@ -413,7 +416,8 @@
           "types": ["GEODATAFRAME"]
         }
       ],
-      "paletteOrder": 4
+      "paletteOrder": 4,
+      "tutorialId": "step-spatial-join"
     },
     {
       "category": "flow",

--- a/utk_curio/backend/tests/test_frontend/test_canvas_delete_key_e2e.py
+++ b/utk_curio/backend/tests/test_frontend/test_canvas_delete_key_e2e.py
@@ -232,13 +232,37 @@ def test_a_wired_node_is_refused_and_the_toast_says_how_many_connections(
 
     # Clearing the edge makes the node deletable, which is the path the toast
     # describes. Proves the refusal is a gate, not a dead end.
-    page.evaluate(
+    #
+    # The edge is removed by selecting it and pressing Delete, exactly as the
+    # toast instructs. Not by writing React Flow's store: `useStoreUpdater`
+    # pushes FlowContext's own edge array straight back over it, so the edge
+    # would reappear and the delete stay refused (see utils.drag_to_canvas).
+    edge_point = page.evaluate(
         """() => {
-            const rf = window.__curio_reactFlow;
-            rf.setEdges([]);
+            const path = document.querySelector('.react-flow__edge-interaction');
+            if (!path) return null;
+            const at = path.getPointAtLength(path.getTotalLength() / 2);
+            const svg = path.ownerSVGElement;
+            const point = svg.createSVGPoint();
+            point.x = at.x;
+            point.y = at.y;
+            const screen = point.matrixTransform(path.getScreenCTM());
+            return [screen.x, screen.y];
         }"""
     )
-    page.wait_for_timeout(500)
+    assert edge_point, "no edge interaction path to click"
+    page.mouse.click(edge_point[0], edge_point[1])
+    page.wait_for_function(
+        "() => (window.__curio_reactFlow.getEdges() || [])"
+        ".some((e) => e.selected)",
+        timeout=10000,
+    )
+    page.keyboard.press("Delete")
+    page.wait_for_function(
+        "() => (window.__curio_reactFlow.getEdges() || []).length === 0",
+        timeout=10000,
+    )
+    dismiss_toasts(page)
     _select(page, second)
     page.keyboard.press("Delete")
     page.wait_for_function(

--- a/utk_curio/backend/tests/test_frontend/test_canvas_delete_key_e2e.py
+++ b/utk_curio/backend/tests/test_frontend/test_canvas_delete_key_e2e.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 from .utils import (
     canvas_nodes,
+    connect_nodes,
     dismiss_toasts,
     drag_to_canvas,
     node_locator,
@@ -173,3 +174,76 @@ def test_delete_inside_a_code_editor_edits_text_and_keeps_the_node(
         page, "canvas-delete-key",
         test_name="test_delete_inside_a_code_editor_edits_text_and_keeps_the_node",
     )
+
+
+def test_a_wired_node_is_refused_and_the_toast_says_how_many_connections(
+    app_frontend: "FrontendPage",
+    current_server: str,
+    page,
+):
+    """Refusing to delete a connected node must explain itself.
+
+    The two tests above never connect their nodes, so neither covers what happens
+    when one is wired - and that is the case a real dataflow is always in. A user
+    test read the silence as "Delete is broken" and only a source bisect showed
+    the refusal was deliberate (``MainCanvas.handleNodesChange``). The behaviour
+    stays; what is pinned here is that the user is told what is in the way.
+    """
+    require_project_page()
+    require_user_auth()
+
+    page.emulate_media(reduced_motion="reduce")
+    stub_login_and_enter_workflow(
+        page,
+        frontend_url=app_frontend.base_url,
+        backend_url=current_server,
+        name="Delete Key",
+        username="delete_key_wired",
+        project_name="Delete Key Wired",
+    )
+    require_owner_view(page)
+
+    first = drag_to_canvas(page, page.locator(ANALYSIS_TILE), at=POS_FIRST)
+    second = drag_to_canvas(page, page.locator(ANALYSIS_TILE), at=POS_SECOND)
+    connect_nodes(page, first, second)
+    dismiss_toasts(page)
+
+    _select(page, second)
+    page.keyboard.press("Delete")
+    page.wait_for_timeout(1500)
+
+    # Still there: the refusal is the documented behaviour.
+    assert second in _node_ids(page), (
+        "a node with an edge was removed; deleting a wired node is supposed to "
+        "be refused until its connections are gone"
+    )
+
+    # And the user was told, with the count so they know what to clear.
+    toast = page.locator('[aria-label="Notifications"] .toast').first
+    toast.wait_for(state="visible", timeout=10000)
+    said = " ".join((toast.text_content() or "").split())
+    assert "1 connection" in said, (
+        f"the toast did not name how many connections block the delete: {said!r}"
+    )
+    assert "Delete or Backspace" in said, (
+        f"the toast did not say how to clear them: {said!r}"
+    )
+    dismiss_toasts(page)
+
+    # Clearing the edge makes the node deletable, which is the path the toast
+    # describes. Proves the refusal is a gate, not a dead end.
+    page.evaluate(
+        """() => {
+            const rf = window.__curio_reactFlow;
+            rf.setEdges([]);
+        }"""
+    )
+    page.wait_for_timeout(500)
+    _select(page, second)
+    page.keyboard.press("Delete")
+    page.wait_for_function(
+        "id => !document.querySelector(`.react-flow__node[data-id='${id}']`)",
+        arg=second,
+        timeout=10000,
+    )
+    assert second not in _node_ids(page)

--- a/utk_curio/backend/tests/test_frontend/test_feature_tour_video.py
+++ b/utk_curio/backend/tests/test_frontend/test_feature_tour_video.py
@@ -281,7 +281,9 @@ def _load_example(ctx: Ctx, path: str, *, expected_nodes: int) -> None:
     load.wait_for(state="visible", timeout=15000)
     tour.focus(load, hold=500)
     with page.expect_file_chooser() as chooser:
-        page.get_by_text("Load dataflow").click()
+        # See utils.upload_workflow: get_by_text matches the menu row and the
+        # button inside it, which is a strict-mode violation.
+        load.click()
     chooser.value.set_files(path)
     page.wait_for_function(
         "(n) => document.querySelectorAll('.react-flow__node').length >= n",

--- a/utk_curio/backend/tests/test_frontend/test_user_stress_video.py
+++ b/utk_curio/backend/tests/test_frontend/test_user_stress_video.py
@@ -1869,8 +1869,34 @@ class TestSessionExtending:
             assert "cells" in notebook, (
                 f"the export at {path} is not a notebook: keys={list(notebook)}"
             )
+            # Coverage, not merely shape. The first version of this step asserted
+            # only that a "cells" key existed, so a three-node dataflow that
+            # exported one cell passed it.
+            on_canvas = canvas_nodes(page)
+            body = json.dumps(notebook)
+            missing = [n["id"] for n in on_canvas if n["id"] not in body]
+            assert not missing, (
+                f"{len(missing)} of {len(on_canvas)} nodes never reached the "
+                f"notebook: {missing}"
+            )
+            # And every code cell must be runnable: a node body ends in `return`,
+            # which is a SyntaxError at a notebook's top level.
+            for index, cell in enumerate(notebook["cells"]):
+                if cell.get("cell_type") != "code":
+                    continue
+                source = cell["source"]
+                if isinstance(source, list):
+                    source = "".join(source)
+                stray = [
+                    line for line in source.splitlines()
+                    if line.startswith("return ") or line.strip() == "return"
+                ]
+                assert not stray, (
+                    f"cell {index} has a top-level return and cannot run: {stray}"
+                )
             s.note(
                 f"exported a notebook with {len(notebook['cells'])} cell(s) "
+                f"covering all {len(on_canvas)} node(s) "
                 f"to {os.path.basename(saved)}"
             )
 

--- a/utk_curio/backend/tests/test_frontend/test_user_stress_video.py
+++ b/utk_curio/backend/tests/test_frontend/test_user_stress_video.py
@@ -820,20 +820,27 @@ class TestSessionFirstHour:
                 )
 
         with s.step("Does the downstream chart know it is stale?",
-                    "The loader is broken; running the chart should not succeed.",
-                    expect="either", quiet_console=True):
+                    "The loader is broken; running the chart must not succeed.",
+                    quiet_console=True):
+            # An assertion, not an observation. The loader produced a valid
+            # artifact before the edit, so a naive "did it ever succeed" check
+            # skips it and the chart reports Done off source that can no longer
+            # produce it. playNodesUpTo now compares each ancestor's code against
+            # the code that produced its output, so the broken loader is re-run
+            # and takes the chart down with it.
             play_node(page, vega_id)
             status = wait_for_node_settled(
                 page, vega_id, node_type="curio.builtin/vis-vega",
-                timeout_ms=60000,
+                timeout_ms=120000,
             )
-            s.note(
-                "with a broken upstream, the chart settled as "
-                f"{status!r}. Note the loader had already produced a valid "
-                "artifact before the edit, so this is the cached-artifact "
-                "question rather than a plain miss: "
-                f"{node_failure_detail(page, vega_id)[:300]!r}"
+            detail = node_failure_detail(page, vega_id)
+            assert status == "error", (
+                "the chart reported "
+                f"{status!r} with a broken upstream, which means it reused the "
+                "artifact the pre-edit loader produced.\n"
+                f"the app said: {detail[:400]!r}"
             )
+            s.note(f"the stale chain failed as it should: {detail[:200]!r}")
             dismiss_toasts(page)
 
         with s.step("Fix the typo and re-run", "Back to a working graph."):

--- a/utk_curio/backend/tests/test_frontend/test_user_stress_video.py
+++ b/utk_curio/backend/tests/test_frontend/test_user_stress_video.py
@@ -54,7 +54,6 @@ from .usertest import (
 from .utils import (
     REPO_ROOT,
     activate_header_icon,
-    canvas_node_type,
     canvas_nodes,
     close_tools_palette,
     connect_nodes,
@@ -375,11 +374,17 @@ def clear_canvas_overlays(page) -> None:
                 button.first.click(timeout=4000)
                 page.wait_for_timeout(300)
             except Exception:
+                # Best effort. The button was there a moment ago; it may have
+                # closed itself or slid under an overlay before the click landed,
+                # and this helper only has to leave the canvas usable.
                 pass
     for kind in ("datasets", "packages", "agents"):
         try:
             close_tools_palette(page, kind)
         except Exception:
+            # Each palette is closed blind, without first asking whether it is
+            # open, so "not open" arrives here as an exception rather than a
+            # no-op. That is the common case, not a problem.
             pass
     dismiss_toasts(page)
 
@@ -605,6 +610,9 @@ def run_session(browser, frontend: str, backend: str, *, session_id: str,
             page.close()
             context.close()
         except Exception:
+            # Already closed, or closed by a crashed browser. finalize_video
+            # below still has to run: losing the recording of a session that
+            # died is exactly the outcome this module exists to prevent.
             pass
         written = finalize_video(page, stem=f"curio-usertest-{session_id}")
         if written:
@@ -1333,6 +1341,8 @@ class TestSessionMapsAndInteraction:
                         button.first.click(timeout=2500)
                         break
                     except Exception:
+                        # Try the next spelling of "Close" instead. Failing to
+                        # shut this panel is not what the step is testing.
                         pass
 
         # A map, on WebGPU, in a fresh dataflow.

--- a/utk_curio/backend/tests/test_frontend/test_user_stress_video.py
+++ b/utk_curio/backend/tests/test_frontend/test_user_stress_video.py
@@ -1,0 +1,2226 @@
+"""Recorded user-test sessions: five personas trying to break Curio.
+
+Not a regression suite. Each test is one *session* - a persona with a goal, doing
+what a real user would do to reach it, including the mistakes on the way - and
+each produces a video plus a list of findings. A session never aborts on the
+first problem: it files it and keeps going, because a real user does, and because
+the interesting findings are usually downstream of the first one.
+
+The harness is borrowed wholesale. ``fixtures.curio_servers`` boots the stack,
+``conftest.py`` launches the system Chrome that Autark's WebGPU needs, ``utils``
+supplies the canvas vocabulary, and ``tour``/``usertest`` supply the on-screen
+narration and the video plumbing. What is new here is the *stance*: see
+``usertest.UserSession.step``.
+
+Gated on ``CURIO_STRESS=1`` so an ordinary ``pytest tests/test_frontend/`` run
+never spends half an hour recording.
+
+Run (from ``utk_curio/backend``, with the repo root on PYTHONPATH)::
+
+    BACKEND_PORT=5013 SANDBOX_PORT=2011 FRONTEND_PORT=8091 \
+    CURIO_TESTING=1 CURIO_STRESS=1 CURIO_SANDBOX_TOKEN=usertest-local \
+      python -m pytest tests/test_frontend/test_user_stress_video.py -s -v
+
+Environment:
+
+===============================  ==============================================
+``CURIO_STRESS=1``               required; otherwise the module skips
+``CURIO_STRESS_SESSIONS``        comma-separated session ids (default: all)
+``CURIO_STRESS_OUT``             output dir (default ``.curio/usertest/``)
+``CURIO_STRESS_SPEED``           pacing multiplier, >1 is faster (default 1.4)
+===============================  ==============================================
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+
+import pytest
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+from playwright.sync_api import expect
+
+from .tour import VIDEO_SIZE, finalize_video
+from .usertest import (
+    PALETTE_ICON_CLASS,
+    UserSession,
+    collect_sessions,
+    out_dir,
+    palette_tile,
+    palette_tile_identity,
+    write_report,
+)
+from .utils import (
+    REPO_ROOT,
+    activate_header_icon,
+    canvas_node_type,
+    canvas_nodes,
+    close_tools_palette,
+    connect_nodes,
+    dismiss_toasts,
+    drag_to_canvas,
+    node_locator,
+    open_new_workflow,
+    open_tools_palette,
+    play_node,
+    read_node_code,
+    read_node_error_text,
+    require_project_page,
+    require_user_auth,
+    set_canvas_zoom,
+    set_node_code,
+    signup_e2e_user,
+    wait_for_node_settled,
+    wait_for_projects_page,
+)
+
+# The tour module owns the shared canvas choreography (menus, Play All, fitView,
+# the agent drag, the AI Settings panel). Importing it rather than restating it
+# keeps this file about the *exploration* - and means a change to the app that
+# breaks a gesture breaks it in one place.
+from .test_feature_tour_video import (  # noqa: E402
+    AGENT_BUILDER,
+    AGENT_CONNECTION,
+    AGENT_EXPLAINER,
+    Ctx,
+    LLM_API_KEY,
+    LLM_BASE_URL,
+    LLM_MODEL,
+    _add_agent,
+    _center_on,
+    _close_data_drawer,
+    _drag_agent_to,
+    _edge_client_point,
+    _empty_canvas_point,
+    _fit_view,
+    _log,
+    _menu,
+    _new_dataflow_from_menu,
+    _node_client_point,
+    _node_ids_by_type,
+    _open_agent_drawer,
+    _play_all,
+    _reset_zoom,
+    scene_ai_settings,
+)
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("CURIO_STRESS") != "1",
+    reason="recorded user-test sessions only run with CURIO_STRESS=1",
+)
+
+
+def _pace() -> float:
+    try:
+        value = float(os.environ.get("CURIO_STRESS_SPEED", "1.4"))
+    except ValueError:
+        return 1.4
+    return value if value > 0 else 1.4
+
+
+def _wanted(session_id: str) -> bool:
+    selected = os.environ.get("CURIO_STRESS_SESSIONS")
+    if not selected:
+        return True
+    return session_id in {s.strip() for s in selected.split(",") if s.strip()}
+
+
+DRAWER_DATA = '[data-curio-dataset-catalog-drawer="true"]'
+DRAWER_NODES = '[data-curio-node-catalog-drawer="true"]'
+CARD = 'article:not([role="status"])'
+
+GEO_DATASET = "data.urbanlab.chicago-boundary"
+
+PKG_DIR = "curio.example-ui@1"
+PKG_NAME = "Example: Custom UI Node"
+
+# ---------------------------------------------------------------------------
+# Content the sessions type
+# ---------------------------------------------------------------------------
+
+QUICKSTART_LOADER = (
+    "import pandas as pd\n"
+    "\n"
+    "d = {'a': [\"A\", \"B\", \"C\", \"D\", \"E\", \"F\", \"G\", \"H\", \"I\"],\n"
+    "     'b': [28, 55, 43, 91, 81, 53, 19, 87, 52]}\n"
+    "df = pd.DataFrame(data=d)\n"
+    "\n"
+    "return df\n"
+)
+
+QUICKSTART_VEGA = json.dumps(
+    {
+        "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
+        "mark": "bar",
+        "encoding": {
+            "x": {"field": "a", "type": "nominal", "axis": {"labelAngle": 0}},
+            "y": {"field": "b", "type": "quantitative", "stack": None},
+        },
+    },
+    indent=2,
+)
+
+# A typo a real person makes: a missing closing bracket, so the traceback is a
+# SyntaxError the node has to surface rather than an exception it can catch.
+BROKEN_LOADER = (
+    "import pandas as pd\n"
+    "\n"
+    "d = {'a': [\"A\", \"B\", \"C\"], 'b': [1, 2, 3}\n"
+    "df = pd.DataFrame(data=d)\n"
+    "return df\n"
+)
+
+# A messy CSV, written to disk and imported through the interface. Every awkward
+# thing here is something a real spreadsheet export contains: a UTF-8 BOM, a
+# quoted comma inside a field, a column name with a space and one with a unit in
+# parentheses, an empty cell, and a thousands separator.
+MESSY_CSV = (
+    "﻿"
+    "Neighborhood Name,median income (USD),population,notes\n"
+    '"Rogers Park, North",41250,54991,baseline\n'
+    "Hyde Park,58300,25681,\n"
+    '"West Town",72150,87781,"revised, 2024"\n'
+    "Englewood,,24369,suppressed\n"
+)
+
+
+def _messy_csv_path() -> str:
+    """Write the messy CSV under the output dir and return its path.
+
+    Not ``tmp_path``: the file has to survive the test for a reader looking at a
+    finding to be able to open the same bytes the session imported.
+    """
+    path = os.path.join(out_dir(), "user-upload-neighborhoods.csv")
+    with open(path, "w", encoding="utf-8", newline="") as fh:
+        fh.write(MESSY_CSV)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Small helpers this file needs on top of utils
+# ---------------------------------------------------------------------------
+
+_GRAMMAR_EDITOR_JS = r"""(nodeId) => {
+    const editors = (window.monaco && window.monaco.editor.getEditors()) || [];
+    return editors.find((e) => {
+        const uri = e.getModel() && e.getModel().uri && e.getModel().uri.path;
+        return uri && uri.includes(`grammar-${nodeId}`);
+    }) || null;
+}"""
+
+
+def set_node_grammar(page, node_id: str, spec: str, *, timeout: float = 20000) -> None:
+    """Put *spec* into a node's Grammar editor.
+
+    ``utils.set_node_code`` targets a node's first Monaco instance, which is the
+    wrong one on any node that has both editors. The grammar model is registered
+    under a ``grammar-<nodeId>.json`` path (``GrammarEditor`` passes ``path``),
+    which is what distinguishes it - the same handle
+    ``test_autark_grammar_edit_e2e.py`` uses.
+    """
+    node_el = node_locator(page, node_id)
+    node_el.scroll_into_view_if_needed()
+    tab = node_el.locator('.nav-link[data-rr-ui-event-key="grammar"]').first
+    tab.wait_for(state="visible", timeout=timeout)
+    if "active" not in (tab.get_attribute("class") or ""):
+        tab.dispatch_event("click")
+    page.wait_for_function(
+        "(nodeId) => !!(" + _GRAMMAR_EDITOR_JS + ")(nodeId)",
+        arg=node_id,
+        timeout=timeout,
+    )
+    page.evaluate(
+        "(args) => { const ed = (" + _GRAMMAR_EDITOR_JS + ")(args.nodeId);"
+        " ed.setValue(args.spec); }",
+        {"nodeId": node_id, "spec": spec},
+    )
+    page.wait_for_function(
+        "(args) => { const ed = (" + _GRAMMAR_EDITOR_JS + ")(args.nodeId);"
+        " return !!ed && ed.getValue() === args.spec; }",
+        arg={"nodeId": node_id, "spec": spec},
+        timeout=timeout,
+    )
+
+
+def read_node_grammar(page, node_id: str) -> str:
+    return page.evaluate(
+        "(nodeId) => { const ed = (" + _GRAMMAR_EDITOR_JS + ")(nodeId);"
+        " return ed ? ed.getValue() : ''; }",
+        node_id,
+    )
+
+
+def node_status(page, node_id: str) -> str:
+    el = node_locator(page, node_id).locator("[data-curio-node-status]").first
+    if not el.count():
+        return "(no status element)"
+    return el.get_attribute("data-curio-node-status") or "idle"
+
+
+
+def load_example(session: UserSession, path: str, *, expected_nodes: int,
+                 timeout: float = 120000) -> None:
+    """File > Load dataflow, on camera, with a locator that is not ambiguous.
+
+    Deliberately not ``tour._load_example`` (nor ``utils.upload_workflow``):
+    both open the chooser with ``page.get_by_text("Load dataflow").click()``,
+    and the menu row is a ``<div class=dropDownRow>`` wrapping a
+    ``<button>`` that carries the same text (``UpMenu.tsx:394-397``). The text
+    engine matches both, so that click dies of a strict-mode violation. The
+    role-based locator resolves only the button.
+    """
+    page, tour = session.page, session.tour
+    clear_canvas_overlays(page)
+    tour.click(_menu(page, "File"), force=True)
+    load = page.get_by_role("button", name="Load dataflow", exact=True)
+    load.wait_for(state="visible", timeout=20000)
+    tour.focus(load, hold=500)
+    with page.expect_file_chooser() as chooser:
+        load.click()
+    chooser.value.set_files(path)
+    page.wait_for_function(
+        "(n) => document.querySelectorAll('.react-flow__node').length >= n",
+        arg=expected_nodes,
+        timeout=timeout,
+    )
+    tour.beat(900)
+    _fit_view(page)
+
+
+def play_all_guarded(session: UserSession, *, timeout_ms: int = 240000) -> bool:
+    """Run every node, unless there are none to run.
+
+    ``tour._play_all`` waits on ``nodes.every(...)`` over a list that is empty
+    when a load failed, and an empty list never satisfies it - so a session whose
+    previous step did not manage to load anything would sit here for the whole
+    budget before failing for the wrong reason. Returns False if there was
+    nothing to run.
+    """
+    page = session.page
+    if not canvas_nodes(page):
+        session.note("Play All skipped: the canvas has no nodes to run")
+        return False
+    _play_all(
+        Ctx(page=page, tour=session.tour, frontend=session.frontend,
+            backend=session.backend),
+        timeout_ms=timeout_ms,
+    )
+    return True
+
+
+def report_failed_nodes(session: UserSession, *, label: str) -> list[str]:
+    """File every node left in an error state, with what it said."""
+    page = session.page
+    failed = [
+        n for n in canvas_nodes(page) if node_status(page, n["id"]) == "error"
+    ]
+    if not failed:
+        return []
+    details = [
+        f"{n['id']} ({n['nodeType']}): "
+        + (node_failure_detail(page, n["id"]) or "(no reason given anywhere)")
+        for n in failed
+    ]
+    session.record(
+        "node-error",
+        f"{label} left {len(failed)} node(s) in error",
+        severity="bug",
+        detail_full="\n\n".join(details),
+    )
+    return [n["id"] for n in failed]
+
+
+def _close_agent_panel(session: UserSession) -> None:
+    """Close the agent chat panel without relying on Escape.
+
+    Escape is not wired to anything (see the ModalShell finding), so a session
+    that pressed it and moved on would leave the panel over the canvas and blame
+    the next step for the consequences.
+    """
+    page = session.page
+    panel = page.get_by_role("dialog", name=re.compile(r"^Chat with "))
+    if not panel.count():
+        return
+    for name in ("Close chat", "Close"):
+        button = panel.get_by_role("button", name=re.compile(name))
+        if button.count():
+            try:
+                button.first.click(timeout=4000)
+                panel.first.wait_for(state="hidden", timeout=8000)
+                return
+            except Exception:
+                continue
+    page.keyboard.press("Escape")
+
+
+def clear_canvas_overlays(page) -> None:
+    """Close any drawer or palette floating over the pane.
+
+    ``connect_nodes`` hit-tests each handle with ``elementFromPoint`` and fails
+    when anything is on top of it, and both catalog drawers and the left-rail
+    palettes float *over* the canvas. A step that opened one and then failed
+    before closing it would otherwise poison every later authoring step with an
+    occlusion error that looks like a React Flow bug - which is exactly what the
+    first run of this file recorded.
+    """
+    for closer in (
+        "Close Data Catalog drawer",
+        "Close Node Catalog drawer",
+        "Close Agent Catalog drawer",
+    ):
+        button = page.get_by_role("button", name=closer)
+        if button.count():
+            try:
+                button.first.click(timeout=4000)
+                page.wait_for_timeout(300)
+            except Exception:
+                pass
+    for kind in ("datasets", "packages", "agents"):
+        try:
+            close_tools_palette(page, kind)
+        except Exception:
+            pass
+    dismiss_toasts(page)
+
+
+# Canvas geometry. A node is 525x350 flow units, so at zoom z it paints
+# 525*z by 350*z screen pixels. Hand-picked drop offsets are how the first S5
+# run broke: three nodes at zoom 0.6 spaced 330px apart left a 15px gap between
+# a node's right edge and the next node's left edge, and React Flow hit-tests a
+# handle with elementFromPoint - so the neighbour's input handle sat on top of
+# the output handle and connect_nodes failed. Deriving the spacing from the zoom
+# makes that arithmetic impossible to get wrong.
+GRID_ZOOM = 0.5
+_NODE_W, _NODE_H = 525 * GRID_ZOOM, 350 * GRID_ZOOM
+_GRID_X0 = 190.0  # clears the ~150px left tool rail, which floats over the pane
+_GRID_Y0 = 110.0
+_GRID_GAP_X, _GRID_GAP_Y = 70.0, 50.0
+
+
+def grid_at(col: int, row: int) -> tuple[float, float]:
+    """Drop coordinates for one cell of a 3x3 grid at ``GRID_ZOOM``.
+
+    Fits a 1280x800 frame: columns end at x=1116, rows at y=735.
+    """
+    return (
+        _GRID_X0 + col * (_NODE_W + _GRID_GAP_X),
+        _GRID_Y0 + row * (_NODE_H + _GRID_GAP_Y),
+    )
+
+
+def grid_drop(session: UserSession, template_id: str, col: int, row: int) -> str:
+    """Drop a built-in tile into one grid cell, so handles never overlap."""
+    return drop_node(session, template_id, grid_at(col, row), zoom=GRID_ZOOM)
+
+
+def drop_node(session: UserSession, template_id: str, at: tuple[float, float],
+              *, zoom: float | None = None) -> str:
+    """Drop a built-in tile on the canvas, narrating it, and return its id."""
+    page, tour = session.page, session.tour
+    clear_canvas_overlays(page)
+    if zoom is not None:
+        set_canvas_zoom(page, zoom)
+    else:
+        _reset_zoom(page)
+    tile = palette_tile(page, template_id)
+    tour.focus(tile, hold=420)
+    node_id = drag_to_canvas(page, tile, at=at)
+    tour.beat(500)
+    return node_id
+
+
+def node_output_or_empty(page, node_id: str, *, timeout: float = 8000) -> str:
+    """The node's inline output box, or ``""`` if it has none.
+
+    ``utils.read_node_output_text`` waits for ``[data-curio-node-output]``, which
+    only ``CodeEditor`` renders - so on a Vega-Lite or Autark node (``hasCode:
+    false`` in the builtin manifest) it times out rather than returning nothing.
+    A session must not stall on a node type that legitimately has no output box.
+    """
+    box = node_locator(page, node_id).locator("[data-curio-node-output]").first
+    if not box.count():
+        return ""
+    try:
+        box.wait_for(state="visible", timeout=timeout)
+    except Exception:
+        return ""
+    return box.text_content() or ""
+
+
+def node_failure_detail(page, node_id: str) -> str:
+    """Whatever the app says about a failed node, from wherever it says it.
+
+    Three surfaces, because different node kinds use different ones:
+
+    * ``[data-curio-node-output]`` for anything with a code editor;
+    * the notifications region, which is where ``vegaBehavior``'s catch block
+      puts ``error.message`` (``showToast(error.message, 'error')``) - a Vega node
+      has no output box at all, so the toast is the *only* place its reason
+      appears;
+    * ``data.warnings``, rendered as a list next to the node header.
+
+    Returns ``""`` when none of them said anything, which is itself worth
+    reporting: a node in an error state with no message anywhere.
+    """
+    parts: list[str] = []
+    inline = read_node_error_text(node_locator(page, node_id)) or ""
+    if inline.strip():
+        parts.append(f"[output box] {' '.join(inline.split())}")
+    toasts = page.locator('[aria-label="Notifications"] .toast')
+    for i in range(toasts.count()):
+        text = " ".join((toasts.nth(i).text_content() or "").split())
+        if text:
+            parts.append(f"[toast] {text}")
+    warnings = node_locator(page, node_id).locator("li p")
+    for i in range(min(warnings.count(), 5)):
+        text = " ".join((warnings.nth(i).text_content() or "").split())
+        if text:
+            parts.append(f"[warning] {text}")
+    return "\n".join(parts)
+
+
+def run_and_report(session: UserSession, node_id: str, *, label: str,
+                   node_type: str = "", timeout_ms: int | None = None) -> str:
+    """Play a node, wait for it to settle, and file the outcome.
+
+    Returns the output text. Unlike ``utils.run_node_and_wait`` this does not
+    raise on a node error - the caller is usually interested in what the error
+    *said*, and a session that stopped at the first red badge would test nothing
+    past it.
+    """
+    page = session.page
+    play_node(page, node_id)
+    status = wait_for_node_settled(
+        page, node_id, node_type=node_type, timeout_ms=timeout_ms
+    )
+    output = node_output_or_empty(page, node_id)
+    if status == "error":
+        detail = node_failure_detail(page, node_id)
+        session.record(
+            "node-error",
+            f"{label} failed to run",
+            severity="bug",
+            detail_full=(
+                f"node {node_id} ({node_type or 'unknown'}):\n"
+                + (detail or "the app gave no reason on any surface "
+                             "(no output box, no toast, no warning)")
+            ),
+        )
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Session runner
+# ---------------------------------------------------------------------------
+
+#: Per-session summaries, drained into the report by the module fixture below.
+_SUMMARIES: list[dict] = []
+_VIDEOS: dict[str, dict] = {}
+
+
+@pytest.fixture(scope="module", autouse=True)
+def stress_report():
+    """Write the combined report once every session in this module has run.
+
+    Sourced from the files on disk rather than from ``_SUMMARIES``, so the report
+    covers sessions recorded by earlier invocations too. A session that crashes
+    the interpreter therefore costs its own video, not the whole report - which
+    is not hypothetical: the first full run died inside S3 and took S1's and S2's
+    findings with it.
+    """
+    yield
+    sessions, videos = collect_sessions()
+    if not sessions:
+        return
+    path = write_report(sessions, videos=videos)
+    _log(f"[usertest] report: {path} ({len(sessions)} session(s))")
+    for name, paths in videos.items():
+        for kind, video in paths.items():
+            _log(f"[usertest] video {name} ({kind}): {video}")
+
+
+def run_session(browser, frontend: str, backend: str, *, session_id: str,
+                title: str, body) -> None:
+    """Record one session and file its summary.
+
+    The context is created here rather than taken from a fixture because a
+    recording context needs ``record_video_dir``, and because the video is only
+    flushed once the page is closed - so the close, the save and the transcode
+    all have to happen inside one place that owns them.
+    """
+    if not _wanted(session_id):
+        pytest.skip(f"session {session_id} not selected by CURIO_STRESS_SESSIONS")
+
+    require_user_auth()
+    raw_dir = os.path.join(out_dir(), "raw")
+    os.makedirs(raw_dir, exist_ok=True)
+
+    context = browser.new_context(
+        viewport=VIDEO_SIZE,
+        record_video_dir=raw_dir,
+        record_video_size=VIDEO_SIZE,
+    )
+    page = context.new_page()
+    # The drawers slide with translate3d and the providers read
+    # prefers-reduced-motion through useSyncExternalStore, so a panel is only
+    # reachable once the transition is collapsed.
+    page.emulate_media(reduced_motion="reduce")
+    # Native confirms (the unsaved-changes guard) would otherwise block forever.
+    # Bound to a name rather than a lambda so S5 can take it off again: Playwright
+    # runs every registered dialog handler, and whichever acts first decides, so
+    # an accept-all left in place silently overrides a later dismiss. That is
+    # exactly how this file once "found" a data-loss bug in a guard whose code
+    # (UpMenu.handleNewWorkflow) is correct.
+    def _accept_dialog(dialog):
+        dialog.accept()
+
+    page.on("dialog", _accept_dialog)
+
+    session = UserSession(
+        page, name=title, frontend=frontend, backend=backend, pace=_pace()
+    )
+    session.state["_accept_dialog"] = _accept_dialog
+    session.tour.chapter("USER TEST", title, "An exploratory session, recorded.")
+
+    try:
+        body(session)
+    except BaseException as exc:  # noqa: BLE001 - the take and the report survive
+        session.record(
+            "exception",
+            f"the session itself aborted: {type(exc).__name__}: {exc}"[:300],
+            severity="bug",
+            detail_full=str(exc),
+            step="(session body)",
+        )
+    finally:
+        summary = session.summary()
+        _SUMMARIES.append(summary)
+        with open(
+            os.path.join(out_dir(), f"session-{session_id}.json"), "w",
+            encoding="utf-8",
+        ) as fh:
+            json.dump(summary, fh, indent=2)
+        try:
+            page.close()
+            context.close()
+        except Exception:
+            pass
+        written = finalize_video(page, stem=f"curio-usertest-{session_id}")
+        if written:
+            _VIDEOS[title] = written
+        _log(
+            f"[usertest] {title}: {len(summary['steps'])} steps, "
+            f"{len(summary['findings'])} findings, video={written or 'NONE'}"
+        )
+        assert written, f"no video was recorded for session {session_id}"
+
+
+def _sign_up(session: UserSession, *, name: str, username: str) -> None:
+    """Create this session's account through the real form."""
+    signup_e2e_user(
+        session.page, session.frontend, name=name, username=username,
+        password="curio-usertest-2026",
+    )
+
+
+# ===========================================================================
+# S1 - "First hour": the quick-start tutorial, then off-script
+# ===========================================================================
+
+
+class TestSessionFirstHour:
+    """Someone who has read QUICK-START.md and nothing else."""
+
+    def test_first_hour(self, browser, frontend_server, current_server):
+        run_session(
+            browser, frontend_server, current_server,
+            session_id="s1", title="S1 First hour", body=self._body,
+        )
+
+    def _body(self, s: UserSession) -> None:
+        page = s.page
+        require_project_page()
+
+        with s.step("Sign up for an account",
+                    "The real /auth/signup form, not a test shortcut.",
+                    chapter="Getting in"):
+            _sign_up(s, name="Dana Reyes", username="dana_reyes")
+            wait_for_projects_page(page, timeout=30000)
+
+        with s.step("Open a new dataflow", "From the projects page."):
+            open_new_workflow(page)
+            page.locator("#tools-menu").wait_for(state="visible", timeout=45000)
+            s.tour.beat(800)
+
+        with s.step("Look over the node rail to see what is on offer",
+                    "Twelve built-in tiles, grouped data / computation / views."):
+            wrong_tile: list[str] = []
+            nameless: list[str] = []
+            for template_id in PALETTE_ICON_CLASS:
+                info = palette_tile_identity(page, template_id)
+                if not info.get("found"):
+                    wrong_tile.append(f"{template_id}: no tile at that position")
+                    continue
+                if not info.get("iconOk"):
+                    wrong_tile.append(
+                        f"{template_id}: expected "
+                        f"{PALETTE_ICON_CLASS[template_id]}, tile carries "
+                        f"{info.get('icon')}"
+                    )
+                if not (info.get("ariaLabel") or info.get("title")
+                        or info.get("accessibleText")):
+                    nameless.append(
+                        f"{template_id} (id={info.get('id')!r}, "
+                        f"role={info.get('role')!r})"
+                    )
+            # A mismatch here means the positional lookup is wrong, which would
+            # misattribute every later finding - so it fails the step rather than
+            # being filed as an application defect.
+            assert not wrong_tile, (
+                "the palette tile lookup landed on the wrong tiles:\n  "
+                + "\n  ".join(wrong_tile)
+            )
+            if nameless:
+                s.record(
+                    "a11y",
+                    f"{len(nameless)} palette tiles have no accessible name",
+                    severity="warning",
+                    detail_full=(
+                        "ToolsMenu.tsx:44 renders each tile as "
+                        "<div id={tutorialID}> with no aria-label, no title "
+                        "attribute and no text content; the only label is a "
+                        "react-bootstrap tooltip that appears on hover. "
+                        "packages/curio.builtin@1/manifest.json gives no "
+                        "tutorialId to data-export, data-summary, js-computation "
+                        "or spatial-join, so those four have no id either - "
+                        "nothing in the DOM names them.\n\nTiles with no name:\n  "
+                        + "\n  ".join(nameless)
+                    ),
+                )
+            s.tour.focus(page.locator("#tools-menu"), hold=1400)
+
+        loader_id = None
+        with s.step("Drag a Data Loading node onto the canvas",
+                    "The first tile on the rail.", chapter="The tutorial"):
+            loader_id = drop_node(s, "data-loading", (150, 150))
+            assert loader_id, "no node appeared"
+
+        with s.step("Type the tutorial's pandas snippet",
+                    "Nine rows, two columns, returned as a DataFrame."):
+            set_node_code(page, loader_id, QUICKSTART_LOADER)
+
+        with s.step("Run it", "The Python runs in the sandbox, not the browser."):
+            output = run_and_report(
+                s, loader_id, label="the tutorial loader",
+                node_type="curio.builtin/data-loading",
+            )
+            if "Saved to file:" not in output:
+                s.record(
+                    "absent",
+                    "the loader ran but reported no artifact",
+                    severity="bug",
+                    detail_full=f"output box said: {output!r}",
+                )
+
+        vega_id = None
+        with s.step("Drag a Vega-Lite node in", "The chart half of the tutorial."):
+            vega_id = drop_node(s, "vis-vega", (760, 150))
+
+        # The first thing a real user does wrong: run the chart before there is
+        # anything connected to it. Exploratory, because "an unconnected view
+        # errors" and "an unconnected view sits idle" are both defensible.
+        with s.step("Run the chart before connecting anything",
+                    "What does an unwired view do?", expect="either",
+                    quiet_console=True):
+            play_node(page, vega_id)
+            status = wait_for_node_settled(
+                page, vega_id, node_type="curio.builtin/vis-vega",
+                timeout_ms=30000,
+            )
+            detail = node_failure_detail(page, vega_id)
+            if status == "error" and not detail:
+                s.record(
+                    "absent",
+                    "an unconnected Vega node goes to an error state with no "
+                    "message on any surface",
+                    severity="warning",
+                    detail_full=(
+                        "vis-vega declares hasCode:false, so NodeEditor renders "
+                        "no output box for it; vegaBehavior's catch block does "
+                        "showToast(error.message), so a toast is the only place a "
+                        "reason could appear - and none did. The user is left "
+                        "with a red node and nothing to read."
+                    ),
+                )
+            s.note(
+                f"an unconnected Vega node settled as {status!r}; "
+                f"it said: {detail[:300]!r}"
+            )
+            dismiss_toasts(page)
+
+        with s.step("Connect the loader to the chart",
+                    "Drag from the output handle to the input handle."):
+            edge_id = connect_nodes(page, loader_id, vega_id)
+            assert edge_id == f"reactflow__edge-{loader_id}out-{vega_id}in", edge_id
+            _fit_view(page)
+
+        with s.step("Wire the chart's output back into the loader",
+                    "A loader has no input port, so this should be refused.",
+                    expect="error"):
+            connect_nodes(page, vega_id, loader_id, timeout=6000)
+
+        with s.step("Paste the Vega-Lite spec into the Grammar tab",
+                    "A bar chart over the two columns the loader returned."):
+            set_node_grammar(page, vega_id, QUICKSTART_VEGA)
+
+        with s.step("Run the chart", "Playing a node runs its ancestors first."):
+            _center_on(page, vega_id, zoom=0.95)
+            run_and_report(
+                s, vega_id, label="the Vega-Lite chart",
+                node_type="curio.builtin/vis-vega",
+            )
+            canvas = node_locator(page, vega_id).locator(f"#vega{vega_id} canvas")
+            if not canvas.count():
+                s.record(
+                    "absent", "the Vega node drew no canvas", severity="bug",
+                    detail_full="no <canvas> inside the node's vega container",
+                )
+            else:
+                s.tour.beat(1600)
+
+        # Now off-script: break it on purpose and see whether the app explains
+        # itself. This is the single most common real-user experience.
+        # NOT expect="error": this step's own body asserts that the node went
+        # red and that the message named the SyntaxError, so the step completing
+        # is the pass. expect="error" is for a step whose *gesture* the app must
+        # refuse, where completing without incident is the defect.
+        with s.step("Introduce a typo in the loader",
+                    "A missing bracket - does the node say so clearly?",
+                    quiet_console=True, chapter="Going wrong"):
+            set_node_code(page, loader_id, BROKEN_LOADER)
+            play_node(page, loader_id)
+            status = wait_for_node_settled(
+                page, loader_id, node_type="curio.builtin/data-loading",
+                timeout_ms=60000,
+            )
+            detail = " ".join(
+                (read_node_error_text(node_locator(page, loader_id)) or "").split()
+            )
+            assert status == "error", (
+                f"a SyntaxError left the node in state {status!r}, not 'error'; "
+                f"the box said {detail[:200]!r}"
+            )
+            if "SyntaxError" not in detail and "invalid syntax" not in detail:
+                s.record(
+                    "node-error",
+                    "the syntax error was reported without naming itself",
+                    severity="warning",
+                    detail_full=f"the node's output box said: {detail[:800]}",
+                )
+
+        with s.step("Does the downstream chart know it is stale?",
+                    "The loader is broken; running the chart should not succeed.",
+                    expect="either", quiet_console=True):
+            play_node(page, vega_id)
+            status = wait_for_node_settled(
+                page, vega_id, node_type="curio.builtin/vis-vega",
+                timeout_ms=60000,
+            )
+            s.note(
+                "with a broken upstream, the chart settled as "
+                f"{status!r}. Note the loader had already produced a valid "
+                "artifact before the edit, so this is the cached-artifact "
+                "question rather than a plain miss: "
+                f"{node_failure_detail(page, vega_id)[:300]!r}"
+            )
+            dismiss_toasts(page)
+
+        with s.step("Fix the typo and re-run", "Back to a working graph."):
+            set_node_code(page, loader_id, QUICKSTART_LOADER)
+            run_and_report(
+                s, loader_id, label="the repaired loader",
+                node_type="curio.builtin/data-loading",
+            )
+            run_and_report(
+                s, vega_id, label="the chart after the repair",
+                node_type="curio.builtin/vis-vega",
+            )
+
+        with s.step("Save the dataflow", "File > Save dataflow.",
+                    chapter="Keeping it"):
+            s.tour.click(_menu(page, "File"), force=True)
+            save = page.get_by_role("button", name="Save dataflow", exact=True)
+            save.wait_for(state="visible", timeout=15000)
+            with page.expect_response(
+                lambda r: "/api/projects" in r.url
+                and r.request.method in ("POST", "PUT") and r.ok,
+                timeout=40000,
+            ):
+                s.tour.click(save)
+            save.wait_for(state="hidden", timeout=30000)
+
+        with s.step("Reload the page and check the work came back",
+                    "The graph, the code, and the spec should all survive."):
+            url = page.url
+            page.reload(wait_until="domcontentloaded")
+            page.locator("#tools-menu").wait_for(state="visible", timeout=60000)
+            page.wait_for_function(
+                "() => document.querySelectorAll('.react-flow__node').length >= 2",
+                timeout=60000,
+            )
+            _fit_view(page)
+            nodes = {n["id"] for n in canvas_nodes(page)}
+            assert {loader_id, vega_id} <= nodes, (
+                f"after a reload of {url} the canvas holds {sorted(nodes)}"
+            )
+            restored = read_node_code(page, loader_id)
+            assert "pd.DataFrame" in restored, (
+                f"the loader's code did not survive the reload: {restored!r}"
+            )
+            grammar = read_node_grammar(page, vega_id)
+            if '"mark"' not in grammar:
+                s.record(
+                    "absent",
+                    "the Vega spec did not survive the reload",
+                    severity="bug",
+                    detail_full=f"the grammar editor holds: {grammar[:500]!r}",
+                )
+            s.tour.beat(1400)
+
+
+# ===========================================================================
+# S2 - "Real data": the Data Catalog, a CSV of the user's own, a longer chain
+# ===========================================================================
+
+
+class TestSessionRealData:
+    """An analyst with a spreadsheet and a shapefile-shaped problem."""
+
+    def test_real_data(self, browser, frontend_server, current_server):
+        run_session(
+            browser, frontend_server, current_server,
+            session_id="s2", title="S2 Real data", body=self._body,
+        )
+
+    # -- drawer plumbing ----------------------------------------------------
+
+    def _open_data_drawer(self, s: UserSession):
+        page = s.page
+        palette = open_tools_palette(page, "datasets")
+        s.tour.click(
+            palette.get_by_role("button", name="Browse Data Catalog +"), force=True
+        )
+        root = page.locator(DRAWER_DATA)
+        root.wait_for(state="attached", timeout=15000)
+        expect(root).to_have_attribute("aria-hidden", "false", timeout=10000)
+        drawer = page.get_by_role("dialog").filter(
+            has=page.get_by_role("heading", name="Data Catalog", exact=True)
+        )
+        expect(drawer).to_be_visible(timeout=10000)
+        return drawer
+
+    def _add_to_dataflow(self, s: UserSession, drawer, dataset_id: str):
+        page = s.page
+        card = drawer.locator(f'{CARD}[data-dataset-id="{dataset_id}"]')
+        expect(card).to_have_count(1, timeout=20000)
+        card.scroll_into_view_if_needed()
+        with page.expect_response(
+            lambda r: "/datasets/install" in r.url
+            and r.request.method == "POST" and r.ok,
+            timeout=90000,
+        ):
+            s.tour.click(
+                card.get_by_role("button", name="Add to dataflow", exact=True)
+            )
+        expect(
+            drawer.locator(f'{CARD}[data-dataset-id="{dataset_id}"]').get_by_role(
+                "button", name="Remove from dataflow", exact=True
+            )
+        ).to_be_visible(timeout=30000)
+
+    def _body(self, s: UserSession) -> None:
+        page = s.page
+        require_project_page()
+
+        with s.step("Sign up and open a dataflow", chapter="Bringing data in"):
+            _sign_up(s, name="Priya Nandakumar", username="priya_nandakumar")
+            wait_for_projects_page(page, timeout=30000)
+            open_new_workflow(page)
+            page.locator("#tools-menu").wait_for(state="visible", timeout=45000)
+
+        # --- the user's own CSV, uploaded through the interface -------------
+        csv_path = _messy_csv_path()
+        imported_id = None
+        with s.step("Import my own CSV through the Data Catalog",
+                    "A real spreadsheet export: BOM, quoted commas, a blank cell."):
+            drawer = self._open_data_drawer(s)
+            import_button = drawer.get_by_role("button", name="Import dataset")
+            expect(import_button).to_be_visible(timeout=15000)
+            accept = drawer.locator('input[type="file"]').get_attribute("accept")
+            assert accept and ".csv" in accept, (
+                f"the import control does not accept .csv: {accept!r}"
+            )
+            with page.expect_response(
+                lambda r: r.url.endswith("/api/datasets/import")
+                and r.request.method == "POST",
+                timeout=90000,
+            ) as imported:
+                with page.expect_file_chooser() as chooser:
+                    s.tour.click(import_button)
+                chooser.value.set_files(csv_path)
+            response = imported.value
+            assert response.ok, (
+                f"the import was rejected: HTTP {response.status} "
+                f"{response.text()[:300]}"
+            )
+            imported_id = response.json().get("id")
+            assert imported_id, f"the import returned no id: {response.json()}"
+            s.tour.beat(1200)
+
+        with s.step("Confirm it became a catalog entry",
+                    "An import registers the dataset; it does not attach it."):
+            drawer = page.get_by_role("dialog").filter(
+                has=page.get_by_role("heading", name="Data Catalog", exact=True)
+            )
+            card = drawer.locator(f'{CARD}[data-dataset-id="{imported_id}"]')
+            expect(card).to_have_count(1, timeout=30000)
+            s.tour.focus(card, hold=1200)
+            add = card.get_by_role("button", name="Add to dataflow", exact=True)
+            if not add.count():
+                s.record(
+                    "absent",
+                    "the imported dataset was auto-attached to the dataflow",
+                    severity="warning",
+                    detail_full=(
+                        "the card offered no 'Add to dataflow', which means the "
+                        "import attached itself - import is documented as "
+                        "register-only"
+                    ),
+                )
+
+        with s.step("Inspect what Curio made of my messy columns",
+                    "Schema and preview, before trusting it downstream."):
+            view = card.locator('button[aria-label^="View "]')
+            if not view.count():
+                s.note("the dataset card offered no detail view button")
+            else:
+                s.tour.click(view.first)
+                tabs = page.get_by_role(
+                    "navigation", name="Dataset detail sections"
+                )
+                expect(tabs).to_be_visible(timeout=25000)
+                s.tour.beat(1600)
+                body_text = " ".join(
+                    (page.locator(
+                        'section[aria-label="Dataset content"]'
+                    ).text_content() or "").split()
+                )
+                for column in ("Neighborhood Name", "median income", "population"):
+                    if column.lower() not in body_text.lower():
+                        s.record(
+                            "absent",
+                            f"the detail panel does not mention the column "
+                            f"{column!r}",
+                            severity="warning",
+                            detail_full=(
+                                f"the imported CSV's header is "
+                                f"{MESSY_CSV.splitlines()[0]!r}\n"
+                                f"the panel showed: {body_text[:900]}"
+                            ),
+                        )
+                page.locator(
+                    'button[aria-label="Close"]:not([data-dismiss="toast"])'
+                ).first.click()
+                expect(tabs).to_have_count(0, timeout=15000)
+
+        with s.step("Add it to this dataflow, and a published dataset too",
+                    "My own CSV plus the Chicago boundary geojson."):
+            drawer = page.get_by_role("dialog").filter(
+                has=page.get_by_role("heading", name="Data Catalog", exact=True)
+            )
+            self._add_to_dataflow(s, drawer, imported_id)
+            geo_card = drawer.locator(f'{CARD}[data-dataset-id="{GEO_DATASET}"]')
+            if geo_card.count():
+                self._add_to_dataflow(s, drawer, GEO_DATASET)
+            else:
+                s.note(
+                    f"{GEO_DATASET} was not in the catalog; the geo half of this "
+                    "session runs without it"
+                )
+            _close_data_drawer(page)
+
+        loader_id = None
+        with s.step("Drag my CSV onto the canvas",
+                    "Curio writes the loader; does it read my file correctly?",
+                    chapter="Loading it"):
+            row = page.locator(f'#datasets-palette [data-dataset-id="{imported_id}"]')
+            expect(row).to_have_count(1, timeout=30000)
+            _reset_zoom(page)
+            loader_id = drag_to_canvas(page, row, at=(140, 130))
+            close_tools_palette(page, "datasets")
+            code = read_node_code(page, loader_id)
+            assert "read_csv" in code, (
+                f"the generated loader for a .csv does not read_csv:\n{code}"
+            )
+            s.tour.beat(900)
+
+        with s.step("Run the generated loader",
+                    "The BOM and the quoted comma are the interesting part.",
+                    quiet_console=True):
+            run_and_report(
+                s, loader_id, label="the loader for my imported CSV",
+                node_type="curio.builtin/data-loading",
+            )
+
+        summary_id = None
+        with s.step("Check what actually arrived",
+                    "A Data Summary node reads the frame's shape and columns."):
+            summary_id = drop_node(s, "data-summary", (700, 130))
+            connect_nodes(page, loader_id, summary_id)
+            output = run_and_report(
+                s, summary_id, label="the data summary",
+                node_type="curio.builtin/data-summary",
+            )
+            s.note(f"Data Summary reported: {' '.join(output.split())[:300]}")
+
+        transform_id = None
+        with s.step("Compute something from it",
+                    "Income per capita, and the column names my CSV really has.",
+                    chapter="Working with it"):
+            transform_id = grid_drop(s, "data-transformation", 0, 1)
+            connect_nodes(page, loader_id, transform_id)
+            set_node_code(
+                page, transform_id,
+                "df = arg.copy()\n"
+                "print('columns:', list(df.columns))\n"
+                "print('rows:', len(df))\n"
+                "num = [c for c in df.columns if 'income' in c.lower()]\n"
+                "print('income-ish columns:', num)\n"
+                "if num:\n"
+                "    col = num[0]\n"
+                "    df['income_filled'] = df[col].fillna(0)\n"
+                "print(df.to_string(index=False))\n"
+                "return df\n",
+            )
+            output = run_and_report(
+                s, transform_id, label="the transformation over my CSV",
+                node_type="curio.builtin/data-transformation",
+            )
+            flat = " ".join(output.split())
+            if "Rogers Park, North" not in flat and "Rogers Park" not in flat:
+                s.record(
+                    "node-error",
+                    "the quoted comma in the CSV did not survive the loader",
+                    severity="bug",
+                    detail_full=(
+                        'the first data row is \'"Rogers Park, North",41250,...\'; '
+                        f"the transformation printed:\n{output[:1200]}"
+                    ),
+                )
+            if re.search(r"﻿|Neighborhood Name'?\]?\s*$", flat):
+                s.note("the BOM may still be attached to the first column name")
+
+        with s.step("Save this node's output as a dataset",
+                    "The database toggle next to the play button."):
+            # The real control is a <label> wrapping #save-output-<nodeId>, and
+            # its aria-label carries the state - so reading it back is how the
+            # click doubles as an assertion (see test_computed_json_output_e2e).
+            toggle = node_locator(page, transform_id).locator(
+                f"label:has(input#save-output-{transform_id})"
+            )
+            toggle.wait_for(state="visible", timeout=20000)
+            before = toggle.get_attribute("aria-label") or ""
+            s.tour.focus(toggle, hold=700)
+            if "enabled" not in before:
+                toggle.click()
+                expect(toggle).to_have_attribute(
+                    "aria-label", "Save output to Data Catalog enabled",
+                    timeout=15000,
+                )
+            else:
+                s.note(
+                    "the save-output toggle was already on "
+                    "(--save-node-outputs is set deployment-wide)"
+                )
+            s.tour.beat(800)
+            run_and_report(
+                s, transform_id, label="the transformation, saving its output",
+                node_type="curio.builtin/data-transformation",
+            )
+
+        with s.step("Look for the computed dataset in the catalog",
+                    "A node output should be reusable as an input."):
+            drawer = self._open_data_drawer(s)
+            cards = drawer.locator(CARD)
+            expect(cards.first).to_be_visible(timeout=20000)
+            titles = " | ".join(
+                " ".join((cards.nth(i).text_content() or "").split())[:120]
+                for i in range(min(cards.count(), 12))
+            )
+            s.note(f"catalog now shows {cards.count()} card(s): {titles[:600]}")
+            _close_data_drawer(page)
+            close_tools_palette(page, "datasets")
+
+        with s.step("Export the result", "A Data Export node ends the chain."):
+            clear_canvas_overlays(page)
+            export_id = grid_drop(s, "data-export", 2, 1)
+            connect_nodes(page, transform_id, export_id)
+            set_node_code(
+                page, export_id,
+                "df = arg\n"
+                "print('exporting', len(df), 'rows')\n"
+                "df.to_csv('curio_usertest_export.csv', index=False)\n"
+                "print('wrote curio_usertest_export.csv')\n",
+            )
+            run_and_report(
+                s, export_id, label="the data export",
+                node_type="curio.builtin/data-export",
+            )
+
+        with s.step("Run the whole graph from scratch",
+                    "Play All, in topological order.", chapter="All of it"):
+            _fit_view(page)
+            if play_all_guarded(s, timeout_ms=300000):
+                report_failed_nodes(s, label="Play All over the whole graph")
+            s.tour.beat(1800)
+
+
+# ===========================================================================
+# S3 - "Maps and interaction": Autark/WebGPU, linked views, dashboard
+# ===========================================================================
+
+
+class TestSessionMapsAndInteraction:
+    """Someone who opens the shipped examples before building anything."""
+
+    def test_maps_and_interaction(self, browser, frontend_server, current_server):
+        run_session(
+            browser, frontend_server, current_server,
+            session_id="s3", title="S3 Maps and interaction", body=self._body,
+        )
+
+    def _body(self, s: UserSession) -> None:
+        page = s.page
+        require_project_page()
+        ctx = Ctx(page=page, tour=s.tour, frontend=s.frontend, backend=s.backend)
+
+        with s.step("Sign up and open a dataflow", chapter="Opening an example"):
+            _sign_up(s, name="Tom Achebe", username="tom_achebe")
+            wait_for_projects_page(page, timeout=30000)
+            open_new_workflow(page)
+            page.locator("#tools-menu").wait_for(state="visible", timeout=45000)
+
+        linked = os.path.join(
+            REPO_ROOT, "docs", "examples",
+            "03-vega-lite-linked-temporal-charts.json",
+        )
+        with s.step("Load the linked-charts example",
+                    "File > Load dataflow, from the shipped examples."):
+            load_example(s, linked, expected_nodes=4)
+
+        with s.step("Run the whole thing", "Play All over 400k rows.",
+                    quiet_console=True):
+            if play_all_guarded(s, timeout_ms=360000):
+                report_failed_nodes(s, label="the shipped linked-charts example")
+            _fit_view(page, padding=0.12)
+            s.tour.beat(1500)
+
+        vega_ids = _node_ids_by_type(page, "vis-vega")
+        with s.step("Check both charts actually drew",
+                    "A view that renders blank is worse than one that errors."):
+            if not vega_ids:
+                s.record(
+                    "absent", "the example has no Vega nodes on the canvas",
+                    severity="bug", detail_full=str(canvas_nodes(page)),
+                )
+            for node_id in vega_ids:
+                probe = page.evaluate(
+                    """(nodeId) => {
+                        const el = document.getElementById('vega' + nodeId);
+                        const c = el && el.querySelector('canvas');
+                        if (!c) return null;
+                        return { w: c.width, h: c.height };
+                    }""",
+                    node_id,
+                )
+                if not probe or not probe["w"] or not probe["h"]:
+                    s.record(
+                        "absent",
+                        f"Vega node {node_id} drew no sized canvas",
+                        severity="bug",
+                        detail_full=f"canvas probe returned {probe!r}",
+                    )
+
+        with s.step("Brush across a chart to drive the rest of the graph",
+                    "A selection propagates upstream and re-runs the filter.",
+                    expect="either", chapter="Linked views"):
+            if not vega_ids:
+                raise AssertionError("no chart to interact with")
+            _center_on(page, vega_ids[0], zoom=1.0)
+            plot = node_locator(page, vega_ids[0]).locator("canvas, svg").first
+            box = plot.bounding_box()
+            assert box, "the chart has no layout box"
+            y = box["y"] + box["height"] * 0.7
+            left = box["x"] + box["width"] * 0.2
+            right = box["x"] + box["width"] * 0.85
+            page.mouse.move(left, y)
+            page.mouse.down()
+            for i in range(1, 7):
+                page.mouse.move(left + (right - left) * i / 6, y)
+                s.tour.point_at(left + (right - left) * i / 6, y, hold=120)
+            page.mouse.up()
+            s.tour.beat(2500)
+            s.note(
+                "after brushing, node statuses were: "
+                + ", ".join(
+                    f"{n['id'][:8]}={node_status(page, n['id'])}"
+                    for n in canvas_nodes(page)
+                )
+            )
+
+        with s.step("Pin the views and switch to Dashboard Mode",
+                    "The presentation half of the canvas.", chapter="Dashboard"):
+            pinned = 0
+            for node_id in vega_ids[:2]:
+                pin = node_locator(page, node_id).locator(
+                    'svg[role="button"].fa-circle, svg[role="button"].fa-circle-dot'
+                ).first
+                if not pin.count():
+                    continue
+                s.tour.focus(pin, hold=400)
+                activate_header_icon(pin)
+                pinned += 1
+                s.tour.beat(600)
+            if not pinned:
+                s.record(
+                    "absent", "no dashboard pin control on any Vega node",
+                    severity="warning",
+                    detail_full=(
+                        "looked for svg[role=button].fa-circle / .fa-circle-dot "
+                        "in each node header"
+                    ),
+                )
+            s.tour.click(_menu(page, "View"), force=True)
+            s.tour.click(
+                page.get_by_role("button", name="Dashboard Mode", exact=True)
+            )
+            s.tour.beat(2600)
+            exit_btn = page.locator('button[title="Exit Dashboard Mode"]')
+            exit_btn.wait_for(state="visible", timeout=20000)
+            s.tour.click(exit_btn)
+            s.tour.beat(1200)
+            _fit_view(page)
+
+        with s.step("Open the provenance window",
+                    "How this dataflow got to be the way it is."):
+            s.tour.click(_menu(page, "Provenance"), force=True)
+            s.tour.click(page.get_by_role("button", name="Provenance", exact=True))
+            s.tour.beat(2200)
+            page.keyboard.press("Escape")
+            s.tour.beat(700)
+            for label in ("Close", "close"):
+                button = page.get_by_role("button", name=label, exact=True)
+                if button.count():
+                    try:
+                        button.first.click(timeout=2500)
+                        break
+                    except Exception:
+                        pass
+
+        # A map, on WebGPU, in a fresh dataflow.
+        with s.step("Start over and load the Autark map example",
+                    "An OSM extract parsed in the browser, rendered on WebGPU.",
+                    chapter="Maps"):
+            _new_dataflow_from_menu(ctx)
+            load_example(
+                s,
+                os.path.join(
+                    REPO_ROOT, "docs", "examples", "11-autark-pbf-loading.json"
+                ),
+                expected_nodes=2,
+            )
+
+        with s.step("Run the map", "DuckDB-WASM reads the .pbf, WebGPU draws it.",
+                    quiet_console=True):
+            if play_all_guarded(s, timeout_ms=420000):
+                report_failed_nodes(s, label="the Autark map example")
+            autark_ids = _node_ids_by_type(page, "autk-grammar")
+            if autark_ids:
+                _center_on(page, autark_ids[-1], zoom=1.2)
+                s.tour.beat(3000)
+
+        with s.step("Edit the map's grammar and re-run",
+                    "The spec is the interface; an edit must stick.",
+                    expect="either"):
+            autark_ids = _node_ids_by_type(page, "autk-grammar")
+            if not autark_ids:
+                raise AssertionError("no Autark node to edit")
+            node_id = autark_ids[-1]
+            before = read_node_grammar(page, node_id)
+            assert before.strip(), "the Autark grammar editor opened empty"
+            marker = '"curio_usertest_marker": 1,'
+            lines = before.split("\n")
+            target = max(1, len(lines) // 2)
+            page.evaluate(
+                "(args) => {"
+                "  const ed = (" + _GRAMMAR_EDITOR_JS + ")(args.nodeId);"
+                "  ed.focus();"
+                "  ed.setPosition({ lineNumber: args.line, column: 1 });"
+                "  ed.executeEdits('usertest', [{ range: {"
+                "    startLineNumber: args.line, startColumn: 1,"
+                "    endLineNumber: args.line, endColumn: 1 },"
+                "    text: args.text, forceMoveMarkers: true }]);"
+                "}",
+                {"nodeId": node_id, "line": target, "text": marker + "\n"},
+            )
+            page.wait_for_timeout(1800)
+            after = read_node_grammar(page, node_id)
+            assert marker.strip(",") in after, (
+                "the grammar edit was reverted by the controlled value "
+                "(this is issue #157's failure mode)"
+            )
+            s.note("the mid-document grammar edit stuck")
+            # Now put it back and confirm the node still runs.
+            set_node_grammar(page, node_id, before)
+            run_and_report(
+                s, node_id, label="the Autark node after a grammar round-trip",
+                node_type="curio.builtin/autk-grammar", timeout_ms=300000,
+            )
+
+        with s.step("Squeeze the window and pan around hard",
+                    "Does the chrome survive a small viewport?",
+                    chapter="Rough handling"):
+            page.set_viewport_size({"width": 900, "height": 620})
+            s.tour.beat(1200)
+            rail_fits = page.evaluate(
+                """() => {
+                    const rail = document.querySelector('#tools-menu');
+                    if (!rail) return { found: false };
+                    const r = rail.getBoundingClientRect();
+                    return {
+                        found: true,
+                        bottom: Math.round(r.bottom),
+                        viewport: window.innerHeight,
+                        overflows: r.bottom > window.innerHeight + 1,
+                    };
+                }"""
+            )
+            if rail_fits.get("overflows"):
+                s.record(
+                    "absent",
+                    "the left tool rail runs past the bottom of a 900x620 window",
+                    severity="warning",
+                    detail_full=json.dumps(rail_fits),
+                )
+            overflow = page.evaluate(
+                "() => document.documentElement.scrollWidth "
+                "- document.documentElement.clientWidth"
+            )
+            if overflow and overflow > 2:
+                s.record(
+                    "absent",
+                    f"the page scrolls horizontally by {overflow}px at 900x620",
+                    severity="warning",
+                    detail_full=f"scrollWidth - clientWidth = {overflow}",
+                )
+            for zoom in (0.2, 2.5, 1.0):
+                set_canvas_zoom(page, zoom)
+                s.tour.beat(700)
+            page.set_viewport_size(VIDEO_SIZE)
+            s.tour.beat(900)
+            _fit_view(page)
+
+
+# ===========================================================================
+# S4 - "Extending Curio": packages, libraries, agents, notebooks
+# ===========================================================================
+
+
+class TestSessionExtending:
+    """A user who wants Curio to do something it does not ship with."""
+
+    def test_extending(self, browser, frontend_server, current_server):
+        run_session(
+            browser, frontend_server, current_server,
+            session_id="s4", title="S4 Extending Curio", body=self._body,
+        )
+
+    def _body(self, s: UserSession) -> None:
+        page = s.page
+        require_project_page()
+        ctx = Ctx(page=page, tour=s.tour, frontend=s.frontend, backend=s.backend)
+
+        with s.step("Sign up", chapter="Setting up"):
+            _sign_up(s, name="Marcus Oyelaran", username="marcus_oyelaran")
+            wait_for_projects_page(page, timeout=30000)
+
+        with s.step("Configure the AI provider in AI Settings",
+                    "Curio ships no endpoint; nothing AI works until this is set."):
+            if not LLM_API_KEY:
+                s.record(
+                    "absent",
+                    "no LLM key was configured, so the agent surfaces cannot be "
+                    "exercised for real",
+                    severity="warning",
+                    detail_full=(
+                        "put a key in .curio/tour-provider.json or "
+                        "CURIO_TOUR_LLM_API_KEY"
+                    ),
+                )
+            scene_ai_settings(ctx)
+            s.note(f"provider configured: {LLM_BASE_URL} model={LLM_MODEL}")
+
+        with s.step("Open a dataflow and build something worth packaging",
+                    "A small transformation of my own."):
+            open_new_workflow(page)
+            page.locator("#tools-menu").wait_for(state="visible", timeout=45000)
+            loader_id = drop_node(s, "data-loading", (150, 150))
+            set_node_code(page, loader_id, QUICKSTART_LOADER)
+            transform_id = drop_node(s, "data-transformation", (760, 150))
+            connect_nodes(page, loader_id, transform_id)
+            set_node_code(
+                page, transform_id,
+                "df = arg.copy()\n"
+                "df['rank'] = df['b'].rank(ascending=False).astype(int)\n"
+                "print(df.sort_values('rank').to_string(index=False))\n"
+                "return df\n",
+            )
+            run_and_report(
+                s, loader_id, label="the loader",
+                node_type="curio.builtin/data-loading",
+            )
+            run_and_report(
+                s, transform_id, label="my ranking transformation",
+                node_type="curio.builtin/data-transformation",
+            )
+            _fit_view(page)
+            s.state.update(loader=loader_id, transform=transform_id)
+
+        # --- node packages -------------------------------------------------
+        with s.step("Install a package from the Node Catalog",
+                    "The example UI package: no python deps to resolve.",
+                    chapter="Packages"):
+            palette = open_tools_palette(page, "packages")
+            s.tour.click(
+                palette.get_by_role(
+                    "button", name=re.compile(r"^Browse Node Catalog")
+                ),
+                force=True,
+            )
+            drawer = page.get_by_role("dialog").filter(
+                has=page.get_by_role("heading", name="Node Catalog", exact=True)
+            )
+            expect(drawer).to_be_visible(timeout=20000)
+            search = drawer.get_by_placeholder("Search packages, publishers, tags…")
+            s.tour.type_into(search, "example", delay=70)
+            card = drawer.locator(f'article[data-pkg-dir="{PKG_DIR}"]')
+            expect(card).to_have_count(1, timeout=20000)
+            with page.expect_response(
+                lambda r: r.url.endswith("/api/packages/resolve"), timeout=60000
+            ):
+                card.get_by_role("button", name="Add to dataflow", exact=True).click()
+            confirm_dialog = page.get_by_role("dialog").filter(
+                has=page.get_by_role("heading", name=f'Add "{PKG_NAME}"', exact=True)
+            )
+            expect(confirm_dialog).to_be_visible(timeout=20000)
+            with page.expect_response(
+                lambda r: "/api/packages/projects/" in r.url
+                and r.url.endswith("/install")
+                and r.request.method == "POST" and r.ok,
+                timeout=120000,
+            ):
+                s.tour.click(
+                    confirm_dialog.get_by_role(
+                        "button", name="Add to dataflow", exact=True
+                    )
+                )
+            expect(confirm_dialog).to_have_count(0, timeout=60000)
+            drawer.locator("header").get_by_role(
+                "button", name="Close Node Catalog drawer"
+            ).click()
+            expect(page.locator(DRAWER_NODES)).to_have_count(0, timeout=10000)
+
+        with s.step("Drag the package's node onto the canvas and wire it up",
+                    "An installed package must be usable, not just listed."):
+            row = page.locator(
+                f'#packages-palette [data-pkg-palette-coords~="{PKG_DIR}"]'
+            )
+            expect(row).to_have_count(1, timeout=30000)
+            _reset_zoom(page)
+            pkg_node = drag_to_canvas(page, row, at=(200, 470))
+            close_tools_palette(page, "packages")
+            connect_nodes(page, s.state["transform"], pkg_node)
+            s.state["pkg_node"] = pkg_node
+            s.tour.beat(1200)
+
+        with s.step("Work out how a custom-UI node is supposed to run",
+                    "It has controls in its body rather than a code editor.",
+                    expect="either"):
+            # Deliberately not run_and_report: curio.example-ui declares
+            # editor:"none" / hasWidgets:false, and styles.tsx only renders the
+            # play control inside the `sendCodeToWidgets != undefined` block, so
+            # this node has no Play button at all. Asserting one exists was this
+            # session's own mistake on an earlier pass; what is worth recording
+            # is whether the node explains itself and whether it receives data.
+            node_el = node_locator(page, s.state["pkg_node"])
+            has_play = node_el.locator("svg.fa-circle-play").count() > 0
+            body = " ".join((node_el.text_content() or "").split())
+            s.note(
+                f"the package node renders a play control: {has_play}; "
+                f"its body reads: {body[:220]!r}"
+            )
+            if not has_play and "run that node" not in body.lower():
+                s.record(
+                    "absent",
+                    "a package node with no Play control gives the user no hint "
+                    "how to run it",
+                    severity="warning",
+                    detail_full=(
+                        "curio.example-ui/column-filter has no play button "
+                        "(styles.tsx gates it on sendCodeToWidgets) and its body "
+                        f"text does not say how to trigger it. Body: {body[:600]}"
+                    ),
+                )
+            s.tour.beat(1000)
+
+        with s.step("Open the library manager",
+                    "Which python libraries this account has."):
+            s.tour.click(_menu(page, "Data"), force=True)
+            s.tour.click(
+                page.get_by_role("button", name="Installed libraries", exact=True)
+            )
+            expect(
+                page.get_by_role("heading", name="Installed libraries")
+            ).to_be_visible(timeout=30000)
+            s.tour.beat(1800)
+            page.get_by_role("button", name="Close", exact=True).first.click()
+            expect(
+                page.get_by_role("heading", name="Installed libraries")
+            ).to_have_count(0, timeout=15000)
+
+        with s.step("Save my own node as a package",
+                    "The cog on a node header > Save as package node.",
+                    expect="either"):
+            gear = node_locator(page, s.state["transform"]).get_by_role(
+                "button", name=re.compile(r"^Node settings for ")
+            )
+            gear.wait_for(state="visible", timeout=30000)
+            s.tour.click(gear)
+            # U+2026, not three dots.
+            save_as = page.get_by_role("button", name="Save as package node…")
+            save_as.wait_for(state="visible", timeout=20000)
+            s.tour.click(save_as)
+            modal = page.get_by_role(
+                "heading", name="Save as package node", level=2
+            )
+            modal.wait_for(state="visible", timeout=20000)
+            s.tour.beat(1600)
+            s.note(
+                "the Save-as-package modal opened over the node built in this "
+                "session"
+            )
+
+        with s.step("Press Escape to back out of the modal",
+                    "The reflex every user has. Does it close?",
+                    expect="either"):
+            page.keyboard.press("Escape")
+            s.tour.beat(1200)
+            if modal.count() and modal.first.is_visible():
+                s.record(
+                    "a11y",
+                    "Escape does not dismiss a modal dialog, and its backdrop "
+                    "then blocks the whole application",
+                    severity="bug",
+                    detail_full=(
+                        "ModalShell.tsx renders every Curio modal with "
+                        'role="dialog" aria-modal="true" and a '
+                        "position:fixed; inset:0 backdrop, but registers no "
+                        "keydown/Escape handler - the only ways out are the "
+                        "close X, Cancel, or a backdrop click.\n\n"
+                        "Because the backdrop covers the viewport and is "
+                        "pointer-interactive, a user who presses Escape and then "
+                        "reaches for a menu gets nothing: the click lands on the "
+                        "backdrop. In this session that made the top menu bar "
+                        "look broken, and the Agent Catalog could not be opened "
+                        "at all until the modal was closed properly.\n\n"
+                        "WAI-ARIA APG for the dialog pattern requires Escape to "
+                        "close a dialog, and aria-modal=\"true\" is an explicit "
+                        "claim to that contract. This affects every modal in the "
+                        "app, since they all go through ModalShell: Save as "
+                        "package node, Node settings, AI Settings, the library "
+                        "manager and the provenance window."
+                    ),
+                )
+                # Leave the app usable for the rest of the session.
+                page.get_by_role("button", name="Close").first.click()
+                modal.first.wait_for(state="hidden", timeout=10000)
+            else:
+                s.note("Escape closed the modal")
+            s.tour.beat(700)
+            clear_canvas_overlays(page)
+
+        # --- agents --------------------------------------------------------
+        with s.step("Add three agents to the dataflow",
+                    "A node agent, a connection agent, and a canvas agent.",
+                    chapter="Agents"):
+            drawer = _open_agent_drawer(ctx)
+            for coord in (AGENT_EXPLAINER, AGENT_CONNECTION, AGENT_BUILDER):
+                _add_agent(ctx, drawer, coord, hold=700)
+            drawer.get_by_role("button", name="Close Agent Catalog drawer").click()
+            s.tour.beat(900)
+
+        with s.step("Attach the node agent to a node", expect="either"):
+            open_tools_palette(page, "agents")
+            _drag_agent_to(
+                ctx, AGENT_EXPLAINER,
+                lambda: _node_client_point(page, s.state["transform"]),
+            )
+            toast = page.locator('[aria-label="Notifications"] .toast').first
+            toast.wait_for(state="visible", timeout=45000)
+            said = " ".join((toast.text_content() or "").split())
+            if "attached to the node" not in said:
+                s.record(
+                    "absent",
+                    "dropping a node agent on a node did not attach it to the node",
+                    severity="bug",
+                    detail_full=f"the app said: {said!r}",
+                )
+            dismiss_toasts(page)
+
+        with s.step("Drop the node agent somewhere it does not belong",
+                    "The canvas. A refusal must say so, not silently rebind.",
+                    expect="either"):
+            point = _empty_canvas_point(page)
+            if not point:
+                raise AssertionError("no empty canvas point found")
+            _drag_agent_to(ctx, AGENT_EXPLAINER, point)
+            toast = page.locator('[aria-label="Notifications"] .toast').first
+            toast.wait_for(state="visible", timeout=45000)
+            said = " ".join((toast.text_content() or "").split())
+            if "attached to the canvas" in said:
+                s.record(
+                    "absent",
+                    "a node-only agent was accepted onto the canvas",
+                    severity="bug",
+                    detail_full=(
+                        "agent.node-explainer declares node targets only, so the "
+                        f"canvas drop should have been refused. The app said: {said!r}"
+                    ),
+                )
+            else:
+                s.note(f"the canvas drop was answered with: {said!r}")
+            dismiss_toasts(page)
+
+        with s.step("Attach the connection agent to the edge", expect="either"):
+            # The agents palette is a ~545px strip floating over the left of the
+            # pane, and _edge_client_point rejects any candidate it occludes - so
+            # an edge has to be framed clear of it before the drag. Fit first,
+            # then nudge the viewport right if the only edges are still hidden.
+            _fit_view(page, padding=0.25)
+            point = _edge_client_point(page)
+            if not point:
+                page.evaluate(
+                    """() => {
+                        const rf = window.__curio_reactFlow;
+                        if (!rf) return;
+                        const vp = rf.getViewport();
+                        rf.setViewport({ x: vp.x + 420, y: vp.y, zoom: vp.zoom });
+                    }"""
+                )
+                page.wait_for_timeout(700)
+                point = _edge_client_point(page)
+            if not point:
+                raise AssertionError(
+                    "no point on any edge resolved; pickEdgeAtPoint would miss"
+                )
+            _drag_agent_to(ctx, AGENT_CONNECTION, lambda: _edge_client_point(page))
+            toast = page.locator('[aria-label="Notifications"] .toast').first
+            toast.wait_for(state="visible", timeout=45000)
+            said = " ".join((toast.text_content() or "").split())
+            if "attached to the connection" not in said:
+                s.record(
+                    "absent",
+                    "dropping a connection agent on an edge did not attach it to "
+                    "the connection",
+                    severity="bug",
+                    detail_full=f"the app said: {said!r}",
+                )
+            dismiss_toasts(page)
+            close_tools_palette(page, "agents")
+
+        with s.step("Ask the node agent a real question",
+                    "A live model, over this dataflow.", expect="either",
+                    quiet_console=True):
+            badge = page.get_by_role(
+                "button", name=re.compile(r"^Open chat with Node Explainer")
+            ).first
+            badge.wait_for(state="visible", timeout=25000)
+            s.tour.click(badge)
+            panel = page.get_by_role("dialog", name=re.compile(r"^Chat with "))
+            expect(panel).to_be_visible(timeout=25000)
+            composer = panel.get_by_label("Message this agent")
+            s.tour.type_into(
+                composer, "What does this node compute, in one sentence?", delay=25
+            )
+            if not LLM_API_KEY:
+                s.note("no provider key; not sending the question")
+                _close_agent_panel(s)
+                return
+            # Measured off the network, not off the transcript's shape. A turn
+            # is one POST to
+            # /api/agents/projects/<p>/attachments/<a>/run (or its SSE sibling),
+            # so the request's status and duration are the fact; guessing from
+            # bubble counts produced a "the agent never answered" claim on an
+            # earlier pass that the DOM could not actually support.
+            before = " ".join((panel.text_content() or "").split())
+            started = time.monotonic()
+            status = None
+            try:
+                # method + /run/stream, not just "/run": the browser sends a
+                # CORS preflight first, and matching that reported a 30 ms
+                # "answer" from an OPTIONS that never touched the model. The turn
+                # is streamed (SSE), so this resolves on the response headers -
+                # the rendered reply is checked separately below.
+                with page.expect_response(
+                    lambda r: r.request.method == "POST" and "/run" in r.url,
+                    timeout=200000,
+                ) as run_response:
+                    composer.press("Enter")
+                status = run_response.value.status
+            except PlaywrightTimeoutError:
+                s.record(
+                    "absent",
+                    "pressing Enter in the agent composer issued no run request "
+                    "within 200s",
+                    severity="bug",
+                    detail_full=(
+                        "expected a POST to "
+                        "/api/agents/projects/<id>/attachments/<id>/run; none was "
+                        "observed, so the composer did not dispatch the turn"
+                    ),
+                )
+            elapsed = int((time.monotonic() - started) * 1000)
+
+            if status is not None and status >= 400:
+                s.record(
+                    "node-error",
+                    f"the agent run returned HTTP {status}",
+                    severity="bug",
+                    detail_full=(
+                        f"POST .../run -> {status} after {elapsed} ms against "
+                        f"{LLM_BASE_URL} model={LLM_MODEL}"
+                    ),
+                )
+            elif status is not None:
+                # The reply renders after the response resolves; wait for the
+                # transcript to actually grow rather than assuming it did.
+                grew = False
+                deadline = time.monotonic() + 60
+                while time.monotonic() < deadline:
+                    now = " ".join((panel.text_content() or "").split())
+                    if len(now) > len(before) + 40:
+                        grew = True
+                        break
+                    page.wait_for_timeout(1500)
+                after = " ".join((panel.text_content() or "").split())
+                if grew:
+                    s.note(
+                        f"the agent answered in {elapsed} ms (HTTP {status}); "
+                        f"transcript grew {len(after) - len(before)} chars"
+                    )
+                    s.tour.beat(2500)
+                else:
+                    s.record(
+                        "absent",
+                        f"the agent run returned HTTP {status} but nothing was "
+                        "rendered into the transcript",
+                        severity="bug",
+                        detail_full=(
+                            f"run completed in {elapsed} ms with HTTP {status}, "
+                            f"then 60s passed with the panel text unchanged at "
+                            f"{len(before)} chars.\nPanel: {after[:1200]}"
+                        ),
+                    )
+            _close_agent_panel(s)
+
+        with s.step("Export this dataflow as a Jupyter notebook",
+                    "Then check the file is a notebook.", expect="either",
+                    chapter="Taking it elsewhere"):
+            s.tour.click(_menu(page, "File"), force=True)
+            candidates = page.get_by_role(
+                "button", name=re.compile(r"notebook", re.I)
+            )
+            if not candidates.count():
+                raise AssertionError(
+                    "the File menu offers no notebook action; menu read: "
+                    + " ".join(
+                        (page.locator("[role='menu'], .dropdown-menu")
+                         .first.text_content() or "").split()
+                    )[:300]
+                )
+            with page.expect_download(timeout=60000) as download:
+                s.tour.click(candidates.first)
+            path = download.value.path()
+            saved = os.path.join(out_dir(), "exported-dataflow.ipynb")
+            download.value.save_as(saved)
+            with open(saved, encoding="utf-8") as fh:
+                notebook = json.load(fh)
+            assert "cells" in notebook, (
+                f"the export at {path} is not a notebook: keys={list(notebook)}"
+            )
+            s.note(
+                f"exported a notebook with {len(notebook['cells'])} cell(s) "
+                f"to {os.path.basename(saved)}"
+            )
+
+        with s.step("Browse the catalogs as pages",
+                    "/catalog/nodes, /catalog/data, /catalog/agents."):
+            for path, heading in (
+                ("/catalog/nodes", "Node"),
+                ("/catalog/data", "Data"),
+                ("/catalog/agents", "Agent Catalog"),
+            ):
+                page.goto(f"{s.frontend}{path}")
+                page.wait_for_load_state("domcontentloaded")
+                s.tour.beat(1600)
+                body = " ".join((page.locator("body").text_content() or "").split())
+                if heading.lower() not in body.lower():
+                    s.record(
+                        "absent",
+                        f"{path} did not render anything mentioning {heading!r}",
+                        severity="bug",
+                        detail_full=body[:600],
+                    )
+                s.tour.scroll(600, steps=5)
+
+
+# ===========================================================================
+# S5 - "Abuse": deliberate misuse, no persona politeness
+# ===========================================================================
+
+
+class TestSessionAbuse:
+    """Everything a careful user would not do."""
+
+    def test_abuse(self, browser, frontend_server, current_server):
+        run_session(
+            browser, frontend_server, current_server,
+            session_id="s5", title="S5 Abuse", body=self._body,
+        )
+
+    def _body(self, s: UserSession) -> None:
+        page = s.page
+        require_project_page()
+
+        with s.step("Sign up and open a dataflow", chapter="Breaking things"):
+            _sign_up(s, name="Rae Kowalczyk", username="rae_kowalczyk")
+            wait_for_projects_page(page, timeout=30000)
+            open_new_workflow(page)
+            page.locator("#tools-menu").wait_for(state="visible", timeout=45000)
+
+        with s.step("Build a three-node chain to abuse"):
+            set_canvas_zoom(page, 0.6)
+            loader = grid_drop(s, "data-loading", 0, 0)
+            middle = grid_drop(s, "data-transformation", 1, 0)
+            tail = grid_drop(s, "data-transformation", 2, 0)
+            connect_nodes(page, loader, middle)
+            connect_nodes(page, middle, tail)
+            set_node_code(page, loader, QUICKSTART_LOADER)
+            set_node_code(page, middle, "df = arg.copy()\ndf['c'] = df['b'] * 2\nreturn df\n")
+            set_node_code(page, tail, "df = arg\nprint('tail sees', list(df.columns))\nreturn df\n")
+            run_and_report(s, tail, label="the chain's tail",
+                           node_type="curio.builtin/data-transformation")
+            _fit_view(page)
+            s.state.update(loader=loader, middle=middle, tail=tail)
+
+        with s.step("Add a Data Summary and a second transformation",
+                    "Setting up an illegal edge, not attempting it yet."):
+            summary = grid_drop(s, "data-summary", 0, 1)
+            # NOT spatial-join as the target: it declares two input ports, so its
+            # handles are not called "in" and connect_nodes fails on the missing
+            # handle rather than on type validation - which reads as a refusal
+            # without ConnectionValidator ever being consulted.
+            # data-transformation takes DATAFRAME/GEODATAFRAME/RASTER on a single
+            # "in" handle and data-summary emits JSON, so this is a real mismatch
+            # exercised through the normal handles.
+            sink = grid_drop(s, "data-transformation", 2, 1)
+            connect_nodes(page, s.state["loader"], summary)
+            s.state["summary"], s.state["sink"] = summary, sink
+
+        # Only the illegal gesture lives in this step: a failure in the setup
+        # above would otherwise be recorded as "refused as it should be".
+        with s.step("Connect two incompatible ports",
+                    "Data Summary emits JSON; a transformation wants a frame.",
+                    expect="error"):
+            connect_nodes(
+                page, s.state["summary"], s.state["sink"], timeout=6000
+            )
+
+        with s.step("Wire a cycle: tail back into the middle node",
+                    "Type-compatible, so the validator allows it. Then what?",
+                    expect="either", quiet_console=True):
+            edge = connect_nodes(
+                page, s.state["tail"], s.state["middle"], timeout=8000
+            )
+            s.note(f"the app accepted a cycle-forming edge: {edge}")
+            play_node(page, s.state["tail"])
+            status = wait_for_node_settled(
+                page, s.state["tail"],
+                node_type="curio.builtin/data-transformation",
+                timeout_ms=90000,
+            )
+            s.note(f"running inside a cycle settled as {status!r}")
+
+        with s.step("Delete the middle node with the Delete key",
+                    "Then run what used to depend on it.", expect="either",
+                    quiet_console=True):
+            node_el = node_locator(page, s.state["middle"])
+            box = node_el.bounding_box()
+            assert box, "the node to delete has no layout box"
+            # The header strip, not the corner: x=12 lands on the minimize icon
+            # and selects nothing, which on an earlier pass produced a false
+            # "Delete does not work" finding. test_canvas_delete_key_e2e clicks
+            # x=300 at zoom 1; as a fraction it survives any zoom.
+            node_el.click(position={"x": box["width"] * 0.55, "y": 6})
+            page.wait_for_function(
+                "(id) => { const el = document.querySelector("
+                "  `.react-flow__node[data-id=\"${id}\"]`);"
+                "  return !!el && el.classList.contains('selected'); }",
+                arg=s.state["middle"],
+                timeout=8000,
+            )
+            s.tour.beat(500)
+            page.keyboard.press("Delete")
+            s.tour.beat(900)
+            remaining = {n["id"] for n in canvas_nodes(page)}
+            if s.state["middle"] in remaining:
+                # Not a defect: MainCanvas.handleNodesChange refuses a "remove"
+                # change for any node that still has an edge, and says so in a
+                # toast. Bisected against the shipped test (which never wires its
+                # nodes): unconnected nodes delete on Delete *and* Backspace, a
+                # connected one is refused on both. What is worth recording is
+                # whether the user is actually told why.
+                said = " ".join(
+                    (page.locator('[aria-label="Notifications"] .toast')
+                     .first.text_content() or "").split()
+                ) if page.locator(
+                    '[aria-label="Notifications"] .toast'
+                ).count() else ""
+                if "cannot be removed" in said.lower():
+                    s.note(
+                        "Delete on a wired node is refused by design, and the "
+                        f"app explains it: {said[:200]!r}"
+                    )
+                else:
+                    s.record(
+                        "absent",
+                        "Delete on a wired node did nothing and said nothing",
+                        severity="bug",
+                        detail_full=(
+                            "MainCanvas.handleNodesChange refuses the remove and "
+                            "is supposed to showToast('Connected boxes cannot be "
+                            "removed...'), but no such toast was on screen. "
+                            f"Toast region held: {said[:300]!r}"
+                        ),
+                    )
+                dismiss_toasts(page)
+            else:
+                play_node(page, s.state["tail"])
+                status = wait_for_node_settled(
+                    page, s.state["tail"],
+                    node_type="curio.builtin/data-transformation",
+                    timeout_ms=90000,
+                )
+                s.note(
+                    f"after its upstream was deleted, the tail settled as {status!r}"
+                )
+
+        with s.step("Import a library nobody installed",
+                    "Runtime install is off under --auth, so this must explain "
+                    "itself.", quiet_console=True):
+            probe = grid_drop(s, "computation-analysis", 0, 2)
+            set_node_code(
+                page, probe,
+                "import curio_definitely_not_a_real_package as nope\n"
+                "return nope.anything()\n",
+            )
+            play_node(page, probe)
+            status = wait_for_node_settled(
+                page, probe, node_type="curio.builtin/computation-analysis",
+                timeout_ms=120000,
+            )
+            detail = " ".join(
+                (read_node_error_text(node_locator(page, probe)) or "").split()
+            )
+            assert status == "error", (
+                f"a missing import left the node {status!r}, and said: {detail[:200]}"
+            )
+            if not re.search(r"(ModuleNotFound|No module named|install)", detail, re.I):
+                s.record(
+                    "node-error",
+                    "a missing module was reported without naming the module or "
+                    "how to install it",
+                    severity="warning",
+                    detail_full=detail[:900],
+                )
+
+        with s.step("Generate a large frame",
+                    "250k rows through one edge.", quiet_console=True):
+            big = grid_drop(s, "data-loading", 2, 2)
+            set_node_code(
+                page, big,
+                "import pandas as pd, numpy as np\n"
+                "n = 250_000\n"
+                "df = pd.DataFrame({\n"
+                "    'i': np.arange(n),\n"
+                "    'x': np.random.default_rng(7).normal(size=n),\n"
+                "    'g': np.random.default_rng(8).integers(0, 40, size=n),\n"
+                "})\n"
+                "print('built', len(df), 'rows')\n"
+                "return df\n",
+            )
+            started = time.monotonic()
+            run_and_report(
+                s, big, label="a 250k-row loader",
+                node_type="curio.builtin/data-loading", timeout_ms=240000,
+            )
+            elapsed = int((time.monotonic() - started) * 1000)
+            output = node_output_or_empty(page, big)
+            if "built 250000 rows" not in " ".join(output.split()):
+                s.record(
+                    "absent",
+                    "the 250k-row node settled without printing what it built",
+                    severity="warning",
+                    detail_full=(
+                        f"settled in {elapsed} ms; output box held: {output[:600]!r}. "
+                        "A settle this fast with no stdout suggests the status "
+                        "was read before the run began."
+                    ),
+                )
+            s.note(f"a 250k-row frame took {elapsed} ms end to end")
+            if elapsed > 120000:
+                s.record(
+                    "slow",
+                    f"a 250k-row DataFrame took {elapsed // 1000}s to run and store",
+                    severity="warning",
+                    detail_full=f"elapsed {elapsed} ms",
+                )
+
+        with s.step("Double-click Play on the same node",
+                    "Two runs of one node at once.", expect="either",
+                    quiet_console=True):
+            play = node_locator(page, s.state["loader"]).locator(
+                "svg.fa-circle-play"
+            ).first
+            if not play.count():
+                raise AssertionError("no play control on the loader")
+            play.dispatch_event("click")
+            play.dispatch_event("click")
+            status = wait_for_node_settled(
+                page, s.state["loader"], node_type="curio.builtin/data-loading",
+                timeout_ms=120000,
+            )
+            s.note(f"a double-clicked play settled as {status!r}")
+
+        with s.step("Navigate away in the middle of a run",
+                    "Then come back and see what state the node is in.",
+                    expect="either", quiet_console=True):
+            slow = grid_drop(s, "computation-analysis", 1, 2)
+            set_node_code(
+                page, slow,
+                "import time\n"
+                "time.sleep(12)\n"
+                "print('finished after a nap')\n"
+                "return 1\n",
+            )
+            dataflow_url = page.url
+            play_node(page, slow)
+            page.wait_for_timeout(1500)
+            page.goto(f"{s.frontend}/projects")
+            page.wait_for_load_state("domcontentloaded")
+            wait_for_projects_page(page, timeout=30000)
+            s.tour.beat(1500)
+            page.goto(dataflow_url)
+            page.wait_for_load_state("domcontentloaded")
+            page.locator("#tools-menu").wait_for(state="visible", timeout=60000)
+            page.wait_for_timeout(3000)
+            still_there = {n["id"] for n in canvas_nodes(page)}
+            s.note(
+                f"after leaving mid-run and returning, the canvas holds "
+                f"{len(still_there)} node(s); the slow node is "
+                f"{'present' if slow in still_there else 'GONE'}"
+            )
+            if slow in still_there:
+                s.note(f"its status on return was {node_status(page, slow)!r}")
+
+        with s.step("Open the same dataflow in a second tab",
+                    "Two tabs, one project, both editing.", expect="either"):
+            second = page.context.new_page()
+            try:
+                second.goto(page.url, wait_until="domcontentloaded")
+                second.locator("#tools-menu").wait_for(state="visible", timeout=60000)
+                second.wait_for_timeout(2500)
+                here = len(canvas_nodes(page))
+                there = len(canvas_nodes(second))
+                s.note(
+                    f"tab one shows {here} node(s), tab two shows {there}"
+                )
+                if there and there != here:
+                    s.record(
+                        "absent",
+                        "two tabs on one dataflow disagree about the node count",
+                        severity="warning",
+                        detail_full=f"tab1={here} tab2={there}",
+                    )
+            finally:
+                second.close()
+                s.tour.beat(600)
+
+        with s.step("Leave with unsaved changes and refuse the guard",
+                    "Dismissing the confirm must keep me on the canvas.",
+                    expect="either"):
+            set_node_code(
+                page, s.state["loader"],
+                QUICKSTART_LOADER + "# an unsaved edit\n",
+            )
+            s.tour.beat(700)
+            # Answer this one confirm with Cancel, then restore the accept-all
+            # handler the rest of the session relies on.
+            handled: list[str] = []
+
+            def _dismiss(dialog):
+                handled.append(dialog.message)
+                dialog.dismiss()
+
+            accept_all = s.state.get("_accept_dialog")
+            if accept_all is not None:
+                page.remove_listener("dialog", accept_all)
+            page.on("dialog", _dismiss)
+            try:
+                s.tour.click(_menu(page, "File"), force=True)
+                new_btn = page.get_by_role("button", name="New dataflow", exact=True)
+                if not new_btn.count():
+                    raise AssertionError("File menu has no 'New dataflow'")
+                new_btn.click()
+                page.wait_for_timeout(2500)
+                if handled:
+                    s.note(f"the guard asked: {handled[0][:200]!r}")
+                    if "/dataflow/new" in page.url:
+                        s.record(
+                            "absent",
+                            "cancelling the unsaved-changes guard still navigated "
+                            "away",
+                            severity="bug",
+                            detail_full=f"landed on {page.url}",
+                        )
+                else:
+                    s.note(
+                        "no unsaved-changes confirm appeared when leaving with an "
+                        f"unsaved edit; now at {page.url}"
+                    )
+            finally:
+                page.remove_listener("dialog", _dismiss)
+                if accept_all is not None:
+                    page.on("dialog", accept_all)
+                s.tour.beat(800)

--- a/utk_curio/backend/tests/test_frontend/test_user_stress_video.py
+++ b/utk_curio/backend/tests/test_frontend/test_user_stress_video.py
@@ -1629,41 +1629,24 @@ class TestSessionExtending:
             )
 
         with s.step("Press Escape to back out of the modal",
-                    "The reflex every user has. Does it close?",
-                    expect="either"):
+                    "The reflex every user has. It must close."):
+            # ModalShell used to claim role="dialog" aria-modal="true" with no
+            # keydown handler, so Escape did nothing - and since its backdrop
+            # covers the viewport and takes pointer events, the next click went
+            # to the backdrop and the app read as frozen. This session could not
+            # open the Agent Catalog at all until the modal was closed properly.
             page.keyboard.press("Escape")
             s.tour.beat(1200)
-            if modal.count() and modal.first.is_visible():
-                s.record(
-                    "a11y",
-                    "Escape does not dismiss a modal dialog, and its backdrop "
-                    "then blocks the whole application",
-                    severity="bug",
-                    detail_full=(
-                        "ModalShell.tsx renders every Curio modal with "
-                        'role="dialog" aria-modal="true" and a '
-                        "position:fixed; inset:0 backdrop, but registers no "
-                        "keydown/Escape handler - the only ways out are the "
-                        "close X, Cancel, or a backdrop click.\n\n"
-                        "Because the backdrop covers the viewport and is "
-                        "pointer-interactive, a user who presses Escape and then "
-                        "reaches for a menu gets nothing: the click lands on the "
-                        "backdrop. In this session that made the top menu bar "
-                        "look broken, and the Agent Catalog could not be opened "
-                        "at all until the modal was closed properly.\n\n"
-                        "WAI-ARIA APG for the dialog pattern requires Escape to "
-                        "close a dialog, and aria-modal=\"true\" is an explicit "
-                        "claim to that contract. This affects every modal in the "
-                        "app, since they all go through ModalShell: Save as "
-                        "package node, Node settings, AI Settings, the library "
-                        "manager and the provenance window."
-                    ),
-                )
-                # Leave the app usable for the rest of the session.
+            still_open = modal.count() and modal.first.is_visible()
+            if still_open:
+                # Leave the app usable so the rest of the session still runs.
                 page.get_by_role("button", name="Close").first.click()
                 modal.first.wait_for(state="hidden", timeout=10000)
-            else:
-                s.note("Escape closed the modal")
+            assert not still_open, (
+                "Escape did not dismiss the modal; its backdrop now blocks "
+                "every click behind it"
+            )
+            s.note("Escape closed the modal")
             s.tour.beat(700)
             clear_canvas_overlays(page)
 

--- a/utk_curio/backend/tests/test_frontend/usertest.py
+++ b/utk_curio/backend/tests/test_frontend/usertest.py
@@ -1,0 +1,670 @@
+"""Driver for exploratory, recorded user-test sessions.
+
+Not a test module (no ``test_`` prefix, so pytest does not collect it). It is the
+counterpart to :mod:`tour`: that module exists to make a *good* recording, this
+one exists to make a *truthful* one.
+
+The difference is ``UserSession.step``. A tour scene asserts nothing and its
+failures are swallowed so the take still ships. A step here is an experiment with
+a stated expectation, and everything that happens inside it is evidence:
+
+* the exception, if it raised - a locator that never appeared, a timeout, a
+  failed assertion;
+* every ``console.error`` and every uncaught ``pageerror`` that arrived while it
+  ran, attributed to that step rather than to the run as a whole;
+* the *absence* of a failure in a step that was supposed to fail - deliberately
+  wiring two incompatible ports and getting an edge anyway is a finding, and one
+  that a pass/fail suite structurally cannot express.
+
+A step never aborts the session. A real user who hits a bug keeps using the
+application, and the interesting findings are usually downstream of the first
+one, so the session carries on and the finding is filed with the wall-clock
+offset into the video that shows it.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import traceback
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field
+
+from .tour import REPO_ROOT, Tour, finalize_video, speed
+
+#: Where videos, stills and the findings report land. ``.curio/`` is gitignored.
+DEFAULT_OUT_DIR = os.path.join(REPO_ROOT, ".curio", "usertest")
+
+
+def out_dir() -> str:
+    path = os.environ.get("CURIO_STRESS_OUT") or DEFAULT_OUT_DIR
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _print(message: str) -> None:
+    """Print without letting the console's codec fail the run.
+
+    Findings quote the application's own text back - dataset titles carry
+    ``↑``, error messages carry smart quotes - and a cp1252 stdout raises
+    ``UnicodeEncodeError`` on those. That exception surfaced inside a ``step()``,
+    where it looked exactly like an application failure and, worse, skipped the
+    rest of the step body: a drawer that step meant to close stayed open and
+    occluded the next step's canvas. One bad ``print`` cost two false findings,
+    which is why this is not merely cosmetic.
+    """
+    encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
+    print(
+        message.encode(encoding, "replace").decode(encoding, "replace"),
+        flush=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Console classification
+# ---------------------------------------------------------------------------
+#
+# A webpack dev build is chatty, and a report that files every line of it is a
+# report nobody reads. These are the messages that are known noise rather than
+# evidence: they are emitted by the toolchain or by third-party libraries on a
+# healthy page, and none of them is under Curio's control.
+
+_CONSOLE_NOISE = re.compile(
+    "|".join(
+        [
+            r"\[webpack-dev-server\]",
+            r"\[HMR\]",
+            r"Download the React DevTools",
+            r"react-devtools",
+            r"DevTools failed to load source ?map",
+            r"Autofocus processing was blocked",
+            r"was preloaded using link preload but not used",
+            r"Could not find source file",
+            r"findDOMNode is deprecated",
+            r"Support for defaultProps will be removed",
+        ]
+    ),
+    re.I,
+)
+
+#: Console text worth surfacing even at ``warning`` level, because in this
+#: application each one names a real broken contract rather than a style
+#: preference.
+_CONSOLE_INTERESTING_WARNING = re.compile(
+    "|".join(
+        [
+            r"Each child in a list should have a unique",
+            r"Cannot update a component",
+            r"unmounted component",
+            r"validateDOMNesting",
+            r"Maximum update depth",
+            r"non-passive event listener",
+            r"WebGL|WebGPU",
+            r"Failed to fetch|NetworkError|ERR_",
+            r"Uncaught",
+        ]
+    ),
+    re.I,
+)
+
+
+#: Uncaught page exceptions that this harness causes and Curio does not.
+#:
+#: ``Tour.__init__`` installs the narration overlay through
+#: ``page.add_init_script``, which runs at document-start - before ``document.body``
+#: *or* ``document.documentElement`` exists. ``_INSTALL_OVERLAY_JS`` ends with
+#: ``(document.body || document.documentElement).appendChild(root)``, so on every
+#: navigation that init script throws exactly this once, from the recorder rather
+#: than from the application. Filed as a harness note in ``UserSession.__init__``
+#: so it is visible rather than silently dropped, then excluded from the findings.
+_PAGEERROR_NOISE = re.compile(
+    r"Cannot read propert(y|ies) of null \(reading 'appendChild'\)"
+    r"|null is not an object \(evaluating '.*appendChild'\)",
+    re.I,
+)
+
+
+@dataclass
+class Finding:
+    """One thing that went wrong, or one thing that suspiciously did not."""
+
+    session: str
+    step: str
+    severity: str  # bug | error | warning | note
+    kind: str  # exception | console | pageerror | node-error | absent | slow | a11y
+    detail: str
+    video_offset_ms: int
+    duration_ms: int = 0
+    still: str = ""
+    console_tail: list[str] = field(default_factory=list)
+
+
+@dataclass
+class StepRecord:
+    session: str
+    step: str
+    expectation: str
+    outcome: str  # ok | failed | failed-as-expected | unexpectedly-ok
+    video_offset_ms: int
+    duration_ms: int
+
+
+class UserSession:
+    """One recorded session: a persona, a page, and a list of findings."""
+
+    def __init__(self, page, *, name: str, frontend: str, backend: str,
+                 pace: float | None = None) -> None:
+        self.page = page
+        self.name = name
+        self.frontend = frontend
+        self.backend = backend
+        self.tour = Tour(page, pace=pace if pace is not None else speed())
+        self.findings: list[Finding] = []
+        self.steps: list[StepRecord] = []
+        #: Scratch space for a session body to thread ids between its steps.
+        #: Pre-created so a step that failed before assigning does not turn every
+        #: later step into an AttributeError finding that hides the real cause.
+        self.state: dict = {}
+        self._t0 = time.monotonic()
+        self._console: list[dict] = []
+        self._still_seq = 0
+        self._harness_pageerrors = 0
+        self._http_failures: list[dict] = []
+        self._current_step = "(setup)"
+        page.on("console", self._on_console)
+        page.on("pageerror", self._on_pageerror)
+        page.on("response", self._on_response)
+
+    # -- clock ------------------------------------------------------------
+
+    def offset_ms(self) -> int:
+        """Milliseconds since the session started, i.e. into the video."""
+        return int((time.monotonic() - self._t0) * 1000)
+
+    def stamp(self) -> str:
+        ms = self.offset_ms()
+        return f"{ms // 60000:02d}:{(ms // 1000) % 60:02d}"
+
+    # -- browser sinks ----------------------------------------------------
+
+    def _on_console(self, msg) -> None:
+        try:
+            text = msg.text
+            kind = msg.type
+        except Exception:
+            return
+        self._console.append(
+            {"type": kind, "text": text, "at": self.offset_ms(),
+             "step": self._current_step}
+        )
+
+    def _on_response(self, response) -> None:
+        """Keep every 4xx/5xx, so a console error can be traced to a request.
+
+        Chromium logs "Failed to load resource: the server responded with a
+        status of 401" with no URL attached, which is unactionable on its own -
+        an expected probe for a session cookie and a genuinely broken call read
+        identically.
+        """
+        try:
+            status = response.status
+            if status < 400:
+                return
+            self._http_failures.append(
+                {"status": status, "url": response.url,
+                 "method": response.request.method, "at": self.offset_ms(),
+                 "step": self._current_step}
+            )
+        except Exception:
+            return
+
+    def _on_pageerror(self, error) -> None:
+        detail = str(error)
+        self._console.append(
+            {"type": "pageerror", "text": detail, "at": self.offset_ms(),
+             "step": self._current_step}
+        )
+        if _PAGEERROR_NOISE.search(detail):
+            # The recorder's own overlay, not the application. Counted so the
+            # report can say how often, but not filed as a Curio defect.
+            self._harness_pageerrors += 1
+            return
+        first = detail.splitlines()[0] if detail else "unknown"
+        self.record(
+            "pageerror",
+            f"uncaught exception in the page: {first}",
+            severity="bug",
+            detail_full=detail,
+        )
+
+    # -- findings ---------------------------------------------------------
+
+    def still(self, tag: str) -> str:
+        """Screenshot the current viewport and return its path."""
+        self._still_seq += 1
+        safe = re.sub(r"[^a-z0-9]+", "-", f"{self.name}-{tag}".lower()).strip("-")
+        path = os.path.join(out_dir(), f"still-{self._still_seq:02d}-{safe}.png")
+        try:
+            self.page.screenshot(path=path)
+        except Exception:
+            return ""
+        return path
+
+    def record(self, kind: str, summary: str, *, severity: str = "bug",
+               detail_full: str | None = None, step: str | None = None,
+               still: bool = True, duration_ms: int = 0) -> Finding:
+        finding = Finding(
+            session=self.name,
+            step=step or self._current_step,
+            severity=severity,
+            kind=kind,
+            detail=detail_full or summary,
+            video_offset_ms=self.offset_ms(),
+            duration_ms=duration_ms,
+            still=self.still(f"{kind}-{summary[:30]}") if still else "",
+            console_tail=[
+                f"[{c['type']}] {c['text'][:400]}" for c in self._console[-8:]
+            ],
+        )
+        self.findings.append(finding)
+        _print(
+            f"  ! [{severity}/{kind}] {self.stamp()} {self._current_step}: {summary}"
+        )
+        return finding
+
+    def note(self, summary: str, **kw) -> Finding:
+        """A usability observation: not broken, worth writing down."""
+        kw.setdefault("severity", "note")
+        kw.setdefault("still", False)
+        return self.record("observation", summary, **kw)
+
+    # -- the step ---------------------------------------------------------
+
+    @contextmanager
+    def step(self, title: str, sub: str = "", *, expect: str = "ok",
+             chapter: str | None = None, quiet_console: bool = False):
+        """Run one experiment, narrate it, and file whatever it produced.
+
+        *expect* is the contract:
+
+        ``ok``      the step should complete; an exception is a bug.
+        ``error``   the step should be *refused* by the application; it
+                    completing without incident is the bug. Use this for the
+                    deliberate misuse - an illegal edge, a cycle, a syntax error
+                    the user is supposed to be told about.
+        ``either``  genuinely exploratory; record what happened, judge nothing.
+
+        *quiet_console* suppresses console-derived findings for steps that are
+        expected to log errors (a node that fails on purpose prints a traceback
+        the app itself surfaces, and filing that twice is noise).
+        """
+        self._current_step = title
+        console_mark = len(self._console)
+        started = time.monotonic()
+        offset = self.offset_ms()
+        if chapter:
+            self.tour.chapter(self.name, chapter, title)
+        self.tour.say(title, sub)
+        raised: BaseException | None = None
+        try:
+            yield self
+        except BaseException as exc:  # noqa: BLE001 - a step never aborts a session
+            raised = exc
+        duration = int((time.monotonic() - started) * 1000)
+
+        if raised is not None and expect == "ok":
+            text = str(raised)
+            first = text.splitlines()[0] if text else type(raised).__name__
+            self.record(
+                "exception",
+                f"{type(raised).__name__}: {first[:200]}",
+                severity="bug",
+                detail_full="".join(
+                    traceback.format_exception(
+                        type(raised), raised, raised.__traceback__
+                    )
+                ),
+                duration_ms=duration,
+            )
+            outcome = "failed"
+        elif raised is not None and expect == "error":
+            text = str(raised).splitlines()[0] if str(raised) else type(raised).__name__
+            self.note(f"refused as it should be: {text[:160]}", duration_ms=duration)
+            outcome = "failed-as-expected"
+        elif raised is not None:
+            text = str(raised).splitlines()[0] if str(raised) else ""
+            self.note(
+                f"raised (exploratory): {type(raised).__name__}: {text[:160]}",
+                duration_ms=duration,
+            )
+            outcome = "failed"
+        elif expect == "error":
+            self.record(
+                "absent",
+                "the application accepted something it should have refused",
+                severity="bug",
+                duration_ms=duration,
+            )
+            outcome = "unexpectedly-ok"
+        else:
+            outcome = "ok"
+
+        if not quiet_console:
+            self._file_console_since(console_mark, duration_ms=duration)
+
+        self.steps.append(
+            StepRecord(
+                session=self.name, step=title, expectation=expect,
+                outcome=outcome, video_offset_ms=offset, duration_ms=duration,
+            )
+        )
+        self.tour.hush()
+        self._current_step = "(between steps)"
+
+    def _file_console_since(self, mark: int, *, duration_ms: int = 0) -> None:
+        """Turn this step's console output into findings, deduplicated."""
+        seen: dict[str, int] = {}
+        for entry in self._console[mark:]:
+            kind, text = entry["type"], entry["text"]
+            if kind == "pageerror":
+                continue  # already filed by the listener
+            if _CONSOLE_NOISE.search(text):
+                continue
+            if kind == "error":
+                severity = "error"
+            elif kind == "warning" and _CONSOLE_INTERESTING_WARNING.search(text):
+                severity = "warning"
+            else:
+                continue
+            key = text[:180]
+            seen[key] = seen.get(key, 0) + 1
+            if seen[key] > 1:
+                continue
+            detail = text
+            if "failed to load resource" in text.lower():
+                recent = [
+                    f"{f['status']} {f['method']} {f['url']}"
+                    for f in self._http_failures[-6:]
+                ]
+                joined = "\n  ".join(recent) if recent else "(none captured)"
+                detail = (
+                    f"{text}\n\nHTTP failures seen around this step:\n  {joined}"
+                )
+            self.record(
+                "console",
+                f"console.{kind}: {key}",
+                severity=severity,
+                detail_full=detail,
+                still=False,
+                duration_ms=duration_ms,
+            )
+
+    # -- reporting --------------------------------------------------------
+
+    def summary(self) -> dict:
+        counts: dict[str, int] = {}
+        for f in self.findings:
+            counts[f.severity] = counts.get(f.severity, 0) + 1
+        return {
+            "session": self.name,
+            "duration_ms": self.offset_ms(),
+            "steps": [asdict(s) for s in self.steps],
+            "findings": [asdict(f) for f in self.findings],
+            "counts": counts,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Palette tiles
+# ---------------------------------------------------------------------------
+#
+# ToolsMenu.tsx renders each built-in tile as ``<div id={tutorialID}>`` - and
+# packages/curio.builtin@1/manifest.json gives no ``tutorialId`` to data-export,
+# data-summary, js-computation or spatial-join. Those four tiles are therefore an
+# icon div with a hover tooltip and no id, no aria-label and no accessible name,
+# which is both why they have to be reached positionally here and a finding in
+# its own right.
+#
+# The rail is three group containers (PALETTE_GROUPS in ToolsMenu.tsx) whose
+# children are ordered by ``paletteOrder`` (getPaletteNodeTypes sorts on it), so
+# an anchor id plus an index is stable.
+
+#: template id -> (anchor tile id, index within that anchor's group container)
+PALETTE_TILES: dict[str, tuple[str, int]] = {
+    # group: data + flow
+    "data-loading": ("#step-loading", 0),
+    "data-export": ("#step-loading", 1),
+    "data-transformation": ("#step-loading", 2),
+    "spatial-join": ("#step-loading", 3),
+    "merge-flow": ("#step-loading", 4),
+    "data-pool": ("#step-loading", 5),
+    # group: computation
+    "computation-analysis": ("#step-analysis", 0),
+    "data-summary": ("#step-analysis", 1),
+    "js-computation": ("#step-analysis", 2),
+    # group: vis
+    "autk-grammar": ("#step-utk", 0),
+    "vis-vega": ("#step-utk", 1),
+    "vis-simple": ("#step-utk", 2),
+}
+
+#: The tooltip each tile should show, from the manifest's ``label``. Used to
+#: prove a positional lookup landed on the tile the caller meant.
+PALETTE_LABELS: dict[str, str] = {
+    "data-loading": "Data Loading",
+    "data-export": "Data Export",
+    "data-transformation": "Data Transformation",
+    "spatial-join": "Spatial Join",
+    "merge-flow": "Merge Flow",
+    "data-pool": "Data Pool",
+    "computation-analysis": "Python Computation",
+    "data-summary": "Data Summary",
+    "js-computation": "JS Computation",
+    "autk-grammar": "Autark",
+    "vis-vega": "Vega-Lite",
+    "vis-simple": "Simple View",
+}
+
+
+def palette_tile(page, template_id: str):
+    """A locator for one built-in palette tile, by manifest template id.
+
+    Uses the tile's own id where the manifest gave it a ``tutorialId``, and falls
+    back to its position inside the group container otherwise.
+    """
+    try:
+        anchor, index = PALETTE_TILES[template_id]
+    except KeyError:
+        raise ValueError(
+            f"unknown built-in template {template_id!r}; "
+            f"known: {sorted(PALETTE_TILES)}"
+        ) from None
+    group = page.locator(anchor).locator("xpath=..")
+    return group.locator("> div").nth(index)
+
+
+#: The FontAwesome class each tile's svg must carry, derived from the manifest's
+#: ``iconRef`` (``fa-solid:upload`` -> ``fa-upload``). This is how a positional
+#: lookup is proved to have landed on the tile the caller meant.
+#:
+#: Deliberately not the hover tooltip: the React Flow pane overlaps the rail, so
+#: ``Locator.hover`` fails its actionability check and times out - which is how
+#: the first run of this file "found" a bug that was only the harness.
+PALETTE_ICON_CLASS: dict[str, str] = {
+    "data-loading": "fa-upload",
+    "data-export": "fa-download",
+    "data-transformation": "fa-database",
+    "data-pool": "fa-server",
+    "computation-analysis": "fa-python",
+    "data-summary": "fa-rectangle-list",
+    "js-computation": "fa-js",
+    "vis-vega": "fa-chart-line",
+    "vis-simple": "fa-table",
+    "autk-grammar": "fa-city",
+    "spatial-join": "fa-object-group",
+    "merge-flow": "fa-code-merge",
+}
+
+
+def palette_tile_identity(page, template_id: str) -> dict:
+    """What the rail exposes about one tile, without touching it.
+
+    Returns ``{found, iconOk, icon, id, ariaLabel, title, accessibleText}``.
+    ``iconOk`` is the check that the positional lookup landed correctly; the
+    remaining fields are the evidence for whether the tile is identifiable to
+    anything other than a sighted user with a mouse.
+    """
+    tile = palette_tile(page, template_id)
+    if not tile.count():
+        return {"found": False}
+    return tile.evaluate(
+        """(el, expected) => {
+            const svg = el.querySelector('svg');
+            const cls = svg ? (svg.getAttribute('class') || '') : '';
+            const icon = (cls.match(/\\bfa-[a-z0-9-]+\\b/g) || [])
+                .filter((c) => c !== 'fa-fw' && c !== 'fa-solid' && c !== 'fa-brands');
+            return {
+                found: true,
+                icon: icon,
+                iconOk: cls.split(/\\s+/).includes(expected),
+                id: el.getAttribute('id'),
+                ariaLabel: el.getAttribute('aria-label'),
+                title: el.getAttribute('title'),
+                role: el.getAttribute('role'),
+                accessibleText: (el.textContent || '').trim(),
+            };
+        }""",
+        PALETTE_ICON_CLASS[template_id],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Report writing
+# ---------------------------------------------------------------------------
+
+
+_SEVERITY_ORDER = {"bug": 0, "error": 1, "warning": 2, "note": 3}
+
+
+def collect_sessions() -> tuple[list[dict], dict[str, dict]]:
+    """Every session summary written to the output dir, and its video.
+
+    Read off disk rather than out of the running process: a session that takes
+    the interpreter down with it (a browser crash, an OOM) must not cost the
+    report for the sessions that already finished, and re-running one session on
+    its own must not erase the others. ``session-<id>.json`` and
+    ``curio-usertest-<id>.webm`` share the id, which is what pairs them.
+    """
+    directory = out_dir()
+    sessions: list[dict] = []
+    videos: dict[str, dict] = {}
+    for name in sorted(os.listdir(directory)):
+        if not (name.startswith("session-") and name.endswith(".json")):
+            continue
+        session_id = name[len("session-"):-len(".json")]
+        try:
+            with open(os.path.join(directory, name), encoding="utf-8") as fh:
+                summary = json.load(fh)
+        except (OSError, ValueError):
+            continue
+        sessions.append(summary)
+        for ext in ("webm", "mp4"):
+            video = os.path.join(directory, f"curio-usertest-{session_id}.{ext}")
+            if os.path.exists(video):
+                videos.setdefault(summary.get("session", session_id), {})[ext] = video
+    return sessions, videos
+
+
+def write_report(sessions: list[dict], *, videos: dict[str, dict]) -> str:
+    """Write findings.json and FINDINGS.md; return the markdown path."""
+    payload = {
+        "generatedAt": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "videos": videos,
+        "sessions": sessions,
+    }
+    json_path = os.path.join(out_dir(), "findings.json")
+    with open(json_path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2)
+
+    findings = [f for s in sessions for f in s["findings"]]
+    findings.sort(
+        key=lambda f: (
+            _SEVERITY_ORDER.get(f["severity"], 9),
+            f["session"],
+            f["video_offset_ms"],
+        )
+    )
+
+    lines = ["# Curio user-test findings", ""]
+    lines.append(
+        f"Generated {payload['generatedAt']}. "
+        f"{len(sessions)} session(s), {len(findings)} finding(s)."
+    )
+    lines.append("")
+    lines.append("## Videos")
+    lines.append("")
+    if videos:
+        lines.append("| Session | File |")
+        lines.append("| --- | --- |")
+        for session, paths in videos.items():
+            for kind, path in paths.items():
+                lines.append(f"| {session} | `{os.path.basename(path)}` ({kind}) |")
+    else:
+        lines.append("_No video was written._")
+    lines.append("")
+
+    lines.append("## Sessions")
+    lines.append("")
+    lines.append("| Session | Steps | ok | failed | unexpectedly ok | bugs | errors |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- |")
+    for s in sessions:
+        outcomes = [st["outcome"] for st in s["steps"]]
+        lines.append(
+            f"| {s['session']} | {len(outcomes)} "
+            f"| {outcomes.count('ok') + outcomes.count('failed-as-expected')} "
+            f"| {outcomes.count('failed')} "
+            f"| {outcomes.count('unexpectedly-ok')} "
+            f"| {s['counts'].get('bug', 0)} | {s['counts'].get('error', 0)} |"
+        )
+    lines.append("")
+
+    lines.append("## Findings")
+    lines.append("")
+    if not findings:
+        lines.append("_Nothing was recorded._")
+    for i, f in enumerate(findings, 1):
+        ms = f["video_offset_ms"]
+        lines.append(
+            f"### {i}. [{f['severity']}/{f['kind']}] {f['session']} - {f['step']}"
+        )
+        lines.append("")
+        lines.append(f"- **Video offset**: {ms // 60000:02d}:{(ms // 1000) % 60:02d}")
+        if f.get("still"):
+            lines.append(f"- **Still**: `{os.path.basename(f['still'])}`")
+        lines.append("")
+        lines.append("```")
+        lines.append(f["detail"].strip()[:4000])
+        lines.append("```")
+        lines.append("")
+
+    md_path = os.path.join(out_dir(), "FINDINGS.md")
+    with open(md_path, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+    return md_path
+
+
+__all__ = [
+    "Finding",
+    "PALETTE_LABELS",
+    "PALETTE_TILES",
+    "UserSession",
+    "collect_sessions",
+    "finalize_video",
+    "out_dir",
+    "palette_tile",
+    "PALETTE_ICON_CLASS",
+    "palette_tile_identity",
+    "write_report",
+]

--- a/utk_curio/backend/tests/test_frontend/utils.py
+++ b/utk_curio/backend/tests/test_frontend/utils.py
@@ -1623,7 +1623,10 @@ def upload_workflow(
     assert load_spec.is_visible()
 
     with page.expect_file_chooser() as fc_info:
-        page.get_by_text("Load dataflow").click()
+        # The role locator, not get_by_text: the File menu row is a <div>
+        # wrapping a <button> carrying the same label (UpMenu.tsx), so the text
+        # engine matches both and the click dies of a strict-mode violation.
+        load_spec.click()
     fc_info.value.set_files(workflow_file)
 
     # Wait until all expected nodes have rendered on the ReactFlow canvas

--- a/utk_curio/frontend/urban-workflows/src/NotebookConvertor.ts
+++ b/utk_curio/frontend/urban-workflows/src/NotebookConvertor.ts
@@ -273,63 +273,167 @@ function topologicalSort(nodes: TrillNode[], edges: TrillEdge[]): TrillNode[] {
   return result;
 }
 
-function generateCell(
-  node: TrillNode,
-  inputNodes: TrillNode[]
-): NotebookCell | null {
-  const content = node.content ?? "";
+/** Templates whose ``content`` is a Python function body, run as ``userCode(arg)``. */
+const PYTHON_BODY_TYPES = new Set<string>([
+  NodeType.DATA_LOADING,
+  NodeType.DATA_TRANSFORMATION,
+  NodeType.COMPUTATION_ANALYSIS,
+  NodeType.DATA_SUMMARY,
+  NodeType.DATA_EXPORT,
+]);
 
-  const inputComments = inputNodes
-    .map((n) => `# input: ${outputVarName(n)}`)
+/** ``curio.builtin/spatial-join`` has no ``NodeType`` member (the enum predates it). */
+const SPATIAL_JOIN_TYPE = "curio.builtin/spatial-join";
+
+function codeCell(source: string): NotebookCell {
+  return {
+    cell_type: "code",
+    source,
+    metadata: {},
+    outputs: [],
+    execution_count: null,
+  };
+}
+
+function markdownCell(source: string): NotebookCell {
+  return {
+    cell_type: "markdown",
+    source,
+    metadata: {},
+    outputs: [],
+    execution_count: null,
+  };
+}
+
+/** How a node names the value it received, mirroring the sandbox's ``arg``.
+ *
+ * ``worker.py`` hands a merge node a *tuple* of its upstream outputs, so several
+ * inputs become a tuple here too. No inputs means the body is a source and gets
+ * ``None``.
+ */
+function argExpression(inputNodes: TrillNode[]): string {
+  if (inputNodes.length === 0) return "None";
+  if (inputNodes.length === 1) return outputVarName(inputNodes[0]);
+  return `(${inputNodes.map(outputVarName).join(", ")})`;
+}
+
+function indent(text: string): string {
+  return text
+    .split(/\r?\n/)
+    .map((line) => (line.trim() === "" ? "" : `    ${line}`))
     .join("\n");
+}
 
+/** A heading a reader can use to line the notebook up against the canvas. */
+function nodeHeading(node: TrillNode, inputNodes: TrillNode[]): string {
+  const inputs = inputNodes.length
+    ? ` &larr; ${inputNodes.map(outputVarName).join(", ")}`
+    : "";
+  return `### \`${unversionedNodeType(node.type)}\` &mdash; \`${node.id}\`${inputs}`;
+}
+
+/** Emit the cells for one node.
+ *
+ * Returns a list rather than a single cell (or ``null``) so that a node can
+ * contribute a heading plus a body, and so that a template a Python kernel
+ * cannot run still leaves a record instead of vanishing. The previous version
+ * returned ``null`` for every type except three, and ``trillToNotebook`` then
+ * dropped those nodes without saying so.
+ */
+function generateCells(node: TrillNode, inputNodes: TrillNode[]): NotebookCell[] {
+  const content = node.content ?? "";
+  // Specs saved since the curio.builtin@1 pack carry versioned ids (dev/64),
+  // and third-party package ids never match a NodeType at all - so this
+  // dispatch always ends in a default branch rather than an enumeration.
   const nodeType = unversionedNodeType(node.type);
+  const outVar = outputVarName(node);
+  const heading = markdownCell(nodeHeading(node, inputNodes));
 
-  if (nodeType === NodeType.DATA_LOADING) {
-    return {
-      cell_type: "code",
-      source: content,
-      metadata: {},
-      outputs: [],
-      execution_count: null,
-    };
+  if (PYTHON_BODY_TYPES.has(nodeType)) {
+    // A node's content is the body of `def userCode(arg):` - PythonInterpreter
+    // indents it by four spaces and the sandbox execs it under exactly that
+    // signature. Reproducing the function is the only faithful inversion:
+    // emitting the body flat would leave a top-level `return` (a SyntaxError)
+    // and an unbound `arg`, which is what shipped.
+    const fn = `node_${sanitizeId(node.id)}`;
+    const body = content.trim() === "" ? "    pass" : indent(content);
+    return [
+      heading,
+      codeCell(`def ${fn}(arg):\n${body}\n\n\n${outVar} = ${fn}(${argExpression(inputNodes)})`),
+    ];
   }
 
-  if (nodeType === NodeType.COMPUTATION_ANALYSIS) {
-    const source = inputComments ? `${inputComments}\n${content}` : content;
-    return {
-      cell_type: "code",
-      source,
-      metadata: {},
-      outputs: [],
-      execution_count: null,
-    };
+  if (nodeType === NodeType.DATA_POOL) {
+    // A pool passes its input through untouched.
+    const source = inputNodes.length
+      ? `${outVar} = ${outputVarName(inputNodes[0])}`
+      : `${outVar} = None`;
+    return [heading, codeCell(source)];
+  }
+
+  if (nodeType === NodeType.MERGE_FLOW) {
+    return [heading, codeCell(`${outVar} = ${argExpression(inputNodes)}`)];
   }
 
   if (nodeType === NodeType.VIS_VEGA) {
-    let specJson = "{}";
+    let spec: unknown = {};
+    let parsed = true;
     try {
-      specJson = JSON.stringify(JSON.parse(content));
+      spec = JSON.parse(content);
     } catch {
-      specJson = JSON.stringify(content);
+      parsed = false;
     }
-    const displayCode = [
-      "import json",
+    if (!parsed) {
+      return [
+        heading,
+        markdownCell(
+          "This Vega-Lite node's specification is not valid JSON, so it is " +
+            "recorded here rather than rendered:\n\n```json\n" +
+            content +
+            "\n```"
+        ),
+      ];
+    }
+    // json.loads of a JSON *string* would yield a Python str rather than a
+    // dict, which is not a usable mimebundle - so the spec is embedded as a
+    // literal object instead.
+    const lines = [
       "from IPython.display import display",
-      `_spec = json.loads(${JSON.stringify(specJson)})`,
-      `display({"application/vnd.vegalite.v5+json": _spec, "text/plain": "<VegaLite>"}, raw=True)`,
-    ].join("\n");
-    const source = inputComments ? `${inputComments}\n${displayCode}` : displayCode;
-    return {
-      cell_type: "code",
-      source,
-      metadata: {},
-      outputs: [],
-      execution_count: null,
-    };
+      "",
+      `_spec = ${JSON.stringify(spec, null, 2)}`,
+    ];
+    if (inputNodes.length) {
+      lines.push(
+        "",
+        "# Attach the upstream rows the canvas would have supplied.",
+        `_spec["data"] = {"values": ${outputVarName(inputNodes[0])}.to_dict(orient="records")}`
+      );
+    }
+    lines.push(
+      "",
+      'display({"application/vnd.vegalite.v5+json": _spec, "text/plain": "<VegaLite>"}, raw=True)'
+    );
+    return [heading, codeCell(lines.join("\n"))];
   }
 
-  return null;
+  // Everything a Python kernel cannot run: an Autark grammar document (which
+  // goes through the JS interpreter despite its manifest engine), a JavaScript
+  // computation, and the presentational templates that carry no content.
+  // Recorded, never silently dropped.
+  const why =
+    nodeType === NodeType.AUTK_GRAMMAR
+      ? "An Autark grammar specification. It renders through Curio's WebGPU pipeline, not a Python kernel."
+      : nodeType === NodeType.JS_COMPUTATION
+        ? "A JavaScript computation. Its source is preserved below; it cannot run in this notebook's Python kernel."
+        : nodeType === SPATIAL_JOIN_TYPE
+          ? "A spatial join, configured on the canvas rather than in code."
+          : nodeType === NodeType.VIS_SIMPLE
+            ? "A Simple View node, which displays its input rather than computing anything."
+            : "This node is provided by a package and has no Python equivalent here.";
+  const fenced = content.trim()
+    ? `\n\n\`\`\`\n${content}\n\`\`\``
+    : "";
+  return [markdownCell(`${nodeHeading(node, inputNodes)}\n\n${why}${fenced}`)];
 }
 
 export function trillToNotebook(spec: TrillSpec): Notebook {
@@ -351,8 +455,7 @@ export function trillToNotebook(spec: TrillSpec): Notebook {
     const inputNodes = (inputsOf.get(node.id) ?? [])
       .map((id) => nodeById.get(id))
       .filter((n): n is TrillNode => n !== undefined);
-    const cell = generateCell(node, inputNodes);
-    if (cell) cells.push(cell);
+    cells.push(...generateCells(node, inputNodes));
   }
 
   return {

--- a/utk_curio/frontend/urban-workflows/src/TrillGenerator.ts
+++ b/utk_curio/frontend/urban-workflows/src/TrillGenerator.ts
@@ -45,16 +45,41 @@ export class TrillGenerator {
         return { nodes, edges };
     }
 
+    /** A version key that is not already taken.
+     *
+     * The base is `<name>_<timestamp>`, which is what saved specs contain and
+     * what `provenanceGraphNode.id` documents. That is not unique: the timestamp
+     * has millisecond resolution and a single gesture can record more than one
+     * version inside one millisecond. When it collided, several versions
+     * collapsed onto one `versions` key, the graph grew duplicate node ids and
+     * self-loop edges, and React reported two children with the same key — with
+     * the real consequence that the provenance graph could silently drop or
+     * duplicate a version. Committed projects on disk already contain this.
+     *
+     * A suffix keeps the format a plain string and a usable `versions` key, so
+     * older files (whose ids never carry one) keep loading untouched.
+     */
+    private static _uniqueVersionId(name: string, timestamp: number): string {
+        const base = `${name}_${timestamp}`;
+        if (this.list_of_trills[base] === undefined) return base;
+        let n = 2;
+        while (this.list_of_trills[`${base}_${n}`] !== undefined) n += 1;
+        return `${base}_${n}`;
+    }
+
     static intializeProvenance(trill_spec: any){
         // TODO: look for a provenance JSON for the workflow. If it does not exist initialize it. If it exists load the meta and trill versions to memory (ideally they should be on the database)
         // TODO: for now assuming that the user is never loading a trill or provenanceJSON.
 
-        this.latestTrill = trill_spec.dataflow.name+"_"+trill_spec.dataflow.timestamp;
-        this.list_of_trills[trill_spec.dataflow.name+"_"+trill_spec.dataflow.timestamp] = trill_spec;
+        const versionId = this._uniqueVersionId(
+            trill_spec.dataflow.name, trill_spec.dataflow.timestamp,
+        );
+        this.latestTrill = versionId;
+        this.list_of_trills[versionId] = trill_spec;
 
         this.provenanceJSON.id = trill_spec.dataflow.provenance_id;
         this.provenanceJSON.nodes.push({
-            id: trill_spec.dataflow.name+"_"+trill_spec.dataflow.timestamp,
+            id: versionId,
             label: trill_spec.dataflow.name+" ("+trill_spec.dataflow.timestamp+")",
             timestamp: trill_spec.dataflow.timestamp,
             preview: this._extractGraphPreview(trill_spec)
@@ -71,27 +96,32 @@ export class TrillGenerator {
         
         console.log("new_trill", new_trill);
 
+        const versionId = this._uniqueVersionId(
+            new_trill.dataflow.name, new_trill.dataflow.timestamp,
+        );
+
         this.provenanceJSON.nodes.push({
-            id: new_trill.dataflow.name+"_"+new_trill.dataflow.timestamp,
+            id: versionId,
             label: new_trill.dataflow.name+" ("+new_trill.dataflow.timestamp+")",
             timestamp: new_trill.dataflow.timestamp,
             preview: this._extractGraphPreview(new_trill)
         });
 
-        this.list_of_trills[new_trill.dataflow.name+"_"+new_trill.dataflow.timestamp] = new_trill;
+        this.list_of_trills[versionId] = new_trill;
 
-        console.log("list_of_trills", this.list_of_trills);
-
-        if(this.latestTrill){ // If there is a previous trill from which this one was derived add an edge connecting both
-            this.provenanceJSON.edges.push({        
-                id: this.latestTrill+"_to_"+new_trill.dataflow.name+"_"+new_trill.dataflow.timestamp,
+        // An edge from a version to itself carries no history and duplicates an
+        // existing key, which is how a colliding id showed up as a React
+        // duplicate-key warning in the provenance graph.
+        if(this.latestTrill && this.latestTrill !== versionId){
+            this.provenanceJSON.edges.push({
+                id: this.latestTrill+"_to_"+versionId,
                 source: this.latestTrill,
-                target: new_trill.dataflow.name+"_"+new_trill.dataflow.timestamp,
+                target: versionId,
                 label: change
             })
         }
 
-        this.latestTrill = new_trill.dataflow.name+"_"+new_trill.dataflow.timestamp;
+        this.latestTrill = versionId;
 
     }
 

--- a/utk_curio/frontend/urban-workflows/src/components/MainCanvas.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/MainCanvas.tsx
@@ -320,15 +320,22 @@ export function MainCanvas() {
             let allowed = true;
 
             if (change.type === "remove") {
-                for (const edge of currentEdges) {
-                    if (edge.source === change.id || edge.target === change.id) {
-                        showToast(
-                            "Connected boxes cannot be removed. Remove the edges first by selecting it and pressing Delete or Backspace.",
-                            "warning"
-                        );
-                        allowed = false;
-                        break;
-                    }
+                // Removing a wired node is refused on purpose. Say how much is
+                // in the way: the old copy told the user to "remove the edges"
+                // without saying how many there were or which, so on a busy
+                // canvas it read as the key simply not working.
+                const attached = currentEdges.filter(
+                    (edge) => edge.source === change.id || edge.target === change.id,
+                );
+                if (attached.length > 0) {
+                    const count = attached.length;
+                    showToast(
+                        `This node still has ${count} connection${count === 1 ? "" : "s"}. ` +
+                        `Select ${count === 1 ? "it" : "them"} and press Delete or Backspace, ` +
+                        "then remove the node.",
+                        "warning"
+                    );
+                    allowed = false;
                 }
                 if (allowed) dirty = true;
             }

--- a/utk_curio/frontend/urban-workflows/src/components/ModalShell.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/ModalShell.tsx
@@ -1,8 +1,27 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import styles from "./ModalShell.module.css";
+
+/** Every mounted ModalShell.
+ *
+ * Escape must reach exactly one overlay, and two things make that awkward. The
+ * catalog drawers listen on `window` too, and a drawer that renders a modal
+ * inside itself (the Agent Catalog holds AI Settings and agent import) mounted
+ * first — so its listener runs first and `stopPropagation` from the modal cannot
+ * help. `modalStackDepth` lets those drawers stand down instead.
+ *
+ * Among modals, "which one is on top" is decided from the DOM rather than from
+ * mount order: React commits child effects before parent ones, so the registry
+ * order is inside-out and cannot be trusted for it.
+ */
+const modalStack = new Set<symbol>();
+
+/** How many ModalShell dialogs are currently open. */
+export function modalStackDepth(): number {
+  return modalStack.size;
+}
 
 interface ModalShellProps {
   onClose: () => void;
@@ -30,6 +49,41 @@ export default function ModalShell({
   titleId,
   label,
 }: ModalShellProps) {
+  // Escape closes the dialog. Deliberately routed through the same `onClose`
+  // the backdrop and the X use, so a consumer that passes `busy ? () => {} :
+  // onClose` (NodeSaveAsModal, PackageMetadataModal) keeps Escape inert
+  // mid-save without knowing this exists.
+  //
+  // Read through a ref so the listener is registered once per mount rather than
+  // re-registered whenever the parent re-renders with a fresh closure.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const token = Symbol("curio-modal");
+    modalStack.add(token);
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      const self = dialogRef.current;
+      if (!self) return;
+      // Only the dialog on top responds, so a modal opened over another does
+      // not close both. Portals all land in document.body, so the last matching
+      // node in document order is the one painted on top.
+      const open = document.querySelectorAll<HTMLElement>(
+        '[data-curio-modal-shell="true"]',
+      );
+      if (open.length > 1 && open[open.length - 1] !== self) return;
+      event.stopPropagation();
+      onCloseRef.current();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      modalStack.delete(token);
+    };
+  }, []);
+
   const packagePaletteActionAttr = preservePackagePaletteOpen
     ? ({ "data-curio-package-palette-node-action": "true" } as const)
     : {};
@@ -48,6 +102,8 @@ export default function ModalShell({
           a screen reader with an unlabeled group and tests with nothing to
           target but headings. */}
       <div
+        ref={dialogRef}
+        data-curio-modal-shell="true"
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}

--- a/utk_curio/frontend/urban-workflows/src/components/UniversalNode.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/UniversalNode.tsx
@@ -74,7 +74,7 @@ const UniversalNodeBody = React.memo(function UniversalNodeBody({ data, isConnec
   const showLoading = behavior.showLoading ?? false;
   const disablePlay = behavior.disablePlay ?? adapter.container.disablePlay ?? false;
 
-  const { signalNodeExecDone, dashboardOn, markNodeStale } = useFlowContext();
+  const { signalNodeExecDone, dashboardOn } = useFlowContext();
   const collab = useCollab();
   const lastTriggerExecRef = useRef<number>(data.triggerExec ?? 0);
   const outputCodeRef = useRef(output?.code);
@@ -258,7 +258,6 @@ const UniversalNodeBody = React.memo(function UniversalNodeBody({ data, isConnec
             defaultValue={defaultValue}
             readOnly={readOnly || lockedByOther}
             floatCode={nodeState.setCode}
-            markNodeStale={markNodeStale}
             contentComponent={behavior.contentComponent}
           />
         ) : (

--- a/utk_curio/frontend/urban-workflows/src/components/UniversalNode.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/UniversalNode.tsx
@@ -74,7 +74,7 @@ const UniversalNodeBody = React.memo(function UniversalNodeBody({ data, isConnec
   const showLoading = behavior.showLoading ?? false;
   const disablePlay = behavior.disablePlay ?? adapter.container.disablePlay ?? false;
 
-  const { signalNodeExecDone, dashboardOn } = useFlowContext();
+  const { signalNodeExecDone, dashboardOn, markNodeStale } = useFlowContext();
   const collab = useCollab();
   const lastTriggerExecRef = useRef<number>(data.triggerExec ?? 0);
   const outputCodeRef = useRef(output?.code);
@@ -258,6 +258,7 @@ const UniversalNodeBody = React.memo(function UniversalNodeBody({ data, isConnec
             defaultValue={defaultValue}
             readOnly={readOnly || lockedByOther}
             floatCode={nodeState.setCode}
+            markNodeStale={markNodeStale}
             contentComponent={behavior.contentComponent}
           />
         ) : (

--- a/utk_curio/frontend/urban-workflows/src/components/agents/attach/AgentChatPanel.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/agents/attach/AgentChatPanel.tsx
@@ -42,6 +42,7 @@ import {
   type AgentRunStatus,
   type RunStatusDisplay,
 } from "./agentRunStatus";
+import { modalStackDepth } from "../../ModalShell";
 import styles from "./AgentChatPanel.module.css";
 
 /** Heuristic: prompts longer than this get the clamp + expand toggle. */
@@ -309,6 +310,11 @@ export const AgentChatPanel: React.FC<{
   // while renaming, Escape cancels the edit instead (handled on the input).
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      // An open modal owns Escape. AI Settings and agent import are raised
+      // over this panel, and this listener is on window in the bubble phase,
+      // so the modal cannot stop it firing. It has to stand down itself, or
+      // dismissing the dialog closed the chat behind it as well.
+      if (modalStackDepth() > 0) return;
       if (e.key === "Escape" && !editingTitle) onClose();
     };
     window.addEventListener("keydown", onKey);

--- a/utk_curio/frontend/urban-workflows/src/components/editing/GrammarEditor.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/editing/GrammarEditor.tsx
@@ -15,8 +15,6 @@ type GrammarEditorProps = {
     defaultValue?: any;
     floatCode?: any;
     readOnly: boolean;
-    /** Same freshness signal CodeEditor sends on a keystroke. */
-    markNodeStale?: (nodeId: string) => void;
 };
 
 export default function GrammarEditor({
@@ -30,7 +28,6 @@ export default function GrammarEditor({
     defaultValue,
     floatCode,
     readOnly,
-    markNodeStale,
 }: GrammarEditorProps) {
     const [grammar, _setGrammar] = useState("{}");
     const grammarRef = useRef(grammar);
@@ -154,12 +151,7 @@ export default function GrammarEditor({
     }, [replacedCodeDirty]);
 
     const updateGrammarContent = (value: string, readOnly: boolean) => {
-        if (readOnly) return;
-        setGrammar(value);
-        // Same signal CodeEditor sends on a keystroke. Without it a node whose
-        // grammar was edited kept its "executed" tick, so the freshness badge
-        // and the dataset lineage status disagreed with the editor.
-        markNodeStale?.(nodeId);
+        if (!readOnly) setGrammar(value);
     };
 
     return (

--- a/utk_curio/frontend/urban-workflows/src/components/editing/GrammarEditor.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/editing/GrammarEditor.tsx
@@ -15,6 +15,8 @@ type GrammarEditorProps = {
     defaultValue?: any;
     floatCode?: any;
     readOnly: boolean;
+    /** Same freshness signal CodeEditor sends on a keystroke. */
+    markNodeStale?: (nodeId: string) => void;
 };
 
 export default function GrammarEditor({
@@ -28,6 +30,7 @@ export default function GrammarEditor({
     defaultValue,
     floatCode,
     readOnly,
+    markNodeStale,
 }: GrammarEditorProps) {
     const [grammar, _setGrammar] = useState("{}");
     const grammarRef = useRef(grammar);
@@ -151,7 +154,12 @@ export default function GrammarEditor({
     }, [replacedCodeDirty]);
 
     const updateGrammarContent = (value: string, readOnly: boolean) => {
-        if (!readOnly) setGrammar(value);
+        if (readOnly) return;
+        setGrammar(value);
+        // Same signal CodeEditor sends on a keystroke. Without it a node whose
+        // grammar was edited kept its "executed" tick, so the freshness badge
+        // and the dataset lineage status disagreed with the editor.
+        markNodeStale?.(nodeId);
     };
 
     return (

--- a/utk_curio/frontend/urban-workflows/src/components/editing/NodeEditor.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/editing/NodeEditor.tsx
@@ -47,6 +47,7 @@ type NodeEditorProps = {
     readOnly: boolean;
     defaultValue: any;
     floatCode?: any;
+    markNodeStale?: (nodeId: string) => void;
     provenance?: boolean;
     customWidgetsCallback?: any;
     contentComponent?: any;
@@ -68,6 +69,7 @@ function NodeEditor({
     readOnly,
     defaultValue,
     floatCode,
+    markNodeStale,
     provenance,
     customWidgetsCallback,
     contentComponent,
@@ -278,6 +280,7 @@ function NodeEditor({
                                         style={{ height: "100%" }}
                                     >
                                         <GrammarEditor
+                                            markNodeStale={markNodeStale}
                                             floatCode={floatCode}
                                             readOnly={readOnly}
                                             defaultValue={defaultCode}

--- a/utk_curio/frontend/urban-workflows/src/components/editing/NodeEditor.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/editing/NodeEditor.tsx
@@ -47,7 +47,6 @@ type NodeEditorProps = {
     readOnly: boolean;
     defaultValue: any;
     floatCode?: any;
-    markNodeStale?: (nodeId: string) => void;
     provenance?: boolean;
     customWidgetsCallback?: any;
     contentComponent?: any;
@@ -69,7 +68,6 @@ function NodeEditor({
     readOnly,
     defaultValue,
     floatCode,
-    markNodeStale,
     provenance,
     customWidgetsCallback,
     contentComponent,
@@ -280,7 +278,6 @@ function NodeEditor({
                                         style={{ height: "100%" }}
                                     >
                                         <GrammarEditor
-                                            markNodeStale={markNodeStale}
                                             floatCode={floatCode}
                                             readOnly={readOnly}
                                             defaultValue={defaultCode}

--- a/utk_curio/frontend/urban-workflows/src/components/menus/nodes/ToolsMenu.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/menus/nodes/ToolsMenu.tsx
@@ -42,6 +42,14 @@ const DraggableTool = memo(function DraggableTool({
         >
             <div
                 id={tutorialID}
+                // The tile is an icon and a drag source: nothing in it was text,
+                // so it had no accessible name at all and the hover tooltip was
+                // its only label. `title` matches how the dataset and agent drag
+                // handles are named (DatasetPaletteRows, AgentPaletteRow); the
+                // explicit aria-label wins the accname computation and keeps the
+                // name stable if the tooltip copy ever diverges.
+                aria-label={tooltip}
+                title={tooltip}
                 className={styles.optionStyle}
                 draggable
                 onDragStart={(event) => {

--- a/utk_curio/frontend/urban-workflows/src/components/packages/ForkFamilyPicker.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/packages/ForkFamilyPicker.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef,
 import type { CSSProperties } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
+import { modalStackDepth } from "../ModalShell";
 import dockStyles from "./ForkFamilyPicker.dock.module.css";
 import hubStyles from "./ForkFamilyPicker.hub.module.css";
 
@@ -73,6 +74,9 @@ export function ForkFamilyPicker({ variant, rootKey, options, value, onChange }:
             if (!rootRef.current?.contains(ev.target as Node)) setOpen(false);
         };
         const onKey = (ev: KeyboardEvent) => {
+            // See AgentChatPanel: a modal raised over the picker owns Escape,
+            // and this window listener cannot be stopped by it.
+            if (modalStackDepth() > 0) return;
             if (ev.key === "Escape") setOpen(false);
         };
         document.addEventListener("mousedown", onDocMouseDown, true);

--- a/utk_curio/frontend/urban-workflows/src/components/packages/publishing/NodeCatalogDrawer.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/packages/publishing/NodeCatalogDrawer.tsx
@@ -26,6 +26,7 @@ import { sortPackages, matchesSearch } from "./packageUtils";
 import { restartNotice } from "../../../services/packageRestartCopy";
 import shell from "./CatalogDrawerShell.module.css";
 import styles from "./NodeCatalogDrawer.module.css";
+import { modalStackDepth } from "../../ModalShell";
 
 
 export interface NodeCatalogDrawerProps {
@@ -160,6 +161,8 @@ export const NodeCatalogDrawer: React.FC<NodeCatalogDrawerProps> = ({
 
   useEffect(() => {
     const onKey = (ev: KeyboardEvent) => {
+      // Defer to any open modal (see ModalShell's stack).
+      if (modalStackDepth() > 0) return;
       if (ev.key === "Escape") onRequestClose();
     };
     window.addEventListener("keydown", onKey);

--- a/utk_curio/frontend/urban-workflows/src/components/styles.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/styles.tsx
@@ -571,15 +571,17 @@ export const NodeContainer = ({
                 onDragOver={onDatasetDragOver}
                 onDrop={onDatasetDrop}
                 style={{
-                    ...getNodeContainerStyles(data.nodeType),
+                    ...getNodeContainerStyles(data.nodeType, {
+                        dashboardOn,
+                        suggested: data.suggestionType != "none" && data.suggestionType != undefined,
+                        acceptable: data.suggestionAcceptable,
+                    }),
                     ...styles,
                     width: currentNodeWidth + "px",
                     height: currentNodeHeight + "px",
                     ...(minimized ? { display: "none" } : {}),
-                    ...((data.suggestionType != "none" && data.suggestionType != undefined) ? {opacity: 0.5, borderWidth: "2px", borderStyle: "dashed", pointerEvents: "none"} : {}),
-                    ...(data.suggestionAcceptable ? {borderColor: "#1d3853"} : {}),
+                    ...((data.suggestionType != "none" && data.suggestionType != undefined) ? {opacity: 0.5, pointerEvents: "none"} : {}),
                     ...(data.keywordHighlighted ? {backgroundColor: "#1E1F23"} : {}),
-                    ...(dashboardOn ? {border: "2px solid #000", boxShadow: "none", borderRadius: "0", resize: "none"} : {})
                 }}
             >
                 {!noContent && !dashboardOn ? (
@@ -1067,17 +1069,62 @@ const nodeTypeBorderColor: Record<string, string> = {
     [NodeType.VIS_SIMPLE]: categoryFg("vis"),
 };
 
-const getNodeContainerStyles = (nodeType: string): CSS.Properties => ({
-    position: "relative",
-    backgroundColor: "#ffffff",
+/** The node container's border and surface, resolved in one place.
+ *
+ * Longhands only, never the `border` shorthand. The two used to be layered: this
+ * function supplied `borderLeft` and the inline style added `border` when
+ * dashboard mode was on, so toggling it changed which of the two was present
+ * between renders and React warned "Removing border borderLeft". The suggestion
+ * state added `borderWidth`/`borderStyle`/`borderColor` on top, colliding with
+ * the same shorthand. Deciding the whole border here removes the layering
+ * instead of reordering it.
+ */
+export const getNodeContainerStyles = (
+    nodeType: string,
+    state: { dashboardOn?: boolean; suggested?: boolean; acceptable?: boolean } = {},
+): CSS.Properties => {
     // `nodeType` arrives versioned for palette-dragged nodes
     // (`curio.builtin/merge-flow@1`) but this map is keyed by the unversioned
     // NodeType enum, so an unnormalized lookup silently falls back to grey (#159).
-    borderLeft: `4px solid ${nodeTypeBorderColor[unversionedNodeType(nodeType)] ?? CATEGORY_FALLBACK_FG}`,
-    borderRadius: "10px",
-    padding: "5px",
-    boxShadow: "rgba(0, 0, 0, 0.35) 0px 5px 15px",
-});
+    const accent = nodeTypeBorderColor[unversionedNodeType(nodeType)] ?? CATEGORY_FALLBACK_FG;
+    const base: CSS.Properties = {
+        position: "relative",
+        backgroundColor: "#ffffff",
+        borderRadius: "10px",
+        padding: "5px",
+        boxShadow: "rgba(0, 0, 0, 0.35) 0px 5px 15px",
+    };
+
+    if (state.dashboardOn) {
+        // Dashboard mode frames every node identically, accent included.
+        return {
+            ...base,
+            borderStyle: "solid",
+            borderColor: "#000",
+            borderWidth: "2px",
+            borderRadius: "0",
+            boxShadow: "none",
+            resize: "none",
+        };
+    }
+
+    const suggested = state.suggested === true;
+    return {
+        ...base,
+        borderTopStyle: suggested ? "dashed" : undefined,
+        borderRightStyle: suggested ? "dashed" : undefined,
+        borderBottomStyle: suggested ? "dashed" : undefined,
+        borderLeftStyle: "solid",
+        borderTopWidth: suggested ? "2px" : undefined,
+        borderRightWidth: suggested ? "2px" : undefined,
+        borderBottomWidth: suggested ? "2px" : undefined,
+        borderLeftWidth: "4px",
+        borderTopColor: state.acceptable ? "#1d3853" : undefined,
+        borderRightColor: state.acceptable ? "#1d3853" : undefined,
+        borderBottomColor: state.acceptable ? "#1d3853" : undefined,
+        borderLeftColor: state.acceptable ? "#1d3853" : accent,
+    };
+};
 
 const nodeContentStyle: CSS.Properties = {
     backgroundColor: "white",

--- a/utk_curio/frontend/urban-workflows/src/hook/useNodeState.ts
+++ b/utk_curio/frontend/urban-workflows/src/hook/useNodeState.ts
@@ -25,7 +25,21 @@ export function useNodeState(data: any, nodeType: NodeTemplateId) {
 
   useEffect(() => { data.code = code; }, [code]);
 
-  useEffect(() => { data.output = output; }, [output]);
+  // Mirrored by direct mutation rather than setNodes, deliberately: a setNodes
+  // per keystroke re-rendered the whole canvas (dev/70). reactFlow.getNodes()
+  // still sees these, which is what lets playNodesUpTo read them.
+  //
+  // `executedCode` records the source that produced the current successful
+  // output, so playNodesUpTo can tell a cached result apart from a stale one.
+  // A comparison rather than a dirty flag on purpose: Curio's Monaco editors are
+  // uncontrolled and useMonacoExternalValue applies external content with
+  // executeEdits, so a project load or an agent write re-enters the change
+  // handler in a real browser - a flag set there would mark every node dirty
+  // straight after a load, while identical content compares equal.
+  useEffect(() => {
+    data.output = output;
+    if (output?.code === 'success') data.executedCode = code;
+  }, [output]);
 
   useEffect(() => {
     if (data.templateId != undefined) {

--- a/utk_curio/frontend/urban-workflows/src/index.tsx
+++ b/utk_curio/frontend/urban-workflows/src/index.tsx
@@ -56,8 +56,11 @@ export { refreshPackageRegistry };
 // Boot sequence:
 //   Fetch installed packages first — `refreshPackageRegistry()` registers every
 //   package-derived descriptor (including the auto-installed `curio.builtin@1`)
-//   so the palette is populated before anything reads it. Anonymous boots are
-//   no-ops until sign-in calls `refreshPackageRegistry()` explicitly.
+//   so the palette is populated before anything reads it.
+//
+//   An anonymous boot is a genuine no-op: `refreshPackageRegistry` returns
+//   early without a session token, because `/api/packages` requires auth and
+//   would only 401 on the sign-up page. Sign-in refreshes the registry itself.
 void refreshPackageRegistry();
 
 import FlowProvider from "./providers/FlowProvider";

--- a/utk_curio/frontend/urban-workflows/src/providers/AgentCatalogDrawerProvider.tsx
+++ b/utk_curio/frontend/urban-workflows/src/providers/AgentCatalogDrawerProvider.tsx
@@ -11,6 +11,7 @@ import React, {
 import { createPortal } from "react-dom";
 import { useFlowContext } from "./FlowProvider";
 import { AgentCatalogDrawer } from "../components/agents/catalog/AgentCatalogDrawer";
+import { modalStackDepth } from "../components/ModalShell";
 
 /**
  * Mounts the Agent Catalog drawer and exposes open/close controls, mirroring
@@ -110,6 +111,10 @@ export function AgentCatalogDrawerProvider({ children }: { children: React.React
   useEffect(() => {
     if (!presented) return;
     const onKey = (e: KeyboardEvent) => {
+      // A modal rendered inside this drawer (AI Settings, agent import) owns
+      // Escape while it is open. This listener was registered first, so the
+      // modal cannot stop it from firing - it has to stand down itself.
+      if (modalStackDepth() > 0) return;
       if (e.key === "Escape" && !pinned) closeAgentCatalogDrawer();
     };
     window.addEventListener("keydown", onKey);

--- a/utk_curio/frontend/urban-workflows/src/providers/FlowProvider.tsx
+++ b/utk_curio/frontend/urban-workflows/src/providers/FlowProvider.tsx
@@ -1109,6 +1109,12 @@ const FlowProvider = ({ children }: { children: ReactNode }) => {
     }
 
     function playNodesUpTo(targetNodeId: string) {
+        // Same guard playAllNodes has. Without it a second play click - which
+        // the e2e helper issues on its own, retrying up to three times when a
+        // node has not visibly acknowledged - overwrites playAllStateRef and
+        // orphans the level already in flight.
+        if (playAllStateRef.current != null) return;
+
         const currentNodes = reactFlow.getNodes();
         const currentEdges = reactFlow.getEdges();
 
@@ -1135,11 +1141,53 @@ const FlowProvider = ({ children }: { children: ReactNode }) => {
         }
         ancestorIds.add(targetNodeId);
 
-        // Skip ancestors that already ran successfully; always keep the target
-        const subgraphNodes = currentNodes.filter(n =>
-            ancestorIds.has(n.id) &&
-            (n.id === targetNodeId || n.data.output?.code !== "success")
+        // Which ancestors actually need to run again.
+        //
+        // "It succeeded once" is not enough: a node whose code has changed since
+        // that run holds an artifact its current source would not produce, and
+        // reusing it made the whole downstream chain report success off stale
+        // data. `executedCode` (mirrored in useNodeState) is the source that
+        // produced the current output, so a mismatch means re-run.
+        //
+        // The last clause is what makes invalidation transitive - a node feeding
+        // off a re-running ancestor must re-run too, or it would pass the old
+        // artifact down while its parent computed a new one.
+        const ancestorNodes = currentNodes.filter(n => ancestorIds.has(n.id));
+        const ancestorEdges = currentEdges.filter(
+            e => ancestorIds.has(e.source) && ancestorIds.has(e.target)
         );
+        const willRun = new Set<string>();
+        const ancestorLevels = computeTopologicalLevels(ancestorNodes, ancestorEdges);
+        // computeTopologicalLevels drops anything inside a cycle. Those nodes
+        // still have to be judged, or a cycle upstream of the target would
+        // silently remove it from the run.
+        const levelled = new Set(ancestorLevels.flat());
+        const decisionOrder = [
+            ...ancestorLevels,
+            ancestorNodes.filter(n => !levelled.has(n.id)).map(n => n.id),
+        ];
+        for (const level of decisionOrder) {
+            for (const nodeId of level) {
+                const node = currentNodes.find(n => n.id === nodeId);
+                if (!node) continue;
+                const neverSucceeded = node.data.output?.code !== "success";
+                const codeChanged =
+                    node.data.executedCode !== undefined &&
+                    node.data.executedCode !== node.data.code;
+                const upstreamRerunning = ancestorEdges.some(
+                    e => e.target === nodeId && willRun.has(e.source)
+                );
+                if (
+                    nodeId === targetNodeId ||
+                    neverSucceeded ||
+                    codeChanged ||
+                    upstreamRerunning
+                ) {
+                    willRun.add(nodeId);
+                }
+            }
+        }
+        const subgraphNodes = currentNodes.filter(n => willRun.has(n.id));
         const subgraphNodeIds = new Set(subgraphNodes.map(n => n.id));
         const subgraphEdges = currentEdges.filter(
             e => subgraphNodeIds.has(e.source) && subgraphNodeIds.has(e.target)

--- a/utk_curio/frontend/urban-workflows/src/registry/packageRegistryBootstrap.ts
+++ b/utk_curio/frontend/urban-workflows/src/registry/packageRegistryBootstrap.ts
@@ -6,6 +6,7 @@
  */
 
 import { loadInstalledPackages } from './packagesClient';
+import { getToken } from '../utils/authApi';
 import { getCurrentProjectPackages } from './projectPackagesStore';
 
 function notifyTemplatesAfterPackageRefresh(): void {
@@ -26,6 +27,14 @@ function notifyTemplatesAfterPackageRefresh(): void {
  * catalog routes the store is empty and every installed package shows.
  */
 export function refreshPackageRegistry(): Promise<void> {
+  // Nothing to fetch without a session. ``/api/packages`` is ``@require_auth``
+  // and its response is per-user, so an anonymous call could only ever 401 —
+  // and although ``loadInstalledPackages`` suppresses its own warning for that
+  // status, the browser still logs "Failed to load resource: 401" on the
+  // sign-up page, the first screen a new user sees. Callers that matter run
+  // after sign-in anyway: ``UserProvider.applyUser`` refreshes as soon as a
+  // user resolves, and ``ToolsMenu`` refreshes again when ``user.id`` appears.
+  if (!getToken()) return Promise.resolve();
   return loadInstalledPackages(getCurrentProjectPackages()).then(() => {
     notifyTemplatesAfterPackageRefresh();
   });

--- a/utk_curio/frontend/urban-workflows/src/tests/NotebookConvertor.test.ts
+++ b/utk_curio/frontend/urban-workflows/src/tests/NotebookConvertor.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Export half of NotebookConvertor.
+ *
+ * Written after a user test exported a three-node dataflow as a one-cell
+ * notebook whose only cell did not compile. Nothing here existed before, which
+ * is why both defects shipped: `generateCell` returned `null` for every node
+ * type except three, and the cells it did emit carried the node body verbatim -
+ * a body that ends in `return`, which is a SyntaxError at a notebook's top
+ * level, and that references an `arg` nothing ever bound.
+ */
+import { trillToNotebook, serializeNotebook, type TrillSpec } from "../NotebookConvertor";
+import { NodeType } from "../constants";
+
+type NodeSpec = { id: string; type: string; content?: string };
+
+function spec(nodes: NodeSpec[], edges: Array<[string, string]> = []): TrillSpec {
+  return {
+    dataflow: {
+      nodes: nodes.map((n, i) => ({ ...n, x: i * 700, y: 0 })),
+      edges: edges.map(([source, target], i) => ({
+        id: `e${i}`,
+        source,
+        target,
+      })),
+      name: "Test",
+      task: "",
+      timestamp: 0,
+      provenance_id: "p",
+    },
+  };
+}
+
+const codeCells = (nb: ReturnType<typeof trillToNotebook>) =>
+  nb.cells.filter((c) => c.cell_type === "code");
+
+/** Every top-level `return` is a SyntaxError in a notebook. */
+function topLevelReturns(source: string): string[] {
+  return source.split(/\r?\n/).filter((line) => /^return\b/.test(line));
+}
+
+describe("trillToNotebook", () => {
+  it("emits a cell for every node type, not just the three the importer makes", () => {
+    const everyType = [
+      NodeType.DATA_LOADING,
+      NodeType.DATA_TRANSFORMATION,
+      NodeType.COMPUTATION_ANALYSIS,
+      NodeType.DATA_SUMMARY,
+      NodeType.DATA_EXPORT,
+      NodeType.DATA_POOL,
+      NodeType.MERGE_FLOW,
+      NodeType.VIS_VEGA,
+      NodeType.VIS_SIMPLE,
+      NodeType.AUTK_GRAMMAR,
+      NodeType.JS_COMPUTATION,
+      "curio.builtin/spatial-join",
+      "acme.geo/buffer@2", // a third-party package node
+    ];
+    const nb = trillToNotebook(
+      spec(
+        everyType.map((type, i) => ({
+          id: `n${i}`,
+          type,
+          content: type === NodeType.VIS_VEGA ? '{"mark":"bar"}' : "return arg\n",
+        }))
+      )
+    );
+
+    for (const type of everyType) {
+      expect(serializeNotebook(nb)).toContain(type.split("@")[0]);
+    }
+    // Each node contributes at least one cell.
+    expect(nb.cells.length).toBeGreaterThanOrEqual(everyType.length);
+  });
+
+  it("emits Python cells with no top-level return", () => {
+    const nb = trillToNotebook(
+      spec([
+        {
+          id: "loader",
+          type: NodeType.DATA_LOADING,
+          content: "import pandas as pd\n\nreturn pd.DataFrame({'a': [1, 2]})\n",
+        },
+        {
+          id: "xform",
+          type: NodeType.DATA_TRANSFORMATION,
+          content: "df = arg.copy()\ndf['b'] = df['a'] * 2\nreturn df\n",
+        },
+      ])
+    );
+
+    for (const cell of codeCells(nb)) {
+      expect(topLevelReturns(cell.source)).toEqual([]);
+    }
+  });
+
+  it("keeps a multi-line return intact by preserving the function", () => {
+    // A textual `return X` -> `var = X` rewrite mangles this; wrapping the body
+    // back into its function does not. SimpleView.json contains exactly this.
+    const content = "import pandas as pd\n\nreturn pd.DataFrame({\n    'city': ['Chicago'],\n})\n";
+    const nb = trillToNotebook(spec([{ id: "n", type: NodeType.DATA_LOADING, content }]));
+    const source = codeCells(nb)[0].source;
+
+    expect(source).toContain("def node_n(arg):");
+    expect(source).toContain("    return pd.DataFrame({");
+    expect(source).toContain("        'city': ['Chicago'],");
+    expect(source).toContain("data_n = node_n(None)");
+  });
+
+  it("binds arg to the upstream value", () => {
+    const nb = trillToNotebook(
+      spec(
+        [
+          { id: "src", type: NodeType.DATA_LOADING, content: "return 1\n" },
+          { id: "dst", type: NodeType.COMPUTATION_ANALYSIS, content: "return arg + 1\n" },
+        ],
+        [["src", "dst"]]
+      )
+    );
+    const downstream = codeCells(nb).find((c) => c.source.includes("node_dst"))!;
+
+    // The upstream variable is passed in, not merely mentioned in a comment.
+    expect(downstream.source).toContain("result_dst = node_dst(data_src)");
+  });
+
+  it("passes several inputs as the tuple the sandbox would hand a merge node", () => {
+    const nb = trillToNotebook(
+      spec(
+        [
+          { id: "a", type: NodeType.DATA_LOADING, content: "return 1\n" },
+          { id: "b", type: NodeType.DATA_LOADING, content: "return 2\n" },
+          { id: "m", type: NodeType.MERGE_FLOW },
+        ],
+        [
+          ["a", "m"],
+          ["b", "m"],
+        ]
+      )
+    );
+    const merge = codeCells(nb).find((c) => c.source.startsWith("result_m ="))!;
+    expect(merge.source).toBe("result_m = (data_a, data_b)");
+  });
+
+  it("records a node a Python kernel cannot run instead of dropping it", () => {
+    const nb = trillToNotebook(
+      spec([{ id: "js", type: NodeType.JS_COMPUTATION, content: "return arg * 2;" }])
+    );
+    const markdown = nb.cells.filter((c) => c.cell_type === "markdown");
+
+    expect(markdown.some((c) => c.source.includes("JavaScript"))).toBe(true);
+    expect(serializeNotebook(nb)).toContain("return arg * 2;");
+    // And it did not pretend to be runnable Python.
+    expect(codeCells(nb)).toHaveLength(0);
+  });
+
+  it("embeds a Vega-Lite spec as an object, not a JSON string", () => {
+    const nb = trillToNotebook(
+      spec([{ id: "v", type: NodeType.VIS_VEGA, content: '{"mark": "bar"}' }])
+    );
+    const source = codeCells(nb)[0].source;
+
+    expect(source).toContain('_spec = {');
+    expect(source).toContain('"mark": "bar"');
+    // The old form round-tripped the spec through a string literal, so
+    // json.loads produced a str and the mimebundle was unusable.
+    expect(source).not.toContain("json.loads");
+  });
+
+  it("does not lose a node that sits in a cycle", () => {
+    const nb = trillToNotebook(
+      spec(
+        [
+          { id: "a", type: NodeType.DATA_TRANSFORMATION, content: "return arg\n" },
+          { id: "b", type: NodeType.DATA_TRANSFORMATION, content: "return arg\n" },
+        ],
+        [
+          ["a", "b"],
+          ["b", "a"],
+        ]
+      )
+    );
+    expect(serializeNotebook(nb)).toContain("node_a");
+    expect(serializeNotebook(nb)).toContain("node_b");
+  });
+});

--- a/utk_curio/frontend/urban-workflows/src/tests/TrillGenerator.test.ts
+++ b/utk_curio/frontend/urban-workflows/src/tests/TrillGenerator.test.ts
@@ -193,3 +193,84 @@ describe("the dataflow goal", () => {
     expect(spec.dataflow.task).toBe("");
   });
 });
+
+/**
+ * Version ids must be unique.
+ *
+ * A version was keyed `<name>_<timestamp>` at millisecond resolution, so two
+ * versions cut inside one millisecond collapsed onto a single `versions` key,
+ * the graph grew duplicate node ids, and the edge between them became a
+ * self-loop with a duplicate id. React then reported "two children with the
+ * same key" in the provenance window — meaning a version could be silently
+ * dropped or duplicated. Saved projects on disk already contain this shape.
+ */
+describe("TrillGenerator provenance ids are unique", () => {
+  beforeEach(() => {
+    TrillGenerator.reset();
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("gives two versions cut in the same millisecond distinct ids", () => {
+    jest.spyOn(Date, "now").mockReturnValue(1700000000000);
+
+    TrillGenerator.addNewVersionProvenance([], [], "wf", "", "Initial");
+    TrillGenerator.addNewVersionProvenance([], [], "wf", "", "Node added");
+
+    const ids = TrillGenerator.provenanceJSON.nodes.map((n: any) => n.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(Object.keys(TrillGenerator.list_of_trills)).toHaveLength(2);
+  });
+
+  it("never emits a self-loop edge, and keeps edge ids unique", () => {
+    jest.spyOn(Date, "now").mockReturnValue(1700000000000);
+
+    TrillGenerator.addNewVersionProvenance([], [], "wf", "", "Initial");
+    TrillGenerator.addNewVersionProvenance([], [], "wf", "", "Node added");
+    TrillGenerator.addNewVersionProvenance([], [], "wf", "", "Node deleted");
+
+    const edges = TrillGenerator.provenanceJSON.edges;
+    for (const edge of edges) {
+      expect(edge.source).not.toBe(edge.target);
+    }
+    const edgeIds = edges.map((e: any) => e.id);
+    expect(new Set(edgeIds).size).toBe(edgeIds.length);
+  });
+
+  it("keeps every version reachable by the id the graph reports", () => {
+    // TrillProvenanceWindow feeds the React Flow node id straight back into
+    // switchProvenanceTrill, so every graph id must be a versions key.
+    jest.spyOn(Date, "now").mockReturnValue(1700000000000);
+
+    TrillGenerator.addNewVersionProvenance([], [], "wf", "", "Initial");
+    TrillGenerator.addNewVersionProvenance([], [], "wf", "", "Node added");
+
+    for (const node of TrillGenerator.provenanceJSON.nodes) {
+      expect(TrillGenerator.list_of_trills[node.id]).toBeDefined();
+    }
+  });
+
+  it("still loads an old file whose ids carry no suffix", () => {
+    TrillGenerator.loadDataflowProvenance({
+      id: "wf",
+      latest: "wf_123",
+      graph: {
+        id: "wf",
+        nodes: [{ id: "wf_123", label: "wf (123)", timestamp: 123, preview: null }],
+        edges: [],
+      },
+      versions: { wf_123: { dataflow: { nodes: [], edges: [] } } },
+    });
+
+    expect(TrillGenerator.latestTrill).toBe("wf_123");
+    expect(TrillGenerator.list_of_trills["wf_123"]).toBeDefined();
+
+    // And a version cut after the load does not reuse the loaded key.
+    jest.spyOn(Date, "now").mockReturnValue(123);
+    TrillGenerator.addNewVersionProvenance([], [], "wf", "", "Node added");
+    expect(Object.keys(TrillGenerator.list_of_trills)).toHaveLength(2);
+  });
+});

--- a/utk_curio/frontend/urban-workflows/src/tests/components/escapeDefersToModal.test.ts
+++ b/utk_curio/frontend/urban-workflows/src/tests/components/escapeDefersToModal.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Every `window` Escape listener defers to an open modal.
+ *
+ * ModalShell routes Escape through a bubble-phase `window` listener, and
+ * `stopPropagation` cannot silence a peer listener registered on the same
+ * target first. So each surface that closes itself on Escape has to stand down
+ * on its own, by asking `modalStackDepth()`.
+ *
+ * Two of the four already did. The agent chat panel and the fork picker did
+ * not, and a modal opened over either one took it down too: AI Settings closed
+ * the chat panel behind it, and the fork picker collapsed under any dialog
+ * raised from the node dock.
+ *
+ * Read from disk rather than rendered, the same approach
+ * `catalog/canvasDrawerParity.test.ts` takes and for the same reason: rendering
+ * AgentChatPanel or ForkFamilyPicker for real needs most of the provider tree,
+ * while the assertion is only about a guard being present in the source.
+ */
+import fs from "fs";
+import path from "path";
+
+const SRC = path.resolve(__dirname, "../..");
+const read = (rel: string) => fs.readFileSync(path.join(SRC, rel), "utf8");
+
+/** Every file that closes something on a `window` keydown Escape. */
+const WINDOW_ESCAPE_LISTENERS = [
+  "components/packages/publishing/NodeCatalogDrawer.tsx",
+  "providers/AgentCatalogDrawerProvider.tsx",
+  "components/agents/attach/AgentChatPanel.tsx",
+  "components/packages/ForkFamilyPicker.tsx",
+];
+
+describe("window Escape listeners defer to an open modal", () => {
+  test.each(WINDOW_ESCAPE_LISTENERS)(
+    "%s stands down while a modal is open",
+    (file) => {
+      expect(read(file)).toContain("if (modalStackDepth() > 0) return;");
+    },
+  );
+
+  test.each(WINDOW_ESCAPE_LISTENERS)(
+    "%s still listens on window for Escape",
+    (file) => {
+      // If one of these moves off window, or stops handling Escape, the guard
+      // above is guarding nothing and this list has gone stale.
+      const source = read(file);
+      expect(source).toContain('window.addEventListener("keydown"');
+      expect(source).toContain('"Escape"');
+    },
+  );
+
+  test("ModalShell still exports the depth the guards read", () => {
+    // Two competing Escape implementations reached main in parallel and only
+    // one exports this. If the other ever comes back, every guard above
+    // silently stops compiling against it.
+    expect(read("components/ModalShell.tsx")).toContain(
+      "export function modalStackDepth()",
+    );
+  });
+});

--- a/utk_curio/frontend/urban-workflows/src/tests/components/modalShellDialog.test.tsx
+++ b/utk_curio/frontend/urban-workflows/src/tests/components/modalShellDialog.test.tsx
@@ -96,6 +96,20 @@ describe("ModalShell responds to Escape", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores other keys", () => {
+    // The listener sits on window, where every keystroke in the app arrives, so
+    // this is the cheap guard against it closing on Enter from a form inside
+    // the dialog.
+    const onClose = jest.fn();
+    render(
+      <ModalShell onClose={onClose} label="Example">
+        <p>body</p>
+      </ModalShell>,
+    );
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it("stops listening once unmounted", () => {
     const onClose = jest.fn();
     const view = render(
@@ -127,6 +141,33 @@ describe("ModalShell responds to Escape", () => {
     press();
     expect(first.mock.calls.length + second.mock.calls.length).toBe(1);
     expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a window listener that checks the depth stand down", () => {
+    // The behavioural half of `escapeDefersToModal.test.ts`. Four surfaces
+    // listen for Escape on window (both catalog drawers, the agent chat panel,
+    // the fork picker) and a peer registered before this one cannot be silenced
+    // by it, so each asks the depth and returns. This is that guard, run for
+    // real: registered first, exactly as a drawer that mounted first would be.
+    const drawerClose = jest.fn();
+    const onKey = () => {
+      if (modalStackDepth() > 0) return;
+      drawerClose();
+    };
+    window.addEventListener("keydown", onKey);
+    try {
+      const onClose = jest.fn();
+      render(
+        <ModalShell onClose={onClose} label="Example">
+          <p>body</p>
+        </ModalShell>,
+      );
+      press();
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(drawerClose).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("keydown", onKey);
+    }
   });
 
   it("reports its depth so the catalog drawers can stand down", () => {

--- a/utk_curio/frontend/urban-workflows/src/tests/components/modalShellDialog.test.tsx
+++ b/utk_curio/frontend/urban-workflows/src/tests/components/modalShellDialog.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import ModalShell from "../../components/ModalShell";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ModalShell, { modalStackDepth } from "../../components/ModalShell";
 
 /**
  * Modals are dialogs.
@@ -70,5 +70,90 @@ describe("ModalShell is announced as a dialog", () => {
       </ModalShell>,
     );
     expect(screen.getAllByRole("dialog")).toHaveLength(1);
+  });
+});
+
+/**
+ * Escape closes a dialog.
+ *
+ * ModalShell claimed `aria-modal="true"` while registering no keydown handler,
+ * so Escape did nothing — and because the backdrop covers the viewport and takes
+ * pointer events, the next click went to the backdrop and the application read
+ * as frozen. A user test hit this by reflexively pressing Escape and then could
+ * not open a menu at all.
+ */
+describe("ModalShell responds to Escape", () => {
+  const press = () => fireEvent.keyDown(window, { key: "Escape" });
+
+  it("closes on Escape", () => {
+    const onClose = jest.fn();
+    render(
+      <ModalShell onClose={onClose} label="Example">
+        <p>body</p>
+      </ModalShell>,
+    );
+    press();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops listening once unmounted", () => {
+    const onClose = jest.fn();
+    const view = render(
+      <ModalShell onClose={onClose} label="Example">
+        <p>body</p>
+      </ModalShell>,
+    );
+    view.unmount();
+    press();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes exactly one dialog when two are open", () => {
+    // Escape must not cascade. "On top" is read from document order, because
+    // every shell portals into document.body and the last node there is the one
+    // painted above the rest.
+    const first = jest.fn();
+    const second = jest.fn();
+    render(
+      <>
+        <ModalShell onClose={first} label="First">
+          <p>a</p>
+        </ModalShell>
+        <ModalShell onClose={second} label="Second">
+          <p>b</p>
+        </ModalShell>
+      </>,
+    );
+    press();
+    expect(first.mock.calls.length + second.mock.calls.length).toBe(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports its depth so the catalog drawers can stand down", () => {
+    // The Agent Catalog drawer renders AI Settings and agent import inside
+    // itself and listens for Escape on window. It mounted first, so the modal
+    // cannot stop its handler — the drawer checks this instead.
+    expect(modalStackDepth()).toBe(0);
+    const view = render(
+      <ModalShell onClose={jest.fn()} label="Example">
+        <p>body</p>
+      </ModalShell>,
+    );
+    expect(modalStackDepth()).toBe(1);
+    view.unmount();
+    expect(modalStackDepth()).toBe(0);
+  });
+
+  it("leaves a busy dialog alone", () => {
+    // NodeSaveAsModal and PackageMetadataModal pass `busy ? () => {} : onClose`.
+    // Routing Escape through onClose is what makes that work untouched.
+    const onClose = jest.fn();
+    render(
+      <ModalShell onClose={() => {}} label="Busy">
+        <p>saving</p>
+      </ModalShell>,
+    );
+    press();
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/utk_curio/frontend/urban-workflows/src/tests/components/nodeContainerBorder.test.tsx
+++ b/utk_curio/frontend/urban-workflows/src/tests/components/nodeContainerBorder.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * The node container must never mix the `border` shorthand with a `border*`
+ * longhand.
+ *
+ * It used to. `getNodeContainerStyles` supplied `borderLeft` (the node-type
+ * accent stripe) and the inline style added the `border` shorthand when
+ * dashboard mode was on, plus `borderWidth`/`borderStyle`/`borderColor` for a
+ * suggested node. Toggling dashboard mode therefore changed which of the two
+ * forms was present between renders, and React warned:
+ *
+ *   Warning: Removing a style property during rerender (border) when a
+ *   conflicting property is set (borderLeft) can lead to styling bugs.
+ *
+ * A recorded user test caught it as a console error on the Dashboard Mode
+ * toggle. Beyond the noise, mixing the two makes which border actually paints
+ * depend on property order.
+ *
+ * The fix resolves the whole border in this one function, so that is what is
+ * asserted here — rendering NodeContainer would need the entire provider tree
+ * and would test React wiring rather than the invariant.
+ */
+jest.mock("vega", () => ({}), { virtual: true });
+jest.mock("vega-lite", () => ({}), { virtual: true });
+jest.mock("../../hook/useVega", () => ({
+  useVega: () => ({ handleCompileGrammar: jest.fn() }),
+}));
+
+import { getNodeContainerStyles } from "../../components/styles";
+
+const STATES: Array<{ name: string; state: Parameters<typeof getNodeContainerStyles>[1] }> = [
+  { name: "on the canvas", state: {} },
+  { name: "in dashboard mode", state: { dashboardOn: true } },
+  { name: "as a suggestion", state: { suggested: true } },
+  { name: "as an acceptable suggestion", state: { suggested: true, acceptable: true } },
+  { name: "suggested inside dashboard mode", state: { dashboardOn: true, suggested: true } },
+];
+
+describe("getNodeContainerStyles", () => {
+  test.each(STATES)("declares no border shorthand $name", ({ state }) => {
+    const style = getNodeContainerStyles("curio.builtin/data-loading", state);
+    // `border` and `borderRadius` are different properties; only the former is
+    // the shorthand that conflicts with the longhands.
+    expect(style).not.toHaveProperty("border");
+  });
+
+  test("keeps the node-type accent stripe on the canvas", () => {
+    const style = getNodeContainerStyles("curio.builtin/data-loading", {});
+    expect(style.borderLeftWidth).toBe("4px");
+    expect(style.borderLeftStyle).toBe("solid");
+    expect(style.borderLeftColor).toBeTruthy();
+  });
+
+  test("frames the node uniformly in dashboard mode", () => {
+    const style = getNodeContainerStyles("curio.builtin/data-loading", { dashboardOn: true });
+    expect(style.borderStyle).toBe("solid");
+    expect(style.borderColor).toBe("#000");
+    expect(style.borderWidth).toBe("2px");
+    expect(style.boxShadow).toBe("none");
+  });
+
+  test("resolves a versioned node type to the same accent as an unversioned one", () => {
+    // Palette-dragged nodes persist `...@1`; an unnormalised lookup used to fall
+    // back to grey (#159).
+    const plain = getNodeContainerStyles("curio.builtin/data-loading", {});
+    const versioned = getNodeContainerStyles("curio.builtin/data-loading@1", {});
+    expect(versioned.borderLeftColor).toBe(plain.borderLeftColor);
+  });
+});

--- a/utk_curio/frontend/urban-workflows/src/tests/components/toolsPaletteNames.test.tsx
+++ b/utk_curio/frontend/urban-workflows/src/tests/components/toolsPaletteNames.test.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+/**
+ * Every built-in palette tile must have an accessible name.
+ *
+ * A user test found ten of the twelve tiles unnamed: `DraggableTool` rendered an
+ * icon inside a bare `<div id={tutorialID}>`, so there was no `aria-label`, no
+ * `title` and no text content — the hover tooltip was the only label, and four
+ * tiles had no `id` either because the builtin manifest gave them no
+ * `tutorialId`. The node rail is the primary way to author anything, so it being
+ * invisible to assistive technology is the whole feature being unreachable.
+ *
+ * The sibling test file (toolsPalette.test.tsx) stubs the descriptor registry to
+ * an empty list to test palette coordination, which is why it never rendered a
+ * tile and could not catch this.
+ */
+
+const paletteStub = (name: string) =>
+    function Stub() {
+        return <div data-testid={`${name}-stub`} />;
+    };
+
+jest.mock("../../components/menus/nodes/datasetPalette", () => ({
+    DatasetsPaletteDropdown: paletteStub("datasets"),
+}));
+jest.mock("../../components/menus/nodes/agentsPalette", () => ({
+    AgentsPaletteDropdown: paletteStub("agents"),
+}));
+jest.mock("../../components/menus/nodes/toolsMenuPackagePalette", () => ({
+    PackagesPaletteDropdown: paletteStub("packages"),
+    groupPalettePackages: () => [],
+    paletteDescriptorBootstrapKey: () => "",
+    OVERLAY_TRIGGER_DELAY_PROPS: {},
+}));
+
+/** The twelve built-in templates, as packages/curio.builtin@1/manifest.json has them.
+ *  Prefixed `mock` so jest's hoisted mock factory may reference it. */
+const mockBuiltin = [
+    { id: "curio.builtin/data-loading", label: "Data Loading", category: "data", tutorialId: "step-loading" },
+    { id: "curio.builtin/data-export", label: "Data Export", category: "data", tutorialId: "step-export" },
+    { id: "curio.builtin/data-transformation", label: "Data Transformation", category: "data", tutorialId: "step-transformation" },
+    { id: "curio.builtin/spatial-join", label: "Spatial Join", category: "data", tutorialId: "step-spatial-join" },
+    { id: "curio.builtin/merge-flow", label: "Merge Flow", category: "flow", tutorialId: "step-merge" },
+    { id: "curio.builtin/data-pool", label: "Data Pool", category: "data", tutorialId: "step-pool" },
+    { id: "curio.builtin/computation-analysis", label: "Python Computation", category: "computation", tutorialId: "step-analysis" },
+    { id: "curio.builtin/data-summary", label: "Data Summary", category: "computation", tutorialId: "step-summary" },
+    { id: "curio.builtin/js-computation", label: "JS Computation", category: "computation", tutorialId: "step-js" },
+    { id: "curio.builtin/autk-grammar", label: "Autark", category: "vis_grammar", tutorialId: "step-utk", badge: "AUTK" },
+    { id: "curio.builtin/vis-vega", label: "Vega-Lite", category: "vis_grammar", tutorialId: "step-vega", badge: "VEGA" },
+    { id: "curio.builtin/vis-simple", label: "Simple View", category: "vis_simple", tutorialId: "step-image" },
+];
+
+jest.mock("../../registry", () => ({
+    getPaletteNodeTypes: () =>
+        mockBuiltin.map((t) => ({
+            ...t,
+            // Required inside the factory: jest hoists mock factories above the
+            // imports, so an out-of-scope binding is a ReferenceError.
+            icon: require("@fortawesome/free-solid-svg-icons").faUpload,
+            package: { packageId: "curio.builtin" },
+        })),
+    subscribeToRegistry: () => () => {},
+}));
+jest.mock("../../registry/packagesClient", () => ({ BUILTIN_PACKAGE_ID: "curio.builtin" }));
+jest.mock("../../api/packagesApi", () => ({ refreshPackageRegistry: jest.fn() }));
+jest.mock("../../providers/FlowProvider", () => ({
+    useFlowContext: () => ({ playAllNodes: jest.fn() }),
+}));
+jest.mock("../../providers/UserProvider", () => ({
+    useUserContext: () => ({ user: { id: 1 } }),
+}));
+
+import ToolsMenu from "../../components/menus/nodes/ToolsMenu";
+
+describe("built-in palette tiles are named", () => {
+    test("every tile is findable by its manifest label", () => {
+        render(<ToolsMenu />);
+        for (const template of mockBuiltin) {
+            expect(
+                screen.getByLabelText(template.label),
+                // jest prints the label on failure, which is the useful part.
+            ).toBeTruthy();
+        }
+    });
+
+    test("no tile is left with an empty accessible name", () => {
+        const { container } = render(<ToolsMenu />);
+        const tiles = Array.from(
+            container.querySelectorAll<HTMLElement>("div[draggable='true']"),
+        );
+        expect(tiles).toHaveLength(mockBuiltin.length);
+        for (const tile of tiles) {
+            const name =
+                tile.getAttribute("aria-label") ||
+                tile.getAttribute("title") ||
+                (tile.textContent ?? "").trim();
+            expect(name).not.toBe("");
+        }
+    });
+
+    test("every tile carries the manifest's tutorial anchor id", () => {
+        // Four templates had no tutorialId, so those tiles rendered with no id
+        // at all. The in-app tutorial only queries the eight anchors it names,
+        // so adding the rest is additive.
+        const { container } = render(<ToolsMenu />);
+        for (const template of mockBuiltin) {
+            expect(container.querySelector(`#${template.tutorialId}`)).not.toBeNull();
+        }
+    });
+});

--- a/utk_curio/frontend/urban-workflows/src/tests/providers/playNodesUpToStale.test.tsx
+++ b/utk_curio/frontend/urban-workflows/src/tests/providers/playNodesUpToStale.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * `playNodesUpTo` must re-run an ancestor whose code changed since it ran.
+ *
+ * The bug this pins: the ancestor filter asked only whether a node's *last run*
+ * succeeded. Edit an upstream node's code, press play on a downstream one, and
+ * the upstream was skipped — so the downstream node consumed the artifact the
+ * pre-edit code had produced and reported success. For a tool built around
+ * provenance, that attributes a result to source which can no longer produce it.
+ *
+ * `executedCode` (mirrored onto node data by useNodeState whenever a run
+ * succeeds) is the source that produced the current output, so comparing it
+ * against `data.code` distinguishes a valid cache from a stale one.
+ *
+ * Drives the real FlowProvider, mirroring src/tests/providers/playAllFlakiness.test.tsx.
+ */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { ReactFlow, ReactFlowProvider } from 'reactflow';
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as any).ResizeObserver = ResizeObserverStub;
+if (!(global as any).DOMMatrixReadOnly) {
+  (global as any).DOMMatrixReadOnly = class { m22 = 1; constructor() {} };
+}
+
+jest.mock('../../hook/useWorkflowOperations', () => ({
+  useWorkflowOperations: () => ({
+    markNodeExecuted: jest.fn(),
+    markNodeStale: jest.fn(),
+    markDirty: jest.fn(),
+    persistDataflowForInstall: jest.fn().mockResolvedValue(undefined),
+    beginPendingInstall: jest.fn(),
+    endPendingInstall: jest.fn(),
+    applyRemoveChanges: jest.fn(),
+    applyReviewedRemovals: jest.fn(),
+    allMinimized: false,
+    setAllMinimized: jest.fn(),
+    expandStatus: {},
+    setExpandStatus: jest.fn(),
+    updateDataNode: jest.fn(),
+    updateDefaultCode: jest.fn(),
+    workflowGoal: '',
+    acceptSuggestion: jest.fn(),
+  }),
+}));
+
+jest.mock('../../providers/ToastProvider', () => ({
+  useToastContext: () => ({ showToast: jest.fn() }),
+}));
+
+jest.mock('../../providers/CollaborationProvider', () => ({
+  useCollab: () => ({
+    enabled: false,
+    lockedNodes: {},
+    currentUserId: null,
+    lockNode: jest.fn(),
+    unlockNode: jest.fn(),
+    broadcastNodeAdded: jest.fn(),
+    broadcastNodeRemoved: jest.fn(),
+    broadcastNodeUpdated: jest.fn(),
+    broadcastEdgeAdded: jest.fn(),
+    broadcastEdgeRemoved: jest.fn(),
+    signalExecDisplay: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hook/useCode', () => ({
+  pythonInterpreter: {},
+  jsInterpreter: {},
+}));
+
+// FlowProvider -> ConnectionValidator -> registry -> vegaBehavior -> useVega
+// pulls in vega (ESM). Stub it so the registry loads under jest.
+jest.mock('../../hook/useVega', () => ({
+  useVega: () => ({ handleCompileGrammar: jest.fn().mockResolvedValue(undefined) }),
+}));
+jest.mock('vega', () => ({}), { virtual: true });
+jest.mock('vega-lite', () => ({}), { virtual: true });
+
+import FlowProvider, { useFlowContext } from '../../providers/FlowProvider';
+
+type FlowApi = ReturnType<typeof useFlowContext>;
+let api: FlowApi;
+
+const Bridge: React.FC = () => {
+  const ctx = useFlowContext();
+  api = ctx;
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <ReactFlow
+        nodes={ctx.nodes}
+        edges={ctx.edges}
+        onNodesChange={ctx.onNodesChange}
+        onEdgesChange={ctx.onEdgesChange}
+      />
+    </div>
+  );
+};
+
+function renderFlow() {
+  return render(
+    <ReactFlowProvider>
+      <FlowProvider>
+        <Bridge />
+      </FlowProvider>
+    </ReactFlowProvider>,
+  );
+}
+
+/** A node that has already run successfully, from the given source. */
+function ranNode(id: string, code: string, executedCode: string = code) {
+  return {
+    id,
+    type: 'curio.builtin/data-loading',
+    position: { x: 0, y: 0 },
+    data: {
+      nodeId: id,
+      nodeType: 'curio.builtin/data-loading',
+      code,
+      executedCode,
+      output: { code: 'success', content: '' },
+    },
+  } as any;
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function seed(nodes: any[], edges: Array<[string, string]>) {
+  await act(async () => {
+    nodes.forEach((n) => api.addNode(n, undefined, false));
+  });
+  await flush();
+  for (const [source, target] of edges) {
+    await act(async () => {
+      api.onEdgesChange([
+        {
+          type: 'add',
+          item: { id: `${source}->${target}`, source, target, sourceHandle: 'out', targetHandle: 'in' },
+        } as any,
+      ]);
+    });
+    await flush();
+  }
+}
+
+function triggerExecOf(id: string): number {
+  const n = api.nodes.find((x: any) => x.id === id);
+  return (n?.data?.triggerExec as number) ?? 0;
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('playNodesUpTo — stale ancestors', () => {
+  test('skips an ancestor whose code still matches what it ran', async () => {
+    renderFlow();
+    await flush();
+    await seed([ranNode('A', 'return 1'), ranNode('B', 'return arg')], [['A', 'B']]);
+
+    await act(async () => {
+      api.playNodesUpTo('B');
+    });
+    await flush();
+
+    // A is a valid cache: only the target runs, in level 0.
+    expect(triggerExecOf('A')).toBe(0);
+    expect(triggerExecOf('B')).toBe(1);
+  });
+
+  test('re-runs an ancestor whose code changed since it ran', async () => {
+    renderFlow();
+    await flush();
+    await seed(
+      [ranNode('A', 'return 2', 'return 1'), ranNode('B', 'return arg')],
+      [['A', 'B']],
+    );
+
+    await act(async () => {
+      api.playNodesUpTo('B');
+    });
+    await flush();
+
+    // A is stale, so it leads the run and B waits for it.
+    expect(triggerExecOf('A')).toBe(1);
+    expect(triggerExecOf('B')).toBe(0);
+  });
+
+  test('invalidation is transitive through a clean intermediate node', async () => {
+    renderFlow();
+    await flush();
+    await seed(
+      [
+        ranNode('A', 'return 2', 'return 1'), // edited
+        ranNode('B', 'return arg'), // clean, but fed by A
+        ranNode('C', 'return arg'), // the target
+      ],
+      [
+        ['A', 'B'],
+        ['B', 'C'],
+      ],
+    );
+
+    await act(async () => {
+      api.playNodesUpTo('C');
+    });
+    await flush();
+
+    // B must not be skipped: it would hand C the artifact it produced from A's
+    // old output while A recomputes a new one.
+    expect(triggerExecOf('A')).toBe(1);
+    expect(triggerExecOf('B')).toBe(0);
+    expect(triggerExecOf('C')).toBe(0);
+
+    await act(async () => {
+      api.signalNodeExecDone('A');
+    });
+    await flush();
+    expect(triggerExecOf('B')).toBe(1);
+  });
+
+  test('a second play while one is running is ignored', async () => {
+    renderFlow();
+    await flush();
+    await seed([ranNode('A', 'return 2', 'return 1'), ranNode('B', 'return arg')], [['A', 'B']]);
+
+    await act(async () => {
+      api.playNodesUpTo('B');
+      api.playNodesUpTo('B');
+    });
+    await flush();
+
+    // Without the re-entrancy guard the second call reset the run state and
+    // orphaned the level already in flight.
+    expect(triggerExecOf('A')).toBe(1);
+  });
+});

--- a/utk_curio/frontend/urban-workflows/src/tests/registry/packageRegistryBootstrapAuth.test.ts
+++ b/utk_curio/frontend/urban-workflows/src/tests/registry/packageRegistryBootstrapAuth.test.ts
@@ -1,0 +1,55 @@
+/**
+ * The package registry must not be fetched before anyone is signed in.
+ *
+ * `/api/packages` is `@require_auth` and its response is per-user, so an
+ * anonymous call can only 401. `loadInstalledPackages` already suppressed its
+ * own console warning for that status — but the request still went out, and the
+ * browser logs "Failed to load resource: 401" itself. Because `index.tsx` called
+ * this at import time, that error greeted every visitor on the sign-up page,
+ * which is the first screen a new user sees.
+ */
+const mockLoadInstalledPackages = jest.fn().mockResolvedValue([]);
+const mockGetToken = jest.fn<string | undefined, []>();
+
+// The factories delegate rather than capture: jest hoists them above the consts
+// above, so a direct reference is still undefined when the module is evaluated.
+jest.mock('../../registry/packagesClient', () => ({
+  loadInstalledPackages: (...args: unknown[]) => mockLoadInstalledPackages(...args),
+}));
+jest.mock('../../registry/projectPackagesStore', () => ({
+  getCurrentProjectPackages: () => [],
+}));
+jest.mock('../../utils/authApi', () => ({
+  getToken: () => mockGetToken(),
+}));
+
+import { refreshPackageRegistry } from '../../registry/packageRegistryBootstrap';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('refreshPackageRegistry', () => {
+  it('makes no request when there is no session token', async () => {
+    mockGetToken.mockReturnValue(undefined);
+
+    await refreshPackageRegistry();
+
+    expect(mockLoadInstalledPackages).not.toHaveBeenCalled();
+  });
+
+  it('fetches once a session token exists', async () => {
+    mockGetToken.mockReturnValue('a-session-token');
+
+    await refreshPackageRegistry();
+
+    expect(mockLoadInstalledPackages).toHaveBeenCalledTimes(1);
+  });
+
+  it('still resolves when it skips the fetch', async () => {
+    // Callers `void` this or chain off it; returning undefined would throw.
+    mockGetToken.mockReturnValue(undefined);
+
+    await expect(refreshPackageRegistry()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes the defects found by five recorded exploratory user-test sessions against
0.16.15, one commit per defect. Exploration while planning turned up a seventh
(exported notebook cells never bind `arg`), which was hidden behind the broken
`return` and would have surfaced the moment that was fixed.

## What was wrong

| | Defect | Cause |
|---|---|---|
| 1 | Notebook export dropped most node types, and the cells it did emit could not run | `generateCell` handled only `DATA_LOADING`/`COMPUTATION_ANALYSIS`/`VIS_VEGA` and returned `null` otherwise; cells carried the node body verbatim, so they ended in a top-level `return` (a `SyntaxError`) and referenced an unbound `arg` |
| 2 | A node kept its stale result after its code changed | `playNodesUpTo` skipped any ancestor whose *last run* succeeded, with no comparison against the node's current source |
| 3 | Escape did not close a modal, and its backdrop then blocked the app | `ModalShell` declared `role="dialog" aria-modal="true"` with no keydown handler |
| 4 | Provenance version ids collided | ids were `<name>_<timestamp>` at millisecond resolution — colliding ids are already present in saved projects on disk |
| 5 | Ten of twelve palette tiles had no accessible name | the tile was an icon `div` with no `aria-label`, `title` or text; four had no `id` either |
| 6 | A console 401 greeted every visitor on the sign-up page | `refreshPackageRegistry()` ran at import time and `/api/packages` requires auth |
| 7 | Dashboard Mode logged a React style warning | `border` shorthand layered over a `borderLeft` longhand, changing between renders |
| 8 | Refusing to delete a wired node did not say what was in the way | message named neither the count nor which connections |

## Notes on the fixes

**Notebook export** reproduces each node's own function rather than rewriting
`return` textually:

```python
def node_<id>(arg):
    <body>

<out> = node_<id>(<upstream>)
```

That inverts the sandbox contract exactly (`PythonInterpreter` indents the body
and the sandbox execs it as `def userCode(arg):`), and survives the multi-line
and early returns a textual rewrite would mangle. Node kinds a Python kernel
cannot run — Autark grammars, JS computations, spatial joins, presentational
nodes — become markdown placeholders naming the node and its inputs, so nothing
is dropped silently.

**Stale results** are detected by comparing content, not by a dirty flag. Curio's
Monaco editors are uncontrolled and `useMonacoExternalValue` applies external
content with `executeEdits`, so a project load re-enters the change handler in a
real browser; a flag set there would mark every node dirty right after loading.
`useNodeState` records the source that produced the current successful output and
`playNodesUpTo` compares against it, propagating the decision transitively so a
clean intermediate node cannot pass an old artifact downstream. A re-entrancy
guard is included, matching `playAllNodes` — without it a second play click
overwrites the run state, and the e2e helper retries its click three times.

**Provenance ids** keep the documented `<name>_<timestamp>` form and gain a
`_<n>` suffix only on collision, so older saved specs load unchanged. Self-loop
edges are no longer emitted. `trill.v1.json`'s two id descriptions are updated.

Behaviour deliberately unchanged: deleting a node with edges is still refused —
that is intentional (`MainCanvas.handleNodesChange`) and only the message
improves.

## Verification

- **Jest: 140 suites, 1561 tests green.** Typecheck and lint clean on every commit.
- 30 new unit tests, placed where the logic lives. Each was confirmed to **fail
  on the old code**: 8/8 for the notebook, 3/4 for stale results, 3/4 for
  provenance ids, 2/3 for palette names.
- One new e2e test closes the gap that made the delete behaviour look like a bug:
  `test_canvas_delete_key_e2e.py`'s existing tests pass only because they never
  wire their nodes. Three tests in that file pass.
- Three recorded-session steps were promoted from observations to assertions
  (notebook coverage and runnability, the stale chain, Escape).
- Two latent harness traps fixed: `get_by_text("Load dataflow")` matches both the
  File-menu row and the button inside it (a strict-mode violation waiting to
  happen in `utils.upload_workflow`), and the notebook step asserted only that a
  `cells` key existed, so a zero-cell export passed it.

**Browser verification is partial.** 18 e2e tests passed against a bundle
verified to contain these changes, including canvas authoring, the Autark grammar
edit and the agent catalog. The full suite could not complete on the machine used
here: Curio stacks are terminated after a few minutes regardless of who starts
them, and the resulting failures carry the harness's own `"the backend may not be
up"` message. Worth a run on CI.
