### PR TITLE
Refuse a blank dashboard, survive a browser without WebGPU (#192, #201)

### DIFF
--- a/utk_curio/backend/tests/test_frontend/walkthroughs.py
+++ b/utk_curio/backend/tests/test_frontend/walkthroughs.py
@@ -925,3 +925,119 @@ def examples_are_seeded_for_a_new_account(ctx: Ctx) -> None:
     ctx.say("Eleven example dataflows, owned by this account",
             "Not the guest's copies - this account's own, ready to open.")
     ctx.capture("examples-gallery")
+
+
+# ---------------------------------------------------------------------------
+# Robustness (#192, #201)
+# ---------------------------------------------------------------------------
+
+def open_view_menu_dashboard(ctx: Ctx) -> None:
+    """View -> Dashboard. ``force`` because the canvas chrome overlaps the bar."""
+    page = ctx.page
+    ctx.click(top_menu(page, "View"), force=True)
+    ctx.click(page.get_by_text("Dashboard", exact=True).first)
+
+
+@walkthrough(
+    slug="dashboard-mode-refuses-a-blank-screen",
+    refs=[192],
+    title="Dashboard Mode says what it needs",
+    premise="Enter Dashboard Mode with nothing pinned, then with one node pinned.",
+    note="Entering with nothing pinned hid every node and every edge, and "
+         "`{!dashboardOn && <UpMenu>}` took the top bar with them - so the "
+         "screen went blank with only the dashboard panel's close button left. "
+         "The menu also ran the toggle twice per click, because MainCanvas "
+         "passed the same handler to two props and UpMenu called both.",
+    tests=["src/tests/providers/dashboardModeGuard.test.tsx"],
+)
+def dashboard_mode_refuses_a_blank_screen(ctx: Ctx) -> None:
+    page = ctx.page
+
+    ctx.say("Dashboard Mode, with nothing pinned",
+            "This used to empty the screen with no way back but one ✕.")
+    open_view_menu_dashboard(ctx)
+
+    toast = page.locator(TOAST_REGION).get_by_text(
+        "Pin at least one node to the dashboard first.", exact=True
+    )
+    toast.first.wait_for(state="visible", timeout=15000)
+    ctx.focus(toast.first, hold=1600)
+
+    # The canvas is untouched: still here, still showing its nodes.
+    nodes = page.locator(".react-flow__node")
+    assert nodes.count() > 0, "the canvas emptied despite the refusal"
+    expect(page.locator("#tools-menu")).to_be_visible()
+    ctx.capture("refused-with-nothing-pinned")
+
+    ctx.say("Pin one node", "Now the mode has something to show.")
+    pin = page.locator(".react-flow__node").first.get_by_role(
+        "button", name="Pin to dashboard"
+    )
+    pin.wait_for(state="visible", timeout=15000)
+    ctx.click(pin.first)
+    ctx.beat(700)
+
+    ctx.say("And it opens", "One pinned node, laid out on its own.")
+    open_view_menu_dashboard(ctx)
+    page.wait_for_timeout(1200)
+    ctx.capture("entered-with-one-pin")
+
+
+@walkthrough(
+    slug="autark-without-webgpu-says-so",
+    refs=[201],
+    title="An Autark node on a browser without WebGPU",
+    premise="Run an Autark node where WebGPU is unavailable, and read the node.",
+    note="Nothing asked whether the browser had WebGPU. The library swallows "
+         "its own init failure and carries on until the layer loader reaches "
+         "`this._renderer.device.createShaderModule`, throwing a TypeError - "
+         "and with no error boundary anywhere, that throw unmounted the whole "
+         "React root and left a blank page. The node now checks first, says "
+         "what is missing and what to do about it, and the canvas survives.",
+    tests=["src/tests/adapters/node/autkGrammarWebgpuFallback.test.tsx",
+           "src/tests/components/errorBoundary.test.tsx"],
+    max_diff_ratio=0.05,
+)
+def autark_without_webgpu_says_so(ctx: Ctx) -> None:
+    page = ctx.page
+
+    # Take WebGPU away in the page itself. `add_init_script` would need to run
+    # before navigation and the runner has already navigated, so the property is
+    # redefined in place - the probe reads it at run time, not at load time.
+    page.evaluate(
+        "() => Object.defineProperty(navigator, 'gpu',"
+        " { configurable: true, value: undefined })"
+    )
+    ctx.say("A browser with no WebGPU",
+            "Firefox and Safari today; Chrome on a blocklisted driver.")
+
+    errors: list[str] = []
+    page.on("pageerror", lambda e: errors.append(str(e)))
+
+    autark = page.locator('.react-flow__node:has-text("Autark")').first
+    if not autark.count():
+        raise AssertionError(
+            "this dataflow has no Autark node, so the scene has nothing to run; "
+            "point it at an example that includes one"
+        )
+    autark.scroll_into_view_if_needed()
+    ctx.focus(autark, hold=1000)
+
+    ctx.say("Run it", "The old failure was a TypeError from inside the shader loader.")
+    play = autark.get_by_role("button", name="Play").first
+    if play.count():
+        ctx.click(play)
+
+    fallback = autark.locator('[role="alert"]')
+    fallback.first.wait_for(state="visible", timeout=45000)
+    ctx.focus(fallback.first, hold=1800)
+    ctx.say("It says what is missing, and what to do",
+            "Named cause, named remedy - and the canvas is still here.")
+    ctx.capture("webgpu-fallback")
+
+    # THE POINT: the app is alive. Before, the root had unmounted.
+    assert page.locator(".react-flow__node").count() > 1, (
+        "the canvas lost its nodes, so the throw was not contained"
+    )
+    expect(page.locator("#tools-menu")).to_be_visible()
+    assert not errors, f"an uncaught page error escaped: {errors}"

--- a/utk_curio/frontend/urban-workflows/src/adapters/node/autkGrammarBehavior.tsx
+++ b/utk_curio/frontend/urban-workflows/src/adapters/node/autkGrammarBehavior.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Feature, FeatureCollection } from 'geojson';
 import { NodeBehaviorHook } from '../../registry/types';
 import { fetchData } from '../../services/api';
