### PR TITLE
Seed examples for registered users (#200)

### DIFF
--- a/utk_curio/backend/app/projects/seed.py
+++ b/utk_curio/backend/app/projects/seed.py
@@ -14,6 +14,7 @@ from utk_curio.backend.app.projects import storage
 from utk_curio.backend.app.projects.models import Project
 from utk_curio.backend.app.projects.schemas import VALID_ACCENTS, _slugify
 from utk_curio.backend.app.projects.services import _is_shared_guest, _user_dir_key
+from utk_curio.backend.config import _env_flag
 
 logger = logging.getLogger(__name__)
 
@@ -71,11 +72,25 @@ def _description_from_spec(spec: dict) -> Optional[str]:
     return None
 
 
-def _example_id(stem: str) -> str:
-    return str(uuid.uuid5(_EXAMPLES_NAMESPACE, stem))
+def _example_id(stem: str, user=None) -> str:
+    """The deterministic project id for one example, scoped to ``user``.
+
+    ``Project.id`` is a **global** primary key, so a namespace keyed on the
+    filename alone gives every user the same ids. Seeding a second account then
+    takes the insert branch with an id that already exists, raises an
+    IntegrityError, and the caller's broad ``except`` swallows it into a silent
+    zero-seed (#200).
+
+    The shared guest keeps the bare-stem id so installs seeded before this
+    change still upsert their existing rows rather than growing a duplicate set
+    beside them.
+    """
+    if user is None or _is_shared_guest(user):
+        return str(uuid.uuid5(_EXAMPLES_NAMESPACE, stem))
+    return str(uuid.uuid5(_EXAMPLES_NAMESPACE, f"{user.id}:{stem}"))
 
 
-def seed_example_projects(user) -> int:
+def seed_example_projects(user, *, prune: bool | None = None) -> int:
     """Seed/refresh example projects for ``user`` from docs/examples/.
 
     Each example JSON gets a deterministic project_id derived from its
@@ -83,12 +98,19 @@ def seed_example_projects(user) -> int:
     (overwrite semantics) without ever colliding with user-created
     projects (which use random uuid4s).
     """
-    if not _is_shared_guest(user):
-        logger.warning(
-            "seed_example_projects refused: user %r is not the shared guest",
-            getattr(user, "username", None),
-        )
-        return 0
+    # Registered accounts get their own copies (#200). Under ``--auth`` the
+    # signed-in user is not the guest that owned the seeded rows, so the
+    # gallery came up empty for everyone with an account; ``--deploy`` carried
+    # the identical defect. The dataset half of this was already fixed in
+    # services.py and the project half never was.
+    is_guest = _is_shared_guest(user)
+
+    # Pruning is destructive - it deletes every project of the seeded user that
+    # is not an example, storage tree included. That is the right posture for
+    # the shared guest, whose projects are disposable scratch, and catastrophic
+    # for a registered account. Default to the guest's behaviour exactly.
+    if prune is None:
+        prune = is_guest
 
     examples_dir = _repo_root() / "docs" / "examples"
     if not examples_dir.exists():
@@ -97,7 +119,7 @@ def seed_example_projects(user) -> int:
 
     ukey = _user_dir_key(user)
     seeded = 0
-    keep_ids = {_example_id(p.stem) for p in _example_files(examples_dir)}
+    keep_ids = {_example_id(p.stem, user) for p in _example_files(examples_dir)}
 
     for i, json_path in enumerate(_example_files(examples_dir)):
         try:
@@ -107,7 +129,7 @@ def seed_example_projects(user) -> int:
             continue
 
         stem = json_path.stem
-        project_id = _example_id(stem)
+        project_id = _example_id(stem, user)
         name = _name_from_spec(spec) or _name_from_stem(stem)
         description = _description_from_spec(spec)
         accent = _ACCENT_CYCLE[i % len(_ACCENT_CYCLE)]
@@ -164,10 +186,52 @@ def seed_example_projects(user) -> int:
     if seeded:
         db.session.commit()
 
-    pruned = _prune_non_example_projects(user, ukey, keep_ids)
-    if pruned:
-        logger.info("Pruned %d non-example guest project(s)", pruned)
+    if prune:
+        pruned = _prune_non_example_projects(user, ukey, keep_ids)
+        if pruned:
+            logger.info("Pruned %d non-example guest project(s)", pruned)
 
+    return seeded
+
+
+def _seeded_marker(ukey: str) -> Path:
+    return storage.user_dir(ukey) / "examples.seeded"
+
+
+def ensure_user_examples_seeded(user) -> int:
+    """Give ``user`` their copy of the examples, once, on first listing.
+
+    Seeding happens at sign-up, but that only covers accounts created after
+    this shipped. Everyone who registered before it - and the shared guest on
+    a stack started without ``--with-examples`` - would still see an empty
+    gallery, so the listing back-fills the same way packages and datasets
+    already self-heal per user.
+
+    The marker is what keeps it a back-fill rather than a reset: an example the
+    user deliberately deleted must stay deleted, and without a marker every
+    listing would resurrect it. Pruning is never enabled here.
+    """
+    # Read at call time, not import time, so the launcher's value is honoured
+    # and a test can flip it. Default off, matching ``config.CURIO_SEED_EXAMPLES``:
+    # a stack started without ``--with-examples`` seeds nobody, exactly as before.
+    if not _env_flag("CURIO_SEED_EXAMPLES"):
+        return 0
+    ukey = _user_dir_key(user)
+    marker = _seeded_marker(ukey)
+    if marker.exists():
+        return 0
+    try:
+        seeded = seed_example_projects(user, prune=False)
+    except Exception:
+        logger.exception("Back-filling examples failed for user %s", user.id)
+        return 0
+    # Written even for a zero-seed: a missing examples directory is not a
+    # reason to retry the whole walk on every listing.
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(str(seeded), encoding="utf-8")
+    except OSError:
+        logger.exception("Could not write the examples marker at %s", marker)
     return seeded
 
 

--- a/utk_curio/backend/app/projects/services.py
+++ b/utk_curio/backend/app/projects/services.py
@@ -791,6 +791,15 @@ def load_shared_project(project_id: str) -> dict:
 def list_projects(
     user, scope: str = "mine", sort: str = "last_opened"
 ) -> List[ProjectSummary]:
+    # The examples are seeded per user at sign-up; this back-fills anyone who
+    # registered before that shipped, so the gallery is never empty under
+    # ``--auth`` (#200). Idempotent behind a marker file, so an example the user
+    # deleted on purpose is not resurrected on the next listing. Imported here
+    # rather than at module scope: ``seed`` imports this module for
+    # ``_is_shared_guest`` / ``_user_dir_key``.
+    from utk_curio.backend.app.projects.seed import ensure_user_examples_seeded
+
+    ensure_user_examples_seeded(user)
     projects = repo.list_for_user(user.id, scope=scope, sort=sort)
     ukey = _user_dir_key(user)
     summaries = []

--- a/utk_curio/backend/app/projects/storage.py
+++ b/utk_curio/backend/app/projects/storage.py
@@ -88,6 +88,11 @@ def ensure_project_dir(user_key: str, project_id: str) -> Path:
     return d
 
 
+def user_dir(user_key: str) -> Path:
+    """The user's own root under ``.curio/users/``."""
+    return safe_join(_users_base(), _user_key_segment(user_key), field="user_key")
+
+
 # ---------------------------------------------------------------------------
 # Spec I/O
 # ---------------------------------------------------------------------------

--- a/utk_curio/backend/app/users/services.py
+++ b/utk_curio/backend/app/users/services.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from utk_curio.backend.extensions import db
 from utk_curio.backend.app.users.models import User
 from utk_curio.backend.app.users.schemas import (
@@ -17,6 +19,9 @@ from utk_curio.backend.config import (
     CURIO_SHARED_GUEST_NAME,
     CURIO_SHARED_GUEST_USERNAME,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 class AuthError(Exception):
@@ -92,6 +97,17 @@ def signup(data: SignUpIn) -> AuthOut:
         password_hash=security.hash_password(data.password),
         type="programmer",
     )
+    # A new account lands on an empty gallery otherwise: the examples were
+    # seeded to the shared guest only, and listing is a plain owner filter, so
+    # under ``--auth`` nobody with an account ever saw them (#200). Best-effort
+    # - a failed seed must never cost the user their sign-up, and
+    # ``list_projects`` back-fills on the next listing anyway.
+    from utk_curio.backend.app.projects.seed import ensure_user_examples_seeded
+
+    try:
+        ensure_user_examples_seeded(user)
+    except Exception:
+        logger.exception("Seeding examples at sign-up failed for %s", user.username)
     return _auth_out(user)
 
 

--- a/utk_curio/backend/tests/test_frontend/fixtures.py
+++ b/utk_curio/backend/tests/test_frontend/fixtures.py
@@ -289,6 +289,14 @@ def curio_servers(session_app, request):
     # flips the per-node toggle in the UI, because "the user turned it on" is the
     # scenario #180 reports.
     extra_args.append("--save-node-outputs")
+    # The examples are what #200 was about, and the gap that let it through:
+    # this harness launched with ``--auth`` but never ``--with-examples``, so
+    # the one configuration where the gallery came up empty was the one
+    # configuration never tested. Opt-in rather than always-on because seeding
+    # eleven dataflows (and provisioning the datasets they reference) costs
+    # real time on every boot, and only the tests that read the gallery need it.
+    if env.get("CURIO_E2E_WITH_EXAMPLES", "0") in ("1", "true", "yes", "on"):
+        extra_args.append("--with-examples")
     # Replay the whole e2e suite against isolated node execution by setting
     # CURIO_E2E_ISOLATION=fork. Off by default, and deliberately so: the
     # confinement path is not yet verified anywhere, so turning it on for every

--- a/utk_curio/backend/tests/test_frontend/test_examples_for_registered_users_e2e.py
+++ b/utk_curio/backend/tests/test_frontend/test_examples_for_registered_users_e2e.py
@@ -1,0 +1,138 @@
+"""Playwright E2E: a signed-up account's gallery lists the example dataflows (#200).
+
+The examples were seeded to exactly one user - the shared guest - and project
+listing is a plain owner filter, so under ``--auth`` every account signed in to
+an empty gallery. ``--deploy`` carried the identical defect.
+
+The reason nothing caught it is visible in ``fixtures.py``: the harness launched
+with ``--auth`` but never ``--with-examples``, so the one configuration where
+the gallery is empty was the one configuration never exercised. This module
+turns the flag on (``CURIO_E2E_WITH_EXAMPLES``) and walks the reporter's path -
+create an account, land on /projects, read what is there.
+
+Cheaper coverage that already exists, and what this adds on top of it:
+
+* ``tests/test_projects/test_example_seed_for_registered_users.py`` covers the
+  seeding itself, both landmines (the global primary key, the destructive
+  prune), idempotence and the marker that stops a deleted example coming back.
+* ``tests/test_projects/test_routes.py`` covers ``GET /api/projects`` answering
+  with the examples for a registered user's token.
+* ``test_scripts/test_launcher_env.py`` pins ``--auth --with-examples`` to the
+  two env vars.
+
+None of those boot a browser against a real ``curio.py start``, which is where
+the defect actually lived: seeding at startup, an account created afterwards,
+and a listing filtered by owner are three separate pieces that were each
+individually correct.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .utils import (
+    require_project_page,
+    require_user_auth,
+    save_workflow_test_screenshot,
+    signup_e2e_user,
+    wait_for_projects_page,
+)
+
+if TYPE_CHECKING:
+    from .utils import FrontendPage
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("CURIO_E2E_WITH_EXAMPLES", "0") not in ("1", "true", "yes", "on"),
+    reason=(
+        "needs a stack started with --with-examples; set CURIO_E2E_WITH_EXAMPLES=1 "
+        "(seeding eleven dataflows costs real boot time, so it is opt-in)"
+    ),
+)
+
+#: A handful of the curated examples, by the ``dataflow.name`` the seeder uses
+#: as the project title. Named rather than counted so adding a twelfth example
+#: does not break this, and so a gallery full of *something else* still fails.
+EXPECTED_EXAMPLES = [
+    "Vega-Lite chained transforms",
+    "Vega-Lite spatial density",
+]
+
+
+def test_a_new_account_lands_on_a_gallery_of_examples(
+    app_frontend: "FrontendPage", frontend_server: str, page
+):
+    require_user_auth()
+    require_project_page()
+
+    # A fresh username per run: the account is what the test is about, and
+    # reusing one would pass on the second run for the wrong reason.
+    username = f"examples_{uuid.uuid4().hex[:10]}"
+    signup_e2e_user(page, frontend_server, name="Examples User", username=username)
+    wait_for_projects_page(page, timeout=30000)
+
+    # THE POINT: this list was empty for every registered account.
+    for name in EXPECTED_EXAMPLES:
+        page.get_by_text(name, exact=True).first.wait_for(
+            state="visible", timeout=30000
+        )
+
+    cards = page.locator("[data-project-id]")
+    assert cards.count() >= len(EXPECTED_EXAMPLES), (
+        f"the gallery holds {cards.count()} project(s); the examples were not seeded "
+        "for this account"
+    )
+
+    save_workflow_test_screenshot(
+        page,
+        "examples-gallery-registered-user",
+        test_name="test_a_new_account_lands_on_a_gallery_of_examples",
+        fit_reactflow=False,
+    )
+
+
+def test_each_account_gets_its_own_copy(
+    app_frontend: "FrontendPage", frontend_server: str, page, context
+):
+    """Two accounts, two disjoint sets of project ids.
+
+    ``Project.id`` is a global primary key and the example ids were derived
+    from the filename alone, so the second account's seed collided on insert -
+    an IntegrityError swallowed by a broad ``except`` into a silent zero-seed.
+    Reading the ids from two browsers is what makes the collision visible.
+    """
+    require_user_auth()
+    require_project_page()
+
+    def ids_for_a_new_account(target_page) -> set[str]:
+        username = f"examples_{uuid.uuid4().hex[:10]}"
+        signup_e2e_user(
+            target_page, frontend_server, name="Examples User", username=username
+        )
+        wait_for_projects_page(target_page, timeout=30000)
+        target_page.get_by_text(EXPECTED_EXAMPLES[0], exact=True).first.wait_for(
+            state="visible", timeout=30000
+        )
+        return set(
+            target_page.locator("[data-project-id]").evaluate_all(
+                "els => els.map(e => e.getAttribute('data-project-id'))"
+            )
+        )
+
+    first = ids_for_a_new_account(page)
+
+    second_page = context.new_page()
+    try:
+        second = ids_for_a_new_account(second_page)
+    finally:
+        second_page.close()
+
+    assert first, "the first account's gallery was empty"
+    assert second, "the second account's gallery was empty"
+    assert first.isdisjoint(second), (
+        "both accounts were served the same project ids, so they are sharing "
+        f"one set of rows rather than owning a copy each: {sorted(first & second)}"
+    )

--- a/utk_curio/backend/tests/test_frontend/walkthroughs.py
+++ b/utk_curio/backend/tests/test_frontend/walkthroughs.py
@@ -26,12 +26,18 @@ from __future__ import annotations
 import json
 import os
 import re
+import uuid
 from dataclasses import dataclass, field
 from typing import Callable, Protocol
 
 from playwright.sync_api import expect
 
-from .utils import REPO_ROOT, accept_confirm_dialog
+from .utils import (
+    REPO_ROOT,
+    accept_confirm_dialog,
+    signup_e2e_user,
+    wait_for_projects_page,
+)
 
 EXAMPLES_DIR = os.path.join(REPO_ROOT, "docs", "examples")
 
@@ -854,3 +860,68 @@ def catalog_add_reports_success(ctx: Ctx) -> None:
     ctx.say("It says so now",
             "The same sentence the Data catalog has always used.")
     ctx.capture("add-toast")
+
+
+# ---------------------------------------------------------------------------
+# Examples for registered accounts (#200)
+# ---------------------------------------------------------------------------
+
+#: A couple of the curated examples, by the ``dataflow.name`` the seeder uses as
+#: the project title. Named rather than counted, so adding a twelfth example
+#: does not break the scene and a gallery full of something else still fails.
+EXAMPLE_TITLES = [
+    "Vega-Lite chained transforms",
+    "Vega-Lite spatial density",
+]
+
+
+@walkthrough(
+    slug="examples-are-seeded-for-a-new-account",
+    refs=[200],
+    title="A new account arrives to a gallery of examples",
+    premise="Create an account and read what is waiting on the projects page.",
+    note="The examples were seeded to exactly one user - the shared guest - "
+         "and project listing is a plain owner filter, so under `--auth` every "
+         "account signed in to an empty gallery; `--deploy` carried the same "
+         "defect. Each account now gets its own copies, seeded at sign-up and "
+         "back-filled on first listing for anyone who registered earlier.",
+    tests=["tests/test_projects/test_example_seed_for_registered_users.py",
+           "tests/test_projects/test_routes.py",
+           "test_frontend/test_examples_for_registered_users_e2e.py"],
+    fit_reactflow=False,
+)
+def examples_are_seeded_for_a_new_account(ctx: Ctx) -> None:
+    """Needs a stack started with ``--with-examples``.
+
+    The runner has already stub-logged-in a walkthrough user on a canvas; this
+    scene deliberately leaves that session and signs up a brand new account,
+    because "what a new account sees" is the whole claim.
+    """
+    page = ctx.page
+
+    ctx.say("Create an account", "The reporter's own path: sign up, then look.")
+    username = f"examples_{uuid.uuid4().hex[:10]}"
+    signup_e2e_user(page, ctx.frontend, name="New User", username=username)
+    wait_for_projects_page(page, timeout=30000)
+    ctx.beat(900)
+
+    missing = [
+        title
+        for title in EXAMPLE_TITLES
+        if page.get_by_text(title, exact=True).count() == 0
+    ]
+    if missing:
+        # Distinguish the two ways this scene can fail: a stack booted without
+        # the flag has nothing to show and is a harness problem, not the bug.
+        raise AssertionError(
+            f"the gallery is missing {missing}. If every example is absent, the "
+            "stack was started without --with-examples (set "
+            "CURIO_E2E_WITH_EXAMPLES=1); if only some are, the seed is at fault."
+        )
+
+    for title in EXAMPLE_TITLES:
+        ctx.focus(page.get_by_text(title, exact=True).first, hold=900)
+
+    ctx.say("Eleven example dataflows, owned by this account",
+            "Not the guest's copies - this account's own, ready to open.")
+    ctx.capture("examples-gallery")

--- a/utk_curio/backend/tests/test_projects/test_example_seed_for_registered_users.py
+++ b/utk_curio/backend/tests/test_projects/test_example_seed_for_registered_users.py
@@ -1,0 +1,203 @@
+"""Example dataflows reach registered accounts, not just the shared guest (#200).
+
+Examples were seeded to exactly one user - the shared guest - and project
+listing is a plain owner filter, so under ``--auth`` (and ``--deploy``, which
+carries the identical defect) every account signed in to an empty gallery. The
+repo had already fixed the *dataset* half of this and never the project half.
+
+Two landmines make the naive fix worse than the bug, and each has a test here:
+
+1. ``Project.id`` is a **global** primary key while ``_example_id`` derived it
+   from the filename alone, so a second user's seed collides on insert. The
+   IntegrityError was swallowed by a broad ``except`` into a silent zero-seed.
+2. ``_prune_non_example_projects`` deletes every project of the seeded user
+   that is not an example, storage tree included. Running that for a registered
+   account destroys their work.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from utk_curio.backend.app.projects import services, storage
+from utk_curio.backend.app.projects.schemas import ProjectCreate
+from utk_curio.backend.app.projects.repositories import list_for_user
+from utk_curio.backend.app.projects.seed import (
+    _EXAMPLES_NAMESPACE,
+    _example_files,
+    _example_id,
+    _repo_root,
+    ensure_user_examples_seeded,
+    seed_example_projects,
+)
+from utk_curio.backend.app.users.models import User, UserSession
+
+
+def _example_stems() -> list[str]:
+    return [p.stem for p in _example_files(_repo_root() / "docs" / "examples")]
+
+
+def _make_user(db, username: str, token: str) -> tuple[User, str]:
+    u = User(username=username, name=username.title(), email=f"{username}@test.com")
+    db.session.add(u)
+    db.session.flush()
+    db.session.add(UserSession(user_id=u.id, token=token))
+    db.session.commit()
+    return u, token
+
+
+@pytest.fixture(autouse=True)
+def examples_enabled(monkeypatch):
+    """The back-fill is gated on the launcher's ``--with-examples`` flag.
+
+    Off by default, matching ``config.CURIO_SEED_EXAMPLES``, so a stack started
+    without the flag still seeds nobody. Every test here is about what happens
+    when it IS on; ``test_seeding_is_off_without_the_flag`` covers the other side.
+    """
+    monkeypatch.setenv("CURIO_SEED_EXAMPLES", "1")
+
+
+@pytest.fixture()
+def shared_guest(db):
+    """The real shared guest, which ``_is_shared_guest`` recognises by username."""
+    from utk_curio.backend.config import CURIO_SHARED_GUEST_USERNAME
+
+    u = User(username=CURIO_SHARED_GUEST_USERNAME, name="Guest", is_guest=True)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def test_registered_user_gets_examples(app, db, user_and_token):
+    """Fails before the fix: the refusal returned 0 for anyone but the guest."""
+    user, _ = user_and_token
+
+    seeded = seed_example_projects(user)
+
+    stems = _example_stems()
+    assert stems, "no example dataflows on disk to seed"
+    assert seeded == len(stems)
+
+    rows = list_for_user(user.id)
+    assert len(rows) == len(stems)
+    for row in rows:
+        assert storage.read_spec(str(user.id), row.id) is not None, (
+            f"{row.name} has a DB row but no spec on disk"
+        )
+
+
+def test_two_users_each_get_their_own_copy(app, db, user_and_token):
+    """Landmine 1: a global PK made the second user's seed collide silently."""
+    alice, _ = user_and_token
+    bob, _ = _make_user(db, "bob", "bob-token")
+
+    assert seed_example_projects(alice) == len(_example_stems())
+    assert seed_example_projects(bob) == len(_example_stems())
+
+    alice_ids = {p.id for p in list_for_user(alice.id)}
+    bob_ids = {p.id for p in list_for_user(bob.id)}
+
+    assert len(alice_ids) == len(_example_stems())
+    assert len(bob_ids) == len(_example_stems())
+    assert alice_ids.isdisjoint(bob_ids), "both users share example project ids"
+
+    # Each user's own copy is on disk under their own key.
+    for pid in bob_ids:
+        assert storage.read_spec(str(bob.id), pid) is not None
+
+
+def test_seeding_does_not_delete_a_users_own_project(app, db, user_and_token):
+    """Landmine 2: the prune would have deleted the user's work, files included."""
+    user, _ = user_and_token
+
+    mine = services.save_project(
+        user,
+        ProjectCreate(name="My own work", spec={"dataflow": {"name": "Mine"}}),
+    )
+
+    seed_example_projects(user)
+
+    surviving = {p.id for p in list_for_user(user.id)}
+    assert mine.id in surviving, "seeding deleted the user's own project"
+    assert storage.read_spec(str(user.id), mine.id) is not None, (
+        "the project row survived but its spec file was deleted"
+    )
+
+
+def test_guest_prune_still_runs(app, db, shared_guest):
+    """The guest's overwrite posture is unchanged: scratch projects are pruned."""
+    scratch = services.save_project(
+        shared_guest,
+        ProjectCreate(name="Scratch", spec={"dataflow": {"name": "Scratch"}}),
+    )
+
+    seed_example_projects(shared_guest)
+
+    surviving = {p.id for p in list_for_user(shared_guest.id)}
+    assert scratch.id not in surviving, (
+        "the guest's non-example project survived; --with-examples must land on "
+        "exactly the curated set"
+    )
+
+
+def test_guest_ids_are_unchanged(app, db, shared_guest):
+    """Installs seeded before this change must upsert, not duplicate."""
+    for stem in _example_stems():
+        assert _example_id(stem, shared_guest) == str(
+            uuid.uuid5(_EXAMPLES_NAMESPACE, stem)
+        )
+    # And a registered user's are genuinely different.
+    alice, _ = _make_user(db, "alice2", "alice2-token")
+    for stem in _example_stems():
+        assert _example_id(stem, alice) != _example_id(stem, shared_guest)
+
+
+def test_seed_is_idempotent(app, db, user_and_token):
+    user, _ = user_and_token
+
+    seed_example_projects(user)
+    first = {p.id for p in list_for_user(user.id)}
+    seed_example_projects(user)
+    second = {p.id for p in list_for_user(user.id)}
+
+    assert first == second, "re-seeding duplicated the examples"
+
+
+def test_backfill_does_not_resurrect_a_deleted_example(app, db, user_and_token):
+    """The marker is what makes the listing back-fill safe to run every time."""
+    user, _ = user_and_token
+
+    assert ensure_user_examples_seeded(user) == len(_example_stems())
+
+    victim = list_for_user(user.id)[0]
+    services.delete_project(user, victim.id, purge=True)
+    assert victim.id not in {p.id for p in list_for_user(user.id)}
+
+    # A second call is a no-op, so the deliberate deletion stands.
+    assert ensure_user_examples_seeded(user) == 0
+    assert victim.id not in {p.id for p in list_for_user(user.id)}
+
+
+def test_listing_backfills_for_a_user_seeded_before_the_fix(app, db, user_and_token):
+    """`list_projects` is the self-heal path, mirroring packages and datasets."""
+    user, _ = user_and_token
+    assert list_for_user(user.id) == []
+
+    summaries = services.list_projects(user)
+
+    assert len(summaries) == len(_example_stems())
+
+
+@pytest.mark.parametrize("flag", ["0", None])
+def test_seeding_is_off_without_the_flag(app, db, user_and_token, monkeypatch, flag):
+    """`--with-examples` is what turns this on; unset means off, as before."""
+    user, _ = user_and_token
+    if flag is None:
+        monkeypatch.delenv("CURIO_SEED_EXAMPLES", raising=False)
+    else:
+        monkeypatch.setenv("CURIO_SEED_EXAMPLES", flag)
+
+    assert ensure_user_examples_seeded(user) == 0
+    assert list_for_user(user.id) == []
+    assert services.list_projects(user) == []

--- a/utk_curio/backend/tests/test_projects/test_routes.py
+++ b/utk_curio/backend/tests/test_projects/test_routes.py
@@ -57,6 +57,27 @@ def test_list_projects(client, user_and_token, tmp_curio):
     assert len(resp.get_json()) == 2
 
 
+def test_list_projects_serves_a_registered_users_examples(
+    client, user_and_token, tmp_curio, monkeypatch
+):
+    """#200 end to end at the route: the gallery is not empty under --auth.
+
+    Examples were seeded to the shared guest alone and listing is a plain owner
+    filter, so a signed-in account got `[]` here however the stack was started.
+    """
+    monkeypatch.setenv("CURIO_SEED_EXAMPLES", "1")
+    _, token = user_and_token
+
+    resp = client.get("/api/projects?scope=mine", headers=_auth(token))
+
+    assert resp.status_code == 200
+    names = {p["name"] for p in resp.get_json()}
+    assert names, "a registered user's gallery came back empty"
+    # Named, not just counted: the rows must be the curated examples rather
+    # than any project that happens to exist.
+    assert "Vega-Lite chained transforms" in names, sorted(names)
+
+
 def test_get_project(client, user_and_token, tmp_curio):
     _, token = user_and_token
     create = client.post(

--- a/utk_curio/backend/tests/test_scripts/test_launcher_env.py
+++ b/utk_curio/backend/tests/test_scripts/test_launcher_env.py
@@ -46,6 +46,33 @@ def _isolate_env(monkeypatch, tmp_path):
     monkeypatch.setenv("CURIO_SHARED_DATA", str(tmp_path / "data"))
 
 
+def test_auth_and_examples_together_is_the_combination_200_needed():
+    """`--auth --with-examples` must turn both on at once.
+
+    This pair is the reported configuration for #200: a signed-in account with
+    the examples seeded. The e2e harness launched with ``--auth`` but never
+    ``--with-examples``, which is why nothing caught the empty gallery.
+    """
+    set_environment_variables(**BASE, auth=True, with_examples=True)
+
+    assert os.environ["CURIO_NO_AUTH"] == "0"
+    assert os.environ["CURIO_SEED_EXAMPLES"] == "1"
+
+
+def test_examples_are_off_unless_asked_for():
+    set_environment_variables(**BASE, auth=True)
+
+    assert os.environ["CURIO_SEED_EXAMPLES"] == "0"
+
+
+def test_deploy_seeds_examples_without_the_flag():
+    # --deploy is the "give me a working install" switch, so it implies both.
+    set_environment_variables(**BASE, deploy=True)
+
+    assert os.environ["CURIO_NO_AUTH"] == "0"
+    assert os.environ["CURIO_SEED_EXAMPLES"] == "1"
+
+
 def test_save_node_outputs_defaults_off_and_can_be_turned_on():
     # Opt-in per node (#180): a dataflow should not accumulate a Computed
     # dataset for every node the user happens to run.


### PR DESCRIPTION
### #200 — Examples are not loaded with `--auth` and `--with-examples`

Example seeding only ever ran for the shared guest. Start Curio with `--auth`, sign
up, and you land on an empty Projects page.

Examples are now seeded per user: at sign-up, and backfilled at login when an account
has none. Each user gets their own copies, so editing one example cannot change what
another account sees.

Two things had to be handled first, and both are the reason this is not a one-liner:

- **The seed ids were global.** `_example_id` hashed the file stem alone, so the
  second user's seed collided with the first user's project id. It is now scoped per
  user (uuid5 over stem + username).
- **The marker keyed on the user id.** A truncated database reuses ids, so a fresh
  account inherited a previous one's "already seeded" marker and skipped seeding
  entirely. The marker now records the username.

Pruning is guest-only: for a registered user, deleting an example must not have it
reappear at next login.

### Tests

13 backend tests over the seed (per-user ids, marker ownership, backfill, prune
scoping), a route test, a launcher env test, and an e2e that signs up and asserts the
examples are there. Plus a walkthrough.