+import { detectWebGpuSupport } from '../../utils/webgpuSupport';
 import { useToastContext } from '../../providers/ToastProvider';
 import { autkGrammarAdapter } from '../../adapters/autkGrammarAdapter';
 import { VisInteractionType, NodeType } from '../../constants';
@@ -10,6 +11,10 @@ import { JavaScriptInterpreter } from '../../JavaScriptInterpreter';
 export const useAutkGrammarBehavior: NodeBehaviorHook = (data, nodeState) => {
     const { showToast } = useToastContext();
     const wrapperRef = useRef<HTMLDivElement>(null);
+    // Set when the browser cannot run Autark at all (#201). Renders an
+    // in-node explanation instead of the map container, so the node says why
+    // it is empty rather than looking like it simply produced nothing.
+    const [gpuBlocked, setGpuBlocked] = useState<string | null>(null);
 
     // Grammar instance and last-run spec, kept in refs so effects can access
     // them without causing re-renders.
@@ -41,6 +46,30 @@ export const useAutkGrammarBehavior: NodeBehaviorHook = (data, nodeState) => {
             nodeState.setOutput({ code: 'error', content: 'Invalid JSON grammar spec.' });
             return;
         }
+
+        // Ask whether this browser can run Autark at all, BEFORE any canvas or
+        // DOM work (#201). Upstream of the dynamic import, the compute path and
+        // the canvas creation, so a refusal leaves no orphaned canvas and no
+        // window listeners behind. The library swallows its own init failure and
+        // only throws much later, inside `createShaders()`, where the stack says
+        // nothing about WebGPU.
+        const needsGpu =
+            spec.map != null ||
+            spec.plot != null ||
+            (Array.isArray(spec.compute) && spec.compute.length > 0);
+        if (needsGpu) {
+            const support = await detectWebGpuSupport();
+            if (!support.supported) {
+                const message =
+                    support.reason ??
+                    'Autark nodes need WebGPU, which this browser does not provide.';
+                setGpuBlocked(message);
+                nodeState.setOutput({ code: 'error', content: message });
+                showToast(message, 'error');
+                return;
+            }
+        }
+        setGpuBlocked(null);
 
         const nodeId = data.nodeId;
         const mapCanvasId = 'autk-grammar-map-' + nodeId;
@@ -364,7 +393,19 @@ export const useAutkGrammarBehavior: NodeBehaviorHook = (data, nodeState) => {
                         layers = layers.filter((l) => !emptyLayers.includes(l));
                     }
                     if (Array.isArray(spec.compute) && spec.compute.length > 0) {
-                        layers = await applyComputeBlocks(layers, spec.compute);
+                        const computeFailures: string[] = [];
+                        layers = await applyComputeBlocks(
+                            layers, spec.compute, computeFailures,
+                        );
+                        if (computeFailures.length > 0) {
+                            // Emitting here would hand downstream nodes the
+                            // untouched input under a green "Done" badge.
+                            const message =
+                                'Compute failed: ' + computeFailures.join('; ');
+                            nodeState.setOutput({ code: 'error', content: message });
+                            showToast(message, 'error');
+                            return;
+                        }
                     }
                     // Build the pool-compatible wrapper and persist it to the
                     // backend sandbox so downstream nodes see a `{path, dataType}`
@@ -441,7 +482,11 @@ export const useAutkGrammarBehavior: NodeBehaviorHook = (data, nodeState) => {
                     ? grammar.clearHighlightOnPlot?.(plotSpec.dataRef)
                     : grammar.setPlotSelection?.(plotSpec.dataRef, sel);
             }
-        })();
+        })().catch((err) => {
+            // Same reason as GrammarEditor's: an escaped rejection here
+            // surfaces as the dev-server overlay rather than as a node error.
+            console.error("[autk-grammar] interaction sync failed:", err);
+        });
     }, [data.input]);
 
     // Forward parent container resizes to AutkMap via a synthetic window.resize.
@@ -506,21 +551,48 @@ export const useAutkGrammarBehavior: NodeBehaviorHook = (data, nodeState) => {
     // Stable JSX reference across incidental re-renders, but identity changes
     // on run completion so NodeEditor switches to the output tab automatically.
     const contentComponent = React.useMemo<React.ReactNode>(
-        () => (
-            <div
-                className="nodrag nopan nowheel"
-                ref={wrapperRef}
-                style={{
-                    position: 'relative',
-                    width: '100%',
-                    height: '100%',
-                    minHeight: 400,
-                    overflow: 'hidden',
-                }}
-            />
-        ),
+        () =>
+            gpuBlocked ? (
+                // Styled after providers/BackendHealthBanner: an explanation the
+                // user can act on, in the node, rather than an empty box. The red
+                // "Error" chip on the node header comes for free from the output
+                // code set alongside this.
+                <div
+                    role="alert"
+                    className="nodrag nopan nowheel"
+                    style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 8,
+                        padding: '14px 16px',
+                        margin: 8,
+                        border: '1px solid var(--curio-danger, #c0392b)',
+                        borderRadius: 'var(--curio-radius-md, 6px)',
+                        background: 'var(--curio-danger-bg, rgba(192, 57, 43, 0.08))',
+                        color: 'var(--curio-danger-strong, #922b21)',
+                        fontSize: 'var(--curio-font-size-md, 13px)',
+                        lineHeight: 1.45,
+                        overflow: 'auto',
+                    }}
+                >
+                    <strong>WebGPU is not available</strong>
+                    <span>{gpuBlocked}</span>
+                </div>
+            ) : (
+                <div
+                    className="nodrag nopan nowheel"
+                    ref={wrapperRef}
+                    style={{
+                        position: 'relative',
+                        width: '100%',
+                        height: '100%',
+                        minHeight: 400,
+                        overflow: 'hidden',
+                    }}
+                />
+            ),
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [nodeState.output],
+        [nodeState.output, gpuBlocked],
     );
 
     // Editor seed, decided ONCE at mount: a node that arrives with no code gets
@@ -1373,6 +1445,10 @@ function buildBatchedUniforms(
 async function applyComputeBlocks(
     layers: Array<{ name: string; type: string; geojson: FeatureCollection }>,
     computeBlocks: any[],
+    /** Appended to for every block that failed, so the caller can refuse to
+     *  report success. A block whose ``dataRef`` matches no upstream layer is
+     *  still skipped quietly - that is a no-op, not a failure. */
+    failures: string[] = [],
 ): Promise<Array<{ name: string; type: string; geojson: FeatureCollection }>> {
     if (!Array.isArray(computeBlocks) || computeBlocks.length === 0) return layers;
     const { ComputeGpgpu } = await import('@urban-toolkit/autk-compute');
@@ -1479,7 +1555,14 @@ async function applyComputeBlocks(
             if (sourceCrs && augmented) (augmented as any).crs = sourceCrs;
             result = result.map((l, i) => (i === idx ? { ...l, geojson: augmented } : l));
         } catch (e) {
+            // Recorded, not just warned (#201). A failed block leaves the layer
+            // exactly as it arrived, so swallowing this emitted UNCOMPUTED data
+            // under a green "Done" badge - the node reported success for work
+            // it had not done. The caller turns a non-empty list into an error.
             console.warn(`[autk-grammar] compute block on '${block.dataRef}' failed`, e);
+            failures.push(
+                `${block.dataRef}: ${(e as Error)?.message ?? "compute failed"}`,
+            );
         }
     }
     return result;

--- a/utk_curio/frontend/urban-workflows/src/components/ErrorBoundary.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/ErrorBoundary.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  /** Rendered in place of the subtree that threw. Given the error so a caller
+   *  can name it; defaults to a short inline notice. */
+  fallback?: (error: Error) => React.ReactNode;
+  /** Names the subtree in the console line, e.g. "node autk-1". */
+  label?: string;
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Contains a render-time throw so one broken subtree cannot take the app (#201).
+ *
+ * There was no error boundary anywhere in the app, so a throw from a single
+ * node's content unmounted the entire React root and left a blank page with
+ * the canvas, the menus and every other node gone. The reported case was an
+ * Autark node on a browser without WebGPU, but the blast radius is the point:
+ * any node that throws while rendering does this.
+ *
+ * Deliberately does NOT catch async failures - `componentDidCatch` never sees
+ * a rejected promise. Those are handled where they are raised (see
+ * `applyGrammar`'s WebGPU guard) and by the `unhandledrejection` logger in
+ * `index.tsx`.
+ */
+export default class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    const where = this.props.label ? ` in ${this.props.label}` : "";
+    console.error(`[ErrorBoundary] contained a render error${where}:`, error, info);
+    this.props.onError?.(error, info);
+  }
+
+  render(): React.ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    if (this.props.fallback) return this.props.fallback(error);
+    return (
+      <div
+        role="alert"
+        style={{
+          padding: "12px 14px",
+          margin: 8,
+          border: "1px solid var(--curio-danger, #c0392b)",
+          borderRadius: "var(--curio-radius-md, 6px)",
+          background: "var(--curio-danger-bg, rgba(192, 57, 43, 0.08))",
+          color: "var(--curio-danger-strong, #922b21)",
+          fontSize: "var(--curio-font-size-md, 13px)",
+          lineHeight: 1.45,
+        }}
+      >
+        <strong>Something went wrong here.</strong>
+        <div style={{ marginTop: 4 }}>
+          {error.message || "This part of the page could not be rendered."}
+        </div>
+        <div style={{ marginTop: 4, opacity: 0.8 }}>
+          The rest of the dataflow is unaffected.
+        </div>
+      </div>
+    );
+  }
+}

--- a/utk_curio/frontend/urban-workflows/src/components/MainCanvas.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/MainCanvas.tsx
@@ -494,8 +494,7 @@ export function MainCanvas() {
             ))}
             {!dashboardOn && <ToolsMenu />}
             {!dashboardOn && <UpMenu
-                setDashBoardMode={(value) => handleDashboardToggle(value)}
-                setDashboardOn={handleDashboardToggle}
+                setDashBoardMode={handleDashboardToggle}
                 dashboardOn={dashboardOn}
             />}
             {!dashboardOn && <CollaborationSidePanel />}

--- a/utk_curio/frontend/urban-workflows/src/components/UniversalNode.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/UniversalNode.tsx
@@ -14,6 +14,7 @@ import { HandleDef, TIconCardinality } from '../registry/types';
 import { useFlowContext } from '../providers/FlowProvider';
 import { NodeAgentBadges } from './agents/attach/NodeAgentBadges';
 import { useCollab } from '../providers/CollaborationProvider';
+import ErrorBoundary from "./ErrorBoundary";
 import './Node.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
 
@@ -240,6 +241,11 @@ const UniversalNodeBody = React.memo(function UniversalNodeBody({ data, isConnec
           custom={nodeState.templateData.custom}
         />
 
+        {/* Per-node blast radius (#201). A throw from one node's content used
+            to unmount the whole React root - canvas, menus and every other
+            node - leaving a blank page. Contained here, the rest of the
+            dataflow keeps working and the broken node says so in place. */}
+        <ErrorBoundary label={`node ${data.nodeId}`}>
         {adapter.editor ? (
           <NodeEditor
             outputId={behavior.outputIdOverride ?? adapter.editor.outputId?.(data.nodeId)}
@@ -270,6 +276,7 @@ const UniversalNodeBody = React.memo(function UniversalNodeBody({ data, isConnec
           // legitimately return ``undefined`` here — they're icon-only.
           behavior.contentComponent ?? null
         )}
+        </ErrorBoundary>
 
         {!dashboardOn && adapter.outputIconType && <OutputIcon type={adapter.outputIconType as TIconCardinality} />}
       </NodeContainer>

--- a/utk_curio/frontend/urban-workflows/src/components/editing/GrammarEditor.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/editing/GrammarEditor.tsx
@@ -145,7 +145,13 @@ export default function GrammarEditor({
             output.code == "exec" &&
             applyGrammar != undefined
         ) {
-            applyGrammar(replacedCode);
+            // Catch, don't float (#201). An escaped rejection reaches
+            // `window` as `unhandledrejection`, which webpack-dev-server's
+            // runtime-error overlay listens for - so one throw inside the
+            // grammar took the whole screen in development.
+            void Promise.resolve(applyGrammar(replacedCode)).catch((err) => {
+                console.error("[GrammarEditor] applyGrammar failed:", err);
+            });
         }
         replacedCodeDirtyBypass.current = true;
     }, [replacedCodeDirty]);

--- a/utk_curio/frontend/urban-workflows/src/components/menus/top/UpMenu.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/menus/top/UpMenu.tsx
@@ -47,11 +47,12 @@ import { getCurrentProjectPackagesList } from "../../../registry/projectPackages
 
 export default function UpMenu({
     setDashBoardMode,
-    setDashboardOn,
     dashboardOn,
 }: {
+    /** The single entry point for entering and leaving dashboard mode.
+     *  There used to be a second prop wired to the SAME handler, and this menu
+     *  called both, so every click ran the toggle twice (#192). */
     setDashBoardMode: (mode: boolean) => void;
-    setDashboardOn: (mode: boolean) => void;
     dashboardOn: boolean;
 }) {
     const [isEditing, setIsEditing] = useState(false);
@@ -450,7 +451,6 @@ export default function UpMenu({
                                 className={styles.dropDownRow}
                                 onClick={() => {
                                     setDashBoardMode(!dashboardOn);
-                                    setDashboardOn(!dashboardOn);
                                     setActiveMenu(null);
                                 }}
                             >

--- a/utk_curio/frontend/urban-workflows/src/index.tsx
+++ b/utk_curio/frontend/urban-workflows/src/index.tsx
@@ -79,6 +79,7 @@ import { DatasetPaletteProvider } from "./providers/DatasetPaletteContext";
 import { ReactFlowProvider } from "reactflow";
 import ProvenanceProvider from "./providers/ProvenanceProvider";
 import { RequireAuth } from "./components/RequireAuth";
+import ErrorBoundary from "./components/ErrorBoundary";
 
 import SignIn from "./pages/auth/SignIn";
 import SignUp from "./pages/auth/SignUp";
@@ -155,6 +156,10 @@ const App: React.FC = () => {
             <ReactFlowProvider>
                 <ProvenanceProvider>
                   <UserProvider>
+                    {/* Backstop under the per-node boundaries (#201): a throw
+                        from page chrome rather than from a node still has to
+                        land somewhere other than a blank document. */}
+                    <ErrorBoundary label="route">
                     <Routes>
                     <Route path="/auth/signin" element={<SignIn />} />
                     <Route path="/auth/signup" element={<SignUp />} />
@@ -209,6 +214,7 @@ const App: React.FC = () => {
                       }
                     />
                     </Routes>
+                    </ErrorBoundary>
                   </UserProvider>
                 </ProvenanceProvider>
             </ReactFlowProvider>
@@ -217,6 +223,17 @@ const App: React.FC = () => {
     </BrowserRouter>
   );
 };
+
+// A rejected promise nobody caught reaches `window` as an `unhandledrejection`,
+// and webpack-dev-server's `client.overlay.runtimeErrors` listens for exactly
+// that - so in development one escaped rejection paints the error overlay over
+// the whole app (#201). Logging it here does not stop the overlay, but it names
+// the rejection in the console instead of leaving only the overlay's stack, and
+// it makes an escaped promise visible in production too, where there is no
+// overlay at all and the failure was previously silent.
+window.addEventListener("unhandledrejection", (event) => {
+  console.error("[curio] unhandled promise rejection:", event.reason);
+});
 
 const root = ReactDOM.createRoot(document.getElementById("root")!);
 

--- a/utk_curio/frontend/urban-workflows/src/providers/FlowProvider.tsx
+++ b/utk_curio/frontend/urban-workflows/src/providers/FlowProvider.tsx
@@ -458,6 +458,16 @@ const FlowProvider = ({ children }: { children: ReactNode }) => {
     }, []);
 
     const setDashBoardMode = (value: boolean) => {
+        // Refuse entry with nothing pinned (#192). `applyDashboardLayout`
+        // returns the nodes untouched when no node is pinned, and then every
+        // one of them is given `display: none` below while the edges are
+        // hidden and `{!dashboardOn && <UpMenu>}` removes the top bar - so the
+        // whole screen goes blank with only DashboardPanel's ✕ to escape by.
+        // Better to say what is missing than to enter a mode that shows nothing.
+        if (value && !Object.values(dashboardPins).some(Boolean)) {
+            showToast("Pin at least one node to the dashboard first.", "warning");
+            return;
+        }
         setDashboardOn(value);
         if (value) {
             setDashboardLocked(true);

--- a/utk_curio/frontend/urban-workflows/src/tests/adapters/node/autkGrammarWebgpuFallback.test.tsx
+++ b/utk_curio/frontend/urban-workflows/src/tests/adapters/node/autkGrammarWebgpuFallback.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * Autark nodes refuse to run without WebGPU, rather than crashing (#201).
+ *
+ * Nothing in the app asked whether the browser could do this. The library
+ * swallows its own init failure — `Renderer.init()` only `console.error`s
+ * "WebGPU is not available" and leaves `_device` undefined — so `AutkMap.init()`
+ * carried on until the layer loader reached
+ * `this._renderer.device.createShaderModule` and threw a TypeError with a stack
+ * that says nothing about WebGPU. With no error boundary anywhere, that throw
+ * took the whole React root down.
+ *
+ * jsdom has no `navigator.gpu`, so "unsupported" is the default here and only
+ * the supported case needs to install one.
+ */
+import React from 'react';
+import { render, act, waitFor } from '@testing-library/react';
+
+const mockShowToast = jest.fn();
+jest.mock('../../../providers/ToastProvider', () => ({
+  useToastContext: () => ({ showToast: mockShowToast }),
+}));
+jest.mock('../../../services/api', () => ({ fetchData: jest.fn() }));
+jest.mock('../../../JavaScriptInterpreter', () => ({
+  JavaScriptInterpreter: class { },
+}));
+jest.mock('../../../adapters/autkGrammarAdapter', () => ({
+  autkGrammarAdapter: { getDefaultSpec: () => '{"map":{}}' },
+}));
+
+const mockGrammarRun = jest.fn().mockResolvedValue(undefined);
+const mockAutkGrammar = jest.fn().mockImplementation(() => ({
+  run: mockGrammarRun,
+  data: {},
+}));
+jest.mock(
+  '@urban-toolkit/autk-grammar',
+  () => ({ AutkGrammar: mockAutkGrammar }),
+  { virtual: true },
+);
+
+const mockComputeGpgpu = jest.fn().mockImplementation(() => ({}));
+jest.mock(
+  '@urban-toolkit/autk-compute',
+  () => ({ ComputeGpgpu: mockComputeGpgpu }),
+  { virtual: true },
+);
+
+import { useAutkGrammarBehavior } from '../../../adapters/node/autkGrammarBehavior';
+import { __resetWebGpuSupportCache } from '../../../utils/webgpuSupport';
+
+const MAP_SPEC = JSON.stringify({ map: { layerRefs: [] } });
+const COMPUTE_SPEC = JSON.stringify({
+  compute: [{ dataRef: 'upstream', wglsFunction: 'fn main() {}' }],
+});
+
+interface Harness {
+  apply: (spec: string) => Promise<void>;
+  outputs: Array<{ code: string; content: string }>;
+  content: () => React.ReactNode;
+}
+
+function renderBehavior(): Harness {
+  const outputs: Array<{ code: string; content: string }> = [];
+  const harness: Partial<Harness> = { outputs };
+  let latestContent: React.ReactNode = null;
+
+  const Probe: React.FC = () => {
+    const behavior = useAutkGrammarBehavior(
+      { nodeId: 'autk-1', input: '', defaultCode: MAP_SPEC } as any,
+      {
+        output: { code: '', content: '' },
+        setOutput: (o: { code: string; content: string }) => outputs.push(o),
+        setCode: jest.fn(),
+        templateData: {},
+      } as any,
+    );
+    harness.apply = behavior.applyGrammar as (spec: string) => Promise<void>;
+    latestContent = behavior.contentComponent;
+    return <>{behavior.contentComponent}</>;
+  };
+
+  render(<Probe />);
+  harness.content = () => latestContent;
+  return harness as Harness;
+}
+
+/** Installs a `navigator.gpu` whose `requestAdapter` answers with *adapter*. */
+function withGpu(adapter: unknown, { throws = false } = {}) {
+  Object.defineProperty(navigator, 'gpu', {
+    configurable: true,
+    value: {
+      requestAdapter: throws
+        ? jest.fn().mockRejectedValue(new Error('pref disabled'))
+        : jest.fn().mockResolvedValue(adapter),
+    },
+  });
+}
+
+function withoutGpu() {
+  Object.defineProperty(navigator, 'gpu', { configurable: true, value: undefined });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  __resetWebGpuSupportCache();
+  withoutGpu();
+});
+
+describe('an Autark node on a browser without WebGPU', () => {
+  test('refuses to run, and never constructs the grammar', async () => {
+    const h = renderBehavior();
+
+    // Resolves rather than throwing: an escaped rejection is what the
+    // dev-server overlay listens for.
+    await act(async () => {
+      await h.apply(MAP_SPEC);
+    });
+
+    expect(mockAutkGrammar).not.toHaveBeenCalled();
+    const errors = h.outputs.filter((o) => o.code === 'error');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].content).toMatch(/WebGPU/i);
+  });
+
+  test('names the remedy, not just the problem', async () => {
+    const h = renderBehavior();
+    await act(async () => {
+      await h.apply(MAP_SPEC);
+    });
+
+    const message = h.outputs.find((o) => o.code === 'error')!.content;
+    // A user on Firefox has an action available; the message has to name it.
+    expect(message).toMatch(/Chrome|Edge/);
+    expect(message).toMatch(/dom\.webgpu\.enabled|about:config/);
+  });
+
+  test('says so in the node, as an alert', async () => {
+    const h = renderBehavior();
+    const { rerender } = render(<>{h.content()}</>);
+    await act(async () => {
+      await h.apply(MAP_SPEC);
+    });
+
+    await waitFor(() => {
+      rerender(<>{h.content()}</>);
+      const alert = document.body.querySelector('[role="alert"]');
+      expect(alert).not.toBeNull();
+      expect(alert!.textContent).toMatch(/WebGPU is not available/i);
+    });
+  });
+
+  test('a compute-only spec emits no output at all, rather than uncomputed data', async () => {
+    const h = renderBehavior();
+
+    await act(async () => {
+      await h.apply(COMPUTE_SPEC);
+    });
+
+    expect(mockComputeGpgpu).not.toHaveBeenCalled();
+    // The point of the issue's silent half: the node must not report success
+    // while handing downstream nodes its untouched input.
+    expect(h.outputs.filter((o) => o.code === 'success')).toHaveLength(0);
+    expect(h.outputs.some((o) => o.code === 'error')).toBe(true);
+  });
+
+  test('toasts once, so the failure is visible without opening the node', async () => {
+    const h = renderBehavior();
+    await act(async () => {
+      await h.apply(MAP_SPEC);
+    });
+
+    expect(mockShowToast).toHaveBeenCalledTimes(1);
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.stringMatching(/WebGPU/i),
+      'error',
+    );
+  });
+});
+
+describe('an Autark node where the API exists but no adapter does', () => {
+  test('still refuses — presence of navigator.gpu is not the test', async () => {
+    // Chrome exposes navigator.gpu on blocklisted drivers and in headless runs,
+    // then resolves requestAdapter() to null. Checking only for the object
+    // would sail straight into the same TypeError.
+    withGpu(null);
+    const h = renderBehavior();
+
+    await act(async () => {
+      await h.apply(MAP_SPEC);
+    });
+
+    expect(mockAutkGrammar).not.toHaveBeenCalled();
+    expect(h.outputs.some((o) => o.code === 'error')).toBe(true);
+  });
+
+  test('a throwing requestAdapter is contained too', async () => {
+    // Firefox throws here rather than resolving null when the pref is off.
+    withGpu(null, { throws: true });
+    const h = renderBehavior();
+
+    await act(async () => {
+      await h.apply(MAP_SPEC);
+    });
+
+    expect(mockAutkGrammar).not.toHaveBeenCalled();
+    expect(h.outputs.some((o) => o.code === 'error')).toBe(true);
+  });
+});
+
+describe('an Autark node on a browser that does have WebGPU', () => {
+  test('runs the grammar, so Chrome is not regressed', async () => {
+    withGpu({ name: 'fake-adapter' });
+    const h = renderBehavior();
+
+    await act(async () => {
+      await h.apply(MAP_SPEC);
+    });
+
+    expect(mockAutkGrammar).toHaveBeenCalled();
+    expect(mockGrammarRun).toHaveBeenCalled();
+    expect(h.outputs.filter((o) => o.code === 'error')).toHaveLength(0);
+    expect(document.body.querySelector('[role="alert"]')).toBeNull();
+  });
+});

--- a/utk_curio/frontend/urban-workflows/src/tests/adapters/node/behaviors.test.tsx
+++ b/utk_curio/frontend/urban-workflows/src/tests/adapters/node/behaviors.test.tsx
@@ -94,6 +94,7 @@ import { useSimpleVisBehavior } from '../../../adapters/node/simpleVisBehavior';
 import { useMergeFlowBehavior } from '../../../adapters/node/mergeFlowBehavior';
 import { useDataPoolBehavior } from '../../../adapters/node/dataPoolBehavior';
 import { useAutkGrammarBehavior, attachMapInteractionZoomFix } from '../../../adapters/node/autkGrammarBehavior';
+import { __resetWebGpuSupportCache } from '../../../utils/webgpuSupport';
 
 function makeMockData(overrides: Partial<NodeBehaviorData> = {}): NodeBehaviorData {
   return {
@@ -346,6 +347,24 @@ describe('Behavior hooks — NodeBehaviorHook contract conformance', () => {
   });
 
   describe('useAutkGrammarBehavior', () => {
+    // Autark refuses to run without a WebGPU adapter now (#201), and jsdom has
+    // no `navigator.gpu` at all - so without this every case in here would take
+    // the refusal path and assert nothing about the grammar. The dedicated
+    // coverage for the refusal itself is
+    // `autkGrammarWebgpuFallback.test.tsx`.
+    beforeEach(() => {
+      __resetWebGpuSupportCache();
+      Object.defineProperty(navigator, 'gpu', {
+        configurable: true,
+        value: { requestAdapter: jest.fn().mockResolvedValue({ name: 'fake' }) },
+      });
+    });
+
+    afterEach(() => {
+      __resetWebGpuSupportCache();
+      Object.defineProperty(navigator, 'gpu', { configurable: true, value: undefined });
+    });
+
     test('returns applyGrammar, contentComponent, and default spec', async () => {
       const result = await callBehavior(useAutkGrammarBehavior);
       assertValidBehaviorResult(result.current);

--- a/utk_curio/frontend/urban-workflows/src/tests/components/errorBoundary.test.tsx
+++ b/utk_curio/frontend/urban-workflows/src/tests/components/errorBoundary.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * One broken subtree must not take the app with it (#201).
+ *
+ * There was no error boundary anywhere in the app, so a throw while rendering a
+ * single node unmounted the whole React root: canvas, menus and every other
+ * node gone, leaving a blank document. The reported trigger was an Autark node
+ * on a browser without WebGPU, but any node that throws does the same thing,
+ * which is why the containment is asserted separately from the WebGPU fix.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ErrorBoundary from '../../components/ErrorBoundary';
+
+function Boom({ message = "kaboom" }: { message?: string }): React.ReactElement {
+  throw new Error(message);
+}
+
+let consoleError: jest.SpyInstance;
+
+beforeEach(() => {
+  // React logs the caught error itself; silencing keeps the run readable
+  // without hiding a genuine failure, since every assertion is on the DOM.
+  consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleError.mockRestore();
+});
+
+describe('ErrorBoundary', () => {
+  test('renders its children when nothing throws', () => {
+    render(
+      <ErrorBoundary>
+        <div>all good</div>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('all good')).toBeInTheDocument();
+  });
+
+  test('contains a throwing child instead of unmounting the tree', () => {
+    render(
+      <ErrorBoundary>
+        <Boom message="node exploded" />
+      </ErrorBoundary>,
+    );
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent('node exploded');
+  });
+
+  test('a sibling subtree still mounts — the blast radius is one boundary', () => {
+    // This is the actual claim of the fix: the canvas around a broken node
+    // keeps rendering. Two boundaries, only one of them tripped.
+    render(
+      <div>
+        <ErrorBoundary label="node a">
+          <Boom />
+        </ErrorBoundary>
+        <ErrorBoundary label="node b">
+          <div>sibling still here</div>
+        </ErrorBoundary>
+      </div>,
+    );
+
+    expect(screen.getByText('sibling still here')).toBeInTheDocument();
+    expect(screen.getAllByRole('alert')).toHaveLength(1);
+  });
+
+  test('a custom fallback replaces the default notice', () => {
+    render(
+      <ErrorBoundary fallback={(err) => <p>custom: {err.message}</p>}>
+        <Boom message="specific" />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('custom: specific')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  test('reports the error to onError, with the label in the console line', () => {
+    const onError = jest.fn();
+    render(
+      <ErrorBoundary label="node autk-1" onError={onError}>
+        <Boom message="createShaderModule of undefined" />
+      </ErrorBoundary>,
+    );
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(onError.mock.calls[0][0].message).toBe('createShaderModule of undefined');
+    // The label is what makes a console line attributable to a node id.
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('node autk-1'),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  test('an error with no message still renders something actionable', () => {
+    render(
+      <ErrorBoundary>
+        <Boom message="" />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'This part of the page could not be rendered.',
+    );
+  });
+});

--- a/utk_curio/frontend/urban-workflows/src/tests/providers/dashboardModeGuard.test.tsx
+++ b/utk_curio/frontend/urban-workflows/src/tests/providers/dashboardModeGuard.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * Dashboard Mode with nothing pinned used to blank the app (#192).
+ *
+ * Two defects compounded. `MainCanvas` passed the SAME handler to two props and
+ * `UpMenu` called both, so every click ran the toggle twice. And on entry
+ * `applyDashboardLayout` returns the nodes untouched when no node is pinned,
+ * after which every node is given `display: none`, every edge is hidden, and
+ * `{!dashboardOn && <UpMenu>}` removes the top bar — so the screen went empty
+ * with only DashboardPanel's ✕ left to escape by.
+ *
+ * Drives the REAL FlowProvider inside a real ReactFlowProvider, the harness
+ * `mergeFlowPropagation.test.tsx` established, because the guard lives in
+ * `setDashBoardMode` and reads state the provider owns.
+ */
+import React from 'react';
+import fs from 'fs';
+import path from 'path';
+import { render, act } from '@testing-library/react';
+import { ReactFlow, ReactFlowProvider } from 'reactflow';
+
+// ── jsdom polyfills ReactFlow needs ────────────────────────────────────────
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as any).ResizeObserver = ResizeObserverStub;
+if (!(global as any).DOMMatrixReadOnly) {
+  (global as any).DOMMatrixReadOnly = class { m22 = 1; constructor() {} };
+}
+
+jest.mock('../../hook/useWorkflowOperations', () => ({
+  useWorkflowOperations: () => ({
+    markNodeExecuted: jest.fn(),
+    markNodeStale: jest.fn(),
+    markDirty: jest.fn(),
+    persistDataflowForInstall: jest.fn().mockResolvedValue(undefined),
+    beginPendingInstall: jest.fn(),
+    endPendingInstall: jest.fn(),
+    applyRemoveChanges: jest.fn(),
+    applyReviewedRemovals: jest.fn(),
+    allMinimized: false,
+    setAllMinimized: jest.fn(),
+    expandStatus: {},
+    setExpandStatus: jest.fn(),
+    updateDataNode: jest.fn(),
+    updateDefaultCode: jest.fn(),
+    workflowGoal: '',
+    acceptSuggestion: jest.fn(),
+  }),
+}));
+
+const mockShowToast = jest.fn();
+jest.mock('../../providers/ToastProvider', () => ({
+  useToastContext: () => ({ showToast: mockShowToast }),
+}));
+
+jest.mock('../../providers/CollaborationProvider', () => ({
+  useCollab: () => ({
+    enabled: false,
+    lockedNodes: {},
+    currentUserId: null,
+    lockNode: jest.fn(),
+    unlockNode: jest.fn(),
+    signalExecDisplay: jest.fn(),
+    broadcastOutputProduced: jest.fn(),
+    broadcastNodeAdded: jest.fn(),
+    broadcastNodeRemoved: jest.fn(),
+    broadcastEdgeAdded: jest.fn(),
+    broadcastEdgeRemoved: jest.fn(),
+    onRemote: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hook/useCode', () => ({
+  pythonInterpreter: {},
+  jsInterpreter: {},
+}));
+
+jest.mock('../../hook/useVega', () => ({
+  useVega: () => ({ handleCompileGrammar: jest.fn().mockResolvedValue(undefined) }),
+}));
+jest.mock('vega', () => ({}), { virtual: true });
+jest.mock('vega-lite', () => ({}), { virtual: true });
+
+import FlowProvider, { useFlowContext } from '../../providers/FlowProvider';
+import { CURIO_UNIVERSAL_NODE_TYPE } from '../../constants';
+
+type FlowApi = ReturnType<typeof useFlowContext>;
+let api: FlowApi;
+
+const Bridge: React.FC = () => {
+  const ctx = useFlowContext();
+  api = ctx;
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <ReactFlow
+        nodes={ctx.nodes}
+        edges={ctx.edges}
+        onNodesChange={ctx.onNodesChange}
+        onEdgesChange={ctx.onEdgesChange}
+      />
+    </div>
+  );
+};
+
+function renderFlow() {
+  return render(
+    <ReactFlowProvider>
+      <FlowProvider>
+        <Bridge />
+      </FlowProvider>
+    </ReactFlowProvider>,
+  );
+}
+
+function makeNode(id: string) {
+  return {
+    id,
+    type: CURIO_UNIVERSAL_NODE_TYPE,
+    position: { x: 0, y: 0 },
+    data: { nodeId: id, nodeType: 'curio.builtin/data-pool@1', input: '', inputTypes: [] },
+  } as any;
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function addNodes(ids: string[]) {
+  await act(async () => {
+    ids.forEach((id) => api.addNode(makeNode(id), undefined, false));
+  });
+  await flush();
+}
+
+/** Every node currently hidden by the dashboard's `display: none`. */
+function hiddenNodeIds(): string[] {
+  return api.nodes
+    .filter((n: any) => n.style?.display === 'none')
+    .map((n: any) => n.id);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('entering Dashboard Mode with nothing pinned', () => {
+  test('is refused, and the canvas is left exactly as it was', async () => {
+    renderFlow();
+    await addNodes(['a', 'b']);
+
+    await act(async () => {
+      api.setDashBoardMode(true);
+    });
+    await flush();
+
+    expect(api.dashboardOn).toBe(false);
+    // The reported symptom: every node hidden behind a menu-less screen.
+    expect(hiddenNodeIds()).toEqual([]);
+  });
+
+  test('says what to do about it', async () => {
+    renderFlow();
+    await addNodes(['a']);
+
+    await act(async () => {
+      api.setDashBoardMode(true);
+    });
+    await flush();
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      'Pin at least one node to the dashboard first.',
+      'warning',
+    );
+  });
+
+  test('leaves the edges visible, so exiting is not required to see the flow', async () => {
+    renderFlow();
+    await addNodes(['a', 'b']);
+
+    await act(async () => {
+      api.setDashBoardMode(true);
+    });
+    await flush();
+
+    expect(api.edges.every((e: any) => !e.hidden)).toBe(true);
+  });
+});
+
+describe('entering Dashboard Mode with a node pinned', () => {
+  test('succeeds, and hides only the unpinned nodes', async () => {
+    renderFlow();
+    await addNodes(['a', 'b']);
+
+    await act(async () => {
+      api.setPinForDashboard('a', true);
+    });
+    await flush();
+
+    await act(async () => {
+      api.setDashBoardMode(true);
+    });
+    await flush();
+
+    expect(api.dashboardOn).toBe(true);
+    expect(hiddenNodeIds()).toEqual(['b']);
+    // No refusal toast on the path that should work.
+    expect(mockShowToast).not.toHaveBeenCalledWith(
+      expect.stringContaining('Pin at least one node'),
+      expect.anything(),
+    );
+  });
+
+  test('leaving restores every node', async () => {
+    renderFlow();
+    await addNodes(['a', 'b']);
+
+    await act(async () => {
+      api.setPinForDashboard('a', true);
+    });
+    await flush();
+    await act(async () => {
+      api.setDashBoardMode(true);
+    });
+    await flush();
+    await act(async () => {
+      api.setDashBoardMode(false);
+    });
+    await flush();
+
+    expect(api.dashboardOn).toBe(false);
+    expect(hiddenNodeIds()).toEqual([]);
+  });
+});
+
+describe('the toggle is wired once, not twice', () => {
+  // Source-level, because the double call is a wiring shape rather than an
+  // observable state difference: both props held the SAME handler, so running
+  // it twice per click left `dashboardOn` looking correct while every side
+  // effect (layout, pin positions, edge hiding) ran twice.
+  const read = (rel: string) =>
+    fs.readFileSync(path.resolve(__dirname, '../..', rel), 'utf8');
+
+  test('MainCanvas passes one dashboard setter to UpMenu', () => {
+    const src = read('components/MainCanvas.tsx');
+    expect(src).toContain('setDashBoardMode={handleDashboardToggle}');
+    expect(src).not.toContain('setDashboardOn={handleDashboardToggle}');
+  });
+
+  test('UpMenu neither declares nor calls a second setter', () => {
+    const src = read('components/menus/top/UpMenu.tsx');
+    expect(src).not.toContain('setDashboardOn');
+  });
+});

--- a/utk_curio/frontend/urban-workflows/src/utils/webgpuSupport.ts
+++ b/utk_curio/frontend/urban-workflows/src/utils/webgpuSupport.ts
@@ -1,0 +1,66 @@
+/**
+ * Does this browser actually have a usable WebGPU device? (#201)
+ *
+ * Nothing in the app asked before: `autkGrammarBehavior` constructed and ran
+ * the grammar unconditionally, and `@urban-toolkit/autk-map` swallows its own
+ * init failure - `Renderer.init()` only `console.error`s "WebGPU is not
+ * available" and leaves `_device` undefined, so `AutkMap.init()` carries on
+ * until the layer loader reaches `this._renderer.device.createShaderModule`
+ * and throws the reported TypeError. In Firefox and Safari that is every
+ * Autark node.
+ *
+ * Presence of `navigator.gpu` is not enough on its own. Chrome exposes it on
+ * hardware it then refuses to run on (blocklisted drivers, a headless run with
+ * no adapter), where `requestAdapter()` resolves **null** rather than throwing,
+ * so the probe has to go all the way to an adapter.
+ */
+
+export interface WebGpuSupport {
+  supported: boolean;
+  /** Why not, phrased for a user rather than a log. Absent when supported. */
+  reason?: string;
+}
+
+/** Memoised across calls: `requestAdapter()` is genuinely expensive, the answer
+ *  cannot change for the life of the page, and a canvas full of Autark nodes
+ *  would otherwise probe once per node. */
+let cached: Promise<WebGpuSupport> | null = null;
+
+const NO_API =
+  "This browser has no WebGPU support. Use Chrome or Edge, or in Firefox enable " +
+  "dom.webgpu.enabled in about:config.";
+
+const NO_ADAPTER =
+  "WebGPU is present but no graphics adapter is available, so Autark cannot " +
+  "render here. This is usually a blocklisted driver or a headless session; " +
+  "try Chrome or Edge on a machine with a GPU.";
+
+async function probe(): Promise<WebGpuSupport> {
+  const gpu = (navigator as unknown as { gpu?: { requestAdapter(): Promise<unknown> } })
+    .gpu;
+  if (!gpu || typeof gpu.requestAdapter !== "function") {
+    return { supported: false, reason: NO_API };
+  }
+  try {
+    const adapter = await gpu.requestAdapter();
+    if (!adapter) return { supported: false, reason: NO_ADAPTER };
+    return { supported: true };
+  } catch (err) {
+    // Firefox throws here rather than resolving null when the pref is off.
+    return {
+      supported: false,
+      reason: `${NO_API} (${(err as Error)?.message ?? "requestAdapter failed"})`,
+    };
+  }
+}
+
+export function detectWebGpuSupport(): Promise<WebGpuSupport> {
+  if (!cached) cached = probe();
+  return cached;
+}
+
+/** Test-only: drops the memoised answer so a case can install its own
+ *  `navigator.gpu` and be probed afresh. */
+export function __resetWebGpuSupportCache(): void {
+  cached = null;
+}


### PR DESCRIPTION
Two ways the app could break irrecoverably in front of a user.

### #192 — Clicking "Dashboard Mode" breaks the application

Entering dashboard mode with nothing pinned laid out zero nodes and left a blank
canvas with no way back. Entry is now refused with a toast that says why, so you never
land somewhere you cannot leave. Enter and leave go through one function rather than
two call sites that had drifted.

An `ErrorBoundary` also goes in around the canvas: a render throw anywhere below it
used to blank the whole page.

### #201 — Unsupported WebGPU environments (e.g. Firefox)

Autark nodes assumed `navigator.gpu` and threw on a browser without it, which is every
Firefox. New `detectWebGpuSupport()` with a cached probe, and the node falls back with
an explanation instead of throwing.

### Tests

The dashboard guard (including the nothing-pinned refusal and the round trip), the
WebGPU fallback, the error boundary, and behaviour registration. Plus walkthroughs for
both.
