### PR TITLE
stop the Node Builder leaking raw JSON instead of creating a node (#245)

### DIFF
--- a/utk_curio/backend/app/agents/content.py
+++ b/utk_curio/backend/app/agents/content.py
@@ -688,6 +688,70 @@ def plan_tail_diagnosis(tail_body: str | None) -> list[str] | None:
     return errors
 
 
+def tool_tail_diagnosis(tail_body: str | None) -> list[str] | None:
+    """Classify a terminal tail body as a toolRequest attempt (#245).
+
+    The ``plan_tail_diagnosis`` twin, and the same three-way contract:
+    ``None`` — not a request attempt, so generic fail-open applies untouched;
+    ``[]`` — a valid request; ``[errors]`` — a request attempt with correctable
+    problems, JSON breakage included, which is exactly what the corrective
+    round feeds back.
+    """
+    if not isinstance(tail_body, str) or '"toolRequest"' not in tail_body:
+        return None
+    try:
+        payload = json.loads(tail_body)
+    except (ValueError, TypeError) as exc:
+        return [f"the block is not valid JSON: {exc}"]
+    if not isinstance(payload, dict) or "toolRequest" not in payload:
+        return None
+    _, errors = parse_tool_request_verbose(payload["toolRequest"])
+    return errors
+
+
+def extract_tool_request_attempt(reply: str) -> tuple[str, object]:
+    """Fence-agnostic toolRequest recognition (#245) — the dev/56 treatment
+    plans already get, applied to tool requests.
+
+    Consulted only after the terminal curio.v1 paths found nothing. Live
+    models put the block in a ```json fence, or follow it with a closing
+    sentence, either of which demotes a perfectly good request to inert text —
+    and for a mutate tool that text is a whole source file rendered as chat.
+
+    Scans every fenced block for a request payload: ``{"toolRequest": …}`` or
+    the bare ``{"tool": …, "params": {…}}`` object. Returns
+    ``(reply_with_the_block_stripped, payload)`` where payload is the raw
+    request dict, the unparseable block body (``str`` — so the JSON error still
+    feeds back), or ``None`` when the reply carries no request attempt. The
+    caller owns the grant check: this is grammar, not authority.
+    """
+    if not isinstance(reply, str) or "```" not in reply:
+        return reply, None
+    for match in reversed(list(_FENCE_RE.finditer(reply))):
+        body = match.group(1)
+        marked = '"toolRequest"' in body
+        if not marked and '"tool"' not in body:
+            continue
+        if len(body.encode("utf-8")) > PLAN_TAIL_MAX_BYTES:
+            continue
+        stripped = (reply[: match.start()] + reply[match.end():]).strip()
+        try:
+            payload = json.loads(body)
+        except (ValueError, TypeError):
+            if marked:
+                return stripped, body  # a request-ish block with broken JSON
+            continue  # a broken unmarked block is too ambiguous to claim
+        if not isinstance(payload, dict):
+            continue
+        if isinstance(payload.get("toolRequest"), dict):
+            return stripped, payload["toolRequest"]
+        # The wrapper-less form: a bare request object. Claimed only on the
+        # full shape, so a chatty JSON block never parses as one by accident.
+        if isinstance(payload.get("tool"), str) and isinstance(payload.get("params"), dict):
+            return stripped, payload
+    return reply, None
+
+
 def _parse_delegate_request(raw: object) -> dict | None:
     if not isinstance(raw, dict):
         return None

--- a/utk_curio/backend/app/agents/content.py
+++ b/utk_curio/backend/app/agents/content.py
@@ -205,23 +205,111 @@ _TOOL_PARAM_BUDGETS = {
     "package.draft.apply": PLAN_TAIL_MAX_BYTES,  # dev/89
 }
 
+# #245: the mutate contracts whose params carry a node's SOURCE — the very
+# bytes their mints already accept up to PROPOSAL_CONTENT_MAX_CHARS. The
+# classic 1KB params cap refused at PARSE time what the mint accepts at 64KB,
+# so every non-trivial node.create failed open (§4.2) and the model's whole
+# request landed in the chat as raw JSON with no node and no review card.
+#
+# The budget is scoped to the CONTENT FIELD, not to the tool: a per-tool
+# budget would also hand the tool's other params a 256KB allowance, which is
+# exactly the smuggling shape the dev/89 tail tests pin against. The path is
+# per-tool because node.template.create NESTS its content one level down.
+_CONTENT_PARAM_PATHS = {
+    "node.create": ("content",),
+    "node.content.write": ("content",),
+    "node.template.create": ("template", "content"),
+}
+# Everything BESIDE the content field keeps a classic-tail budget: nodeType,
+# nodeId, title, goal and appearance are tiny, and node.template.create's
+# justification is prose the review card shows. Not the 1KB tool cap (that
+# would starve the justification), and never the plan budget.
+_CONTENT_PARAM_REST_MAX_BYTES = TAIL_MAX_BYTES
 
-def _parse_tool_request(raw: object) -> dict | None:
+#: The tools whose TAIL may exceed TAIL_MAX_BYTES (both gates in parse_parts).
+_BIG_TAIL_TOOLS = frozenset(_TOOL_PARAM_BUDGETS) | frozenset(_CONTENT_PARAM_PATHS)
+
+
+def _pop_content_field(params: dict, path: tuple[str, ...]) -> tuple[str | None, dict]:
+    """Split *params* into ``(content_string, everything_else)`` for a
+    content-class tool.
+
+    The field is lifted only when it is actually a ``str``: a wrong-typed one
+    stays in the remainder, so the mint's own "must be a non-empty string"
+    refusal still fires and small malformed payloads behave exactly as before.
+    """
+    cursor: object = params
+    for key in path[:-1]:
+        if not isinstance(cursor, dict):
+            return None, params
+        cursor = cursor.get(key)
+    if not isinstance(cursor, dict) or not isinstance(cursor.get(path[-1]), str):
+        return None, params
+    content_text = cursor[path[-1]]
+    # Shallow copies down the path — the caller's params are never mutated.
+    rest = dict(params)
+    branch = rest
+    for key in path[:-1]:
+        branch[key] = dict(branch[key])
+        branch = branch[key]
+    branch.pop(path[-1], None)
+    return content_text, rest
+
+
+def parse_tool_request_verbose(raw: object) -> tuple[dict | None, list[str]]:
+    """Validate one ``toolRequest`` payload with field-level errors (#245).
+
+    The verbose sibling of :func:`_parse_tool_request`, mirroring the plan
+    pair (:func:`_parse_dataflow_plan` / :func:`_parse_dataflow_plan_verbose`):
+    the runtime's correction rounds feed these strings back to the model, so
+    each one must name the real field path and the real number.
+    """
     if not isinstance(raw, dict):
-        return None
+        return None, ["toolRequest must be an object"]
     tool = raw.get("tool")
     if not (isinstance(tool, str) and _TOOL_ID_RE.match(tool)):
-        return None
+        return None, ["toolRequest.tool must be a tool id like node.create"]
     params = raw.get("params", {})
     if not isinstance(params, dict):
-        return None
-    try:
+        return None, ["toolRequest.params must be an object"]
+    errors: list[str] = []
+    path = _CONTENT_PARAM_PATHS.get(tool)
+    if path is not None:
+        where = "params." + ".".join(path)
+        content_text, rest = _pop_content_field(params, path)
+        if content_text is not None and len(content_text) > PROPOSAL_CONTENT_MAX_CHARS:
+            errors.append(
+                f"{where} is {len(content_text)} chars "
+                f"(max {PROPOSAL_CONTENT_MAX_CHARS})"
+            )
+        try:
+            rest_bytes = len(json.dumps(rest).encode("utf-8"))
+        except (TypeError, ValueError) as exc:
+            return None, [f"toolRequest.params is not JSON-serializable: {exc}"]
+        if rest_bytes > _CONTENT_PARAM_REST_MAX_BYTES:
+            errors.append(
+                f"the params other than {where} are {rest_bytes} bytes "
+                f"(max {_CONTENT_PARAM_REST_MAX_BYTES}) — put the code in "
+                f"{where}, not in other fields"
+            )
+    else:
         budget = _TOOL_PARAM_BUDGETS.get(tool, _TOOL_PARAMS_MAX_BYTES)
-        if len(json.dumps(params).encode("utf-8")) > budget:
-            return None
-    except (TypeError, ValueError):
-        return None
-    return {"type": "toolRequest", "tool": tool, "params": params}
+        try:
+            params_bytes = len(json.dumps(params).encode("utf-8"))
+        except (TypeError, ValueError) as exc:
+            return None, [f"toolRequest.params is not JSON-serializable: {exc}"]
+        if params_bytes > budget:
+            errors.append(f"toolRequest.params is {params_bytes} bytes (max {budget})")
+    if errors:
+        return None, errors
+    return {"type": "toolRequest", "tool": tool, "params": params}, []
+
+
+def _parse_tool_request(raw: object) -> dict | None:
+    """Strict-parse contract (the T2 rule): a valid request or ``None`` — the
+    verbose sibling carries the correction detail (#245)."""
+    request, errors = parse_tool_request_verbose(raw)
+    return request if not errors else None
 
 
 def _bounded_str(value: object, max_chars: int) -> str | None:
@@ -643,11 +731,11 @@ def parse_parts(body: str) -> list[dict] | None:
         # Plans get their own budget (dev/52; the toolRequest form too,
         # dev/55): the classic cap was sized for prompts/tool requests. The
         # substring check bounds json.loads cost before parsing; the
-        # payload-key check below closes the loophole.
+        # payload-key check below closes the loophole. #245 adds the
+        # content-class node tools, whose params carry a node's source.
         if body_bytes > PLAN_TAIL_MAX_BYTES or (
             '"dataflowPlan"' not in body
-            and '"dataflow.plan.write"' not in body
-            and '"package.draft.apply"' not in body  # dev/89: draft-class tails
+            and not any(f'"{tool}"' in body for tool in _BIG_TAIL_TOOLS)
             # dev/90 A6: authoring delegations carry look specs + findings.
             and not ('"delegateRequest"' in body and any(
                 f'"{capability}"' in body
@@ -663,12 +751,14 @@ def parse_parts(body: str) -> list[dict] | None:
     if body_bytes > TAIL_MAX_BYTES and "dataflowPlan" not in payload:
         req = payload.get("toolRequest")
         delegate_req = payload.get("delegateRequest")
-        big_tool = (isinstance(req, dict)
-                    and req.get("tool") in ("dataflow.plan.write", "package.draft.apply"))
+        big_tool = isinstance(req, dict) and req.get("tool") in _BIG_TAIL_TOOLS
         big_delegate = (isinstance(delegate_req, dict)  # dev/90 A6
                         and delegate_req.get("capability") in PACKAGE_AUTHORING_CAPABILITIES)
         if not (big_tool or big_delegate):
             return None  # the enlarged budget is for plan/draft/authoring payloads only
+        # A content-class tool's enlarged tail is spent on its CONTENT FIELD;
+        # parse_tool_request_verbose still holds every other param to the
+        # classic cap, so a padded non-content param cannot ride it (#245).
     if "proposal" in payload or "proposals" in payload:
         return None  # never accepted from the model (memo dev/41 §4.1)
     if "toolRequest" in payload and "delegateRequest" in payload:

--- a/utk_curio/backend/app/agents/services.py
+++ b/utk_curio/backend/app/agents/services.py
@@ -2117,18 +2117,17 @@ def _handle_plan_reply(
     return "cap", [p for p in parts if p.get("type") != "dataflowPlan"] + [card], None
 
 
-def _tool_correction_message(tool: str | None, errors: list[str]) -> dict:
+def _tool_correction_message(errors: list[str]) -> dict:
     """The corrective round's feedback for a tool request (#245) — the
     ``_plan_correction_message`` twin: precise, model-actionable, and explicit
     that the invalid block never reached the user."""
     listed = "\n".join(f"- {e}" for e in errors[:10])
-    named = f"{tool} " if tool else ""
     return {
         "role": "user",
         "content": (
-            f"[tool validation] Your {named}tool request block was invalid and "
-            "was NOT shown to the user. Fix exactly these problems and resend "
-            "the COMPLETE corrected block (same fence syntax):\n" + listed
+            "[tool validation] Your tool request block was invalid and was NOT "
+            "shown to the user. Fix exactly these problems and resend the "
+            "COMPLETE corrected block (same fence syntax):\n" + listed
         ),
     }
 
@@ -2199,7 +2198,6 @@ def _handle_tool_reply(
         "put the tool request in a ```curio.v1 fenced block as the VERY LAST "
         "thing in your reply (not ```json, and with no text after it)"
     )
-    tool: str | None = None
 
     _, tail_body = content.split_tail(reply)
     errors = content.tool_tail_diagnosis(tail_body)
@@ -2227,7 +2225,6 @@ def _handle_tool_reply(
         else:
             if not _claimed(raw):
                 return "none", parts, None, None
-            tool = _requested_tool_of(raw)
             request, request_errors = content.parse_tool_request_verbose(raw)
             if request is not None:
                 return "request", parts, stripped, request
@@ -7118,7 +7115,7 @@ def run_attachment(
                         rounds_used += 1
                         messages_work.append({"role": "assistant", "content": reply})
                         messages_work.append(
-                            _tool_correction_message(_requested_tool_of(req), payload)
+                            _tool_correction_message(payload)
                         )
                         continue
                 if req is None:
@@ -7503,7 +7500,7 @@ def stream_attachment(
                                 {"role": "assistant", "content": result["reply"]}
                             )
                             messages_work.append(
-                                _tool_correction_message(_requested_tool_of(req), payload)
+                                _tool_correction_message(payload)
                             )
                             continue
                         # A held request tail is NOT released at the cap: see

--- a/utk_curio/backend/app/agents/services.py
+++ b/utk_curio/backend/app/agents/services.py
@@ -2117,6 +2117,136 @@ def _handle_plan_reply(
     return "cap", [p for p in parts if p.get("type") != "dataflowPlan"] + [card], None
 
 
+def _tool_correction_message(tool: str | None, errors: list[str]) -> dict:
+    """The corrective round's feedback for a tool request (#245) — the
+    ``_plan_correction_message`` twin: precise, model-actionable, and explicit
+    that the invalid block never reached the user."""
+    listed = "\n".join(f"- {e}" for e in errors[:10])
+    named = f"{tool} " if tool else ""
+    return {
+        "role": "user",
+        "content": (
+            f"[tool validation] Your {named}tool request block was invalid and "
+            "was NOT shown to the user. Fix exactly these problems and resend "
+            "the COMPLETE corrected block (same fence syntax):\n" + listed
+        ),
+    }
+
+
+def _tool_cap_card(errors: list[str]) -> dict:
+    """The visible outcome of a request attempt that never became proposable.
+
+    Distinct from :func:`_round_cap_cutoff_card`, which reports a *valid*
+    request dangling at the round cap. This one reports a request the runtime
+    could never turn into a proposal, and it is the ONLY thing the user sees
+    of that block — see ``_handle_tool_reply`` for why the raw JSON is dropped.
+    """
+    return {
+        "type": "card",
+        "kind": "error",
+        "title": "Proposal not created",
+        "lines": [e[:300] for e in errors[:10]],
+    }
+
+
+def _requested_tool_of(payload: object) -> str | None:
+    if isinstance(payload, dict) and isinstance(payload.get("tool"), str):
+        return payload["tool"]
+    return None
+
+
+def _handle_tool_reply(
+    loop_ctx: dict,
+    reply: str,
+    parts: list,
+    rounds_used: int,
+) -> tuple[str, list, str | None, dict | None]:
+    """In-loop toolRequest recovery (#245) — the dev/56 fence-agnostic scan and
+    the dev/54 correction rounds that plans already have, for tool requests.
+
+    Consulted ONLY after ``extract_content`` produced no request and
+    ``_handle_plan_reply`` returned ``"none"``, so every existing path is
+    byte-unchanged. ``extract_content`` itself is not touched: recovery lives
+    here, exactly as ``extract_plan_attempt`` does for plans.
+
+    Returns ``(kind, payload, visible_override, request)``:
+    ``("none", parts, None, None)`` — not a request attempt, generic fail-open
+    applies; ``("request", parts, stripped, req)`` — recovered, and the caller
+    runs it through the ordinary request path (grant check, mint, and round
+    accounting all unchanged); ``("correct", errors, None, None)`` — feed the
+    errors back and re-round (shares the MAX_TOOL_ROUNDS budget, since a
+    correction costs a real provider call); ``("cap", parts+card, stripped,
+    None)`` — budget exhausted: fail loudly, never silently.
+    """
+    granted = loop_ctx.get("granted") or []
+    if not granted:
+        # A run with no tools cannot be attempting one — an agent quoting the
+        # protocol keeps the pre-#245 fail-open behaviour exactly.
+        return "none", parts, None, None
+
+    def _claimed(payload: object) -> bool:
+        """A request is ours to correct only when it names a GRANTED tool.
+
+        Without this the runtime would 'correct' a model that merely echoed
+        the literal ``{"tool": "<tool id>", "params": {}}`` out of the tail
+        instruction — which is valid JSON — burning rounds on nothing.
+        """
+        tool = _requested_tool_of(payload)
+        return tool is not None and tool in granted
+
+    visible_override: str | None = None
+    fence_guidance = (
+        "put the tool request in a ```curio.v1 fenced block as the VERY LAST "
+        "thing in your reply (not ```json, and with no text after it)"
+    )
+    tool: str | None = None
+
+    _, tail_body = content.split_tail(reply)
+    errors = content.tool_tail_diagnosis(tail_body)
+    if errors:
+        import json as _json
+
+        try:
+            tool = _requested_tool_of((_json.loads(tail_body) or {}).get("toolRequest"))
+        except (ValueError, TypeError, AttributeError):
+            tool = None
+        if tool is not None and tool not in granted:
+            return "none", parts, None, None
+    else:
+        # No terminal-tail attempt (or a valid one, which never reaches here):
+        # scan every fence, wherever the model put it.
+        stripped, raw = content.extract_tool_request_attempt(reply)
+        if raw is None:
+            return "none", parts, None, None
+        if isinstance(raw, str):
+            # Broken JSON: claim it only when it names a granted tool, so a
+            # malformed block about something else stays the model's text.
+            if not any(f'"{t}"' in raw for t in granted):
+                return "none", parts, None, None
+            errors = (content.tool_tail_diagnosis(raw) or []) + [fence_guidance]
+        else:
+            if not _claimed(raw):
+                return "none", parts, None, None
+            tool = _requested_tool_of(raw)
+            request, request_errors = content.parse_tool_request_verbose(raw)
+            if request is not None:
+                return "request", parts, stripped, request
+            errors = request_errors + [fence_guidance]
+        visible_override = stripped
+
+    if rounds_used < MAX_TOOL_ROUNDS:
+        return "correct", errors, None, None
+    # The cap. Unlike a plan tail (dev/54 releases it — a plan is a spec the
+    # user can read), a mutate request's params are an entire source file:
+    # releasing it IS the bug this fixes (#245 — 60KB of Python rendered as
+    # chat prose under an Apply button that never existed). The model's own
+    # prose still shows; only the machine block drops, and the card names
+    # precisely why, which is more actionable than the JSON ever was.
+    if visible_override is None:
+        visible_override, _ = content.split_tail(reply)
+    return "cap", list(parts) + [_tool_cap_card(errors)], visible_override, None
+
+
 def _resolve_catalog_dataset(project_id: str, dataset_id: object) -> tuple[dict | None, str]:
     """Resolve a dataset id against the project's Data Catalog (dev/50 —
     the datasets domain is the single truth; `ADR-AG-007`). Returns
@@ -6976,11 +7106,33 @@ def run_attachment(
                     messages_work.append({"role": "assistant", "content": reply})
                     messages_work.append(_plan_correction_message(payload))
                     continue
-                effective_visible = visible_override if visible_override is not None else visible
-                if effective_visible:
-                    folded.append(effective_visible)
-                final_parts = payload
-                break
+                if kind == "none":
+                    # #245: only once the plan handler has declined — a
+                    # toolRequest the parser could not take (wrong fence,
+                    # trailing prose, correctable params) must never fold into
+                    # the chat as raw JSON.
+                    kind, payload, visible_override, req = _handle_tool_reply(
+                        loop_ctx, reply, parts, rounds_used
+                    )
+                    if kind == "correct":
+                        rounds_used += 1
+                        messages_work.append({"role": "assistant", "content": reply})
+                        messages_work.append(
+                            _tool_correction_message(_requested_tool_of(req), payload)
+                        )
+                        continue
+                if req is None:
+                    effective_visible = (
+                        visible_override if visible_override is not None else visible
+                    )
+                    if effective_visible:
+                        folded.append(effective_visible)
+                    final_parts = payload
+                    break
+                # A RECOVERED request falls through to the shared request path
+                # below, so grant re-check, mint, cap card and the dev/105 D2
+                # free-refusal accounting all apply to it unchanged.
+                visible = visible_override if visible_override is not None else visible
             if visible:
                 folded.append(visible)
             if rounds_used >= MAX_TOOL_ROUNDS:
@@ -7200,14 +7352,19 @@ def stream_attachment(
         return buf, ""
 
     def _stream_round(
-        messages_work: list, usage_sink: dict, result: dict, hold_plan_tail: bool = False
+        messages_work: list, usage_sink: dict, result: dict,
+        hold_plan_tail: bool = False, hold_request_tail: bool = False,
     ):
         """Stream one provider round: yields ("delta", text) with the dev/39
         tail withholding, then leaves {reply, visible, parts} in *result*.
         ``hold_plan_tail`` (dev/54): an INVALID tail that looks like a plan
         attempt is held (``result["heldPlanTail"]``) instead of flushed — the
         correction round must not leak raw plan JSON to the user; the caller
-        releases it at the round cap (fail-open transparency)."""
+        releases it at the round cap (fail-open transparency).
+        ``hold_request_tail`` (#245): the same for a mutate toolRequest tail —
+        held in ``result["heldToolTail"]`` and, unlike the plan tail, never
+        released: the params are a whole source file, and streaming them as
+        chat prose IS the bug (see ``_handle_tool_reply``)."""
         chunks: list[str] = []
         buf = ""  # pass-mode text not yet emitted
         withheld: str | None = None  # not None → holding a candidate tail
@@ -7251,6 +7408,13 @@ def stream_attachment(
                 # A failed plan attempt (dev/54): held for the correction
                 # round instead of leaking raw JSON into the chat.
                 result["heldPlanTail"] = withheld
+            elif hold_request_tail and '"toolRequest"' in withheld and any(
+                f'"{tool}"' in withheld for tool in MUTATE_PROPOSAL_TOOLS
+            ):
+                # #245: a failed mutate request. The old code fell to the
+                # fail-open branch below and streamed the whole node source
+                # into the transcript as it arrived.
+                result["heldToolTail"] = withheld
             else:
                 # Invalid or non-terminal tail: fail-open (dev/39 §4.2) — the
                 # withheld text is the model's, so it streams after all.
@@ -7292,6 +7456,9 @@ def stream_attachment(
                     usage_sink,
                     result,
                     hold_plan_tail="dataflow.plan.write" in loop_ctx.get("granted", []),
+                    hold_request_tail=bool(
+                        set(loop_ctx.get("granted") or []) & MUTATE_PROPOSAL_TOOLS
+                    ),
                 )
                 _add_usage(usage_total, usage_sink)
                 if usage_sink:
@@ -7321,18 +7488,45 @@ def stream_attachment(
                         )
                         messages_work.append(_plan_correction_message(payload))
                         continue
+                    if kind == "none":
+                        # #245: the toolRequest twin, after the plan handler.
+                        kind, payload, visible_override, req = _handle_tool_reply(
+                            loop_ctx, result["reply"], parts, rounds_used
+                        )
+                        if kind == "correct":
+                            rounds_used += 1
+                            yield (
+                                "tool_revision",
+                                {"attempt": rounds_used, "errors": len(payload)},
+                            )
+                            messages_work.append(
+                                {"role": "assistant", "content": result["reply"]}
+                            )
+                            messages_work.append(
+                                _tool_correction_message(_requested_tool_of(req), payload)
+                            )
+                            continue
+                        # A held request tail is NOT released at the cap: see
+                        # _handle_tool_reply — a source file is not a spec.
                     if kind == "cap" and result.get("heldPlanTail"):
                         # Fail-open transparency at the cap: the held tail is
                         # the model's text — released, then explained by the
                         # error card in `payload`.
                         yield ("delta", result["heldPlanTail"])
-                    effective_visible = (
-                        visible_override if visible_override is not None else result["visible"]
-                    )
-                    if effective_visible:
-                        folded.append(effective_visible)
-                    final_parts = payload
-                    break
+                    if req is not None:
+                        # A RECOVERED request: fall through to the shared
+                        # request path with the block stripped from the text.
+                        if visible_override is not None:
+                            result["visible"] = visible_override
+                    else:
+                        effective_visible = (
+                            visible_override if visible_override is not None
+                            else result["visible"]
+                        )
+                        if effective_visible:
+                            folded.append(effective_visible)
+                        final_parts = payload
+                        break
                 if result["visible"]:
                     folded.append(result["visible"])
                 if rounds_used >= MAX_TOOL_ROUNDS:

--- a/utk_curio/backend/tests/test_agents/test_builtin.py
+++ b/utk_curio/backend/tests/test_agents/test_builtin.py
@@ -232,6 +232,14 @@ class TestNodeBuilderComposite:
         assert text and "Reuse first" in text
         assert builtin.read_prompt_text(self.COORD, "system")  # default preamble
 
+    def test_instruction_sends_code_through_params_not_the_reply(self):
+        # #245: the runtime now recovers a misplaced request, but the cheapest
+        # fix is the model never misplacing it. Both the direct and the
+        # delegated create paths must name params.content as the code channel.
+        text = builtin.read_prompt_text(self.COORD, "instruction")
+        assert "params.content" in text
+        assert "code in your reply is not a node" in text
+
 
 class TestDatasetFinderComposite:
     """The dev/50 roster entry — spec per dev/15 §3.4 + docs/06, minus

--- a/utk_curio/backend/tests/test_agents/test_content.py
+++ b/utk_curio/backend/tests/test_agents/test_content.py
@@ -187,6 +187,95 @@ class TestToolRequestPart:
             assert content.parse_parts(json.dumps(payload)) is None
 
 
+class TestContentClassToolBudgets:
+    """#245 — the mutate tools whose params carry a node's SOURCE.
+
+    The parser refused at 1KB (``_TOOL_PARAMS_MAX_BYTES``) what the mints
+    accept at ``PROPOSAL_CONTENT_MAX_CHARS`` (65536), so every non-trivial
+    node.create failed open and the whole request rendered as raw JSON in the
+    chat with no node and no review card. The budget is scoped to the CONTENT
+    FIELD, never to the tool — the smuggling tests below are why.
+    """
+
+    def _request(self, tool, params):
+        return json.dumps({"toolRequest": {"tool": tool, "params": params}})
+
+    def test_node_create_content_gets_the_proposal_budget(self):
+        body = self._request("node.create", {
+            "nodeType": "curio.builtin/computation-analysis",
+            "content": "x" * 20000, "title": "Loader", "goal": "load a CSV"})
+        assert len(body.encode()) > content.TAIL_MAX_BYTES
+        (part,) = content.parse_parts(body)
+        assert part["tool"] == "node.create"
+        assert len(part["params"]["content"]) == 20000  # byte-identical passthrough
+
+    def test_content_over_the_mint_bound_is_refused(self):
+        # Parser and mint now agree at ONE number, so an oversized body is a
+        # correctable refusal rather than a silent fail-open leak.
+        body = self._request("node.create", {
+            "nodeType": "a/b", "content": "x" * (content.PROPOSAL_CONTENT_MAX_CHARS + 1)})
+        assert content.parse_parts(body) is None
+
+    def test_non_content_params_keep_a_classic_cap(self):
+        # The whole reason the budget is field-scoped: a per-tool budget would
+        # hand `pad` a 256KB allowance too.
+        body = self._request("node.create", {"pad": "x" * 8000})
+        assert content.parse_parts(body) is None
+
+    def test_node_content_write_gets_it_too(self):
+        (part,) = content.parse_parts(
+            self._request("node.content.write", {"nodeId": "n1", "content": "z" * 20000}))
+        assert part["tool"] == "node.content.write"
+
+    def test_node_template_create_nests_its_content(self):
+        # The fallback rung of the reuse ladder carries its source one level
+        # down, at params.template.content (services.py::_mint_node_template_create).
+        (part,) = content.parse_parts(self._request("node.template.create", {
+            "justification": "j" * 2000,
+            "template": {"label": "L", "engine": "python", "content": "y" * 20000}}))
+        assert len(part["params"]["template"]["content"]) == 20000
+        assert content.parse_parts(self._request("node.template.create", {
+            "template": {"content": "y" * (content.PROPOSAL_CONTENT_MAX_CHARS + 1)}})) is None
+        # The justification is prose for the review card, not a code channel.
+        assert content.parse_parts(self._request("node.template.create", {
+            "justification": "j" * 6000, "template": {"content": "y"}})) is None
+
+    def test_wrong_typed_content_still_reaches_the_mint(self):
+        # A non-str content field is left in the remainder so the mint's own
+        # "must be a non-empty string" refusal fires — behaviour unchanged.
+        assert content.parse_parts(self._request("node.create", {
+            "nodeType": "a/b", "content": {"not": "a string"}})) is not None
+
+    def test_other_tools_are_byte_identical(self):
+        assert content.parse_parts(self._request("node.read", {"x": "y" * 2000})) is None
+        (part,) = content.parse_parts(self._request("node.create", {
+            "nodeType": "a/b", "content": "print(1)"}))
+        assert part["params"]["content"] == "print(1)"
+
+    def test_smuggling_a_content_tool_name_stays_refused(self):
+        payload = {"suggestedPrompts": {"primary": "P"},
+                   "pad": '"node.create"' + "x" * 8000}
+        assert content.parse_parts(json.dumps(payload)) is None
+
+    def test_verbose_errors_name_the_real_field_path(self):
+        _, errors = content.parse_tool_request_verbose({
+            "tool": "node.template.create",
+            "params": {"template": {"content": "y" * (content.PROPOSAL_CONTENT_MAX_CHARS + 1)}}})
+        # The model cannot correct what the error does not name.
+        assert errors and "params.template.content" in errors[0]
+        _, errors = content.parse_tool_request_verbose({"tool": "node.create", "params": []})
+        assert errors == ["toolRequest.params must be an object"]
+
+    def test_the_reported_leak_is_gone_end_to_end(self):
+        # Issue #245's exact shape: prose, then the request block.
+        body = self._request("node.create", {
+            "nodeType": "curio.builtin/computation-analysis", "content": "x" * 20000})
+        visible, parts = content.extract_content("I will add that node.\n\n"
+                                                 f"```curio.v1\n{body}\n```")
+        assert parts and parts[0]["tool"] == "node.create"
+        assert "toolRequest" not in visible
+
+
 class TestTailInstruction:
     def test_grantless_instruction_is_byte_identical(self):
         # Regression pin (dev/41): runs without grants are unchanged from T2.

--- a/utk_curio/backend/tests/test_agents/test_routes.py
+++ b/utk_curio/backend/tests/test_agents/test_routes.py
@@ -5228,6 +5228,210 @@ class TestPlanToolRequestForm:
         assert content_mod.parse_parts(_json.dumps(big)) is None
 
 
+class TestToolRequestRecovery:
+    """#245 — a tool request the parser could not take must never fold into the
+    chat as raw JSON.
+
+    Plans got fence-agnostic recognition (dev/56) and correction rounds
+    (dev/54); tool requests never did, so a node.create in a ```json fence, or
+    one followed by a closing sentence, or one whose params were correctable,
+    was demoted to inert text — and for a mutate tool that text is a whole
+    source file rendered under an Apply button that never existed.
+    """
+
+    def _helper(self):
+        return TestNodeCreate()
+
+    def _json_fence(self, content="print('recovered')", trailing="Click Apply above."):
+        import json as _json
+
+        block = _json.dumps({"toolRequest": {"tool": "node.create", "params": {
+            "nodeType": "curio.builtin/computation-analysis", "content": content}}})
+        return f"Here is the node.\n\n```json\n{block}\n```\n\n{trailing}"
+
+    def _run(self, client, user, token, project, monkeypatch, replies):
+        helper = self._helper()
+        att_id, calls = helper._setup(
+            client, user=user, token=token, project_id=project,
+            monkeypatch=monkeypatch, replies=replies,
+        )
+        return helper._run(client, token, project, att_id), calls, att_id, helper
+
+    def test_json_fence_request_mints_and_strips_the_block(self, client, user_and_token, tmp_curio, alice_project, monkeypatch):
+        user, token = user_and_token
+        r, calls, _, _ = self._run(
+            client, user, token, alice_project, monkeypatch,
+            replies=[self._json_fence(), "Proposed."],
+        )
+        body = r.get_json()
+        assert any(p["type"] == "proposal" for p in body["content"])
+        # The block is stripped; the model's own prose survives.
+        assert "toolRequest" not in body["reply"]
+        assert "```" not in body["reply"]
+        assert "Click Apply above." in body["reply"]
+
+    def test_non_terminal_curio_fence_is_recovered(self, client, user_and_token, tmp_curio, alice_project, monkeypatch):
+        # extract_content deliberately refuses a non-terminal block (dev/90
+        # A10's conservative boundary); recovery claims it at the runtime layer.
+        import json as _json
+
+        user, token = user_and_token
+        block = _json.dumps({"toolRequest": {"tool": "node.create", "params": {
+            "nodeType": "curio.builtin/computation-analysis", "content": "print(1)"}}})
+        reply = f"Adding it.\n\n```curio.v1\n{block}\n```\n\nDone."
+        r, _, _, _ = self._run(client, user, token, alice_project, monkeypatch,
+                               replies=[reply, "Proposed."])
+        body = r.get_json()
+        assert any(p["type"] == "proposal" for p in body["content"])
+        assert "toolRequest" not in body["reply"]
+
+    def test_large_content_survives_recovery(self, client, user_and_token, tmp_curio, alice_project, monkeypatch):
+        # Both halves of #245 at once: a wrong fence AND a body past the old cap.
+        user, token = user_and_token
+        source = "import pandas as pd\n# analysis\n" * 400
+        r, _, att_id, helper = self._run(
+            client, user, token, alice_project, monkeypatch,
+            replies=[self._json_fence(content=source), "Proposed."],
+        )
+        proposal = helper._proposal_from_run(r)
+        assert proposal["tool"] == "node.create"
+        assert "import pandas" not in r.get_json()["reply"]
+        resp = client.post(
+            f"/api/agents/projects/{alice_project}/attachments/{att_id}"
+            f"/proposals/{proposal['proposalId']}/apply",
+            headers=_auth(token),
+        )
+        assert resp.get_json()["createdNode"]["content"] == source.strip()
+
+    def test_broken_json_request_corrects_then_mints(self, client, user_and_token, tmp_curio, alice_project, monkeypatch):
+        user, token = user_and_token
+        broken = ('Attempt one.\n\n```curio.v1\n'
+                  '{"toolRequest": {"tool": "node.create", "params": {oops}\n```')
+        helper = self._helper()
+        r, calls, _, _ = self._run(
+            client, user, token, alice_project, monkeypatch,
+            replies=[broken, helper._create_tail_json(content="print('fixed')"), "Proposed."],
+        )
+        assert len(calls) >= 2
+        # `calls` aliases the live message list, so scan the whole conversation
+        # rather than indexing a snapshot that no longer exists.
+        feedback = "\n".join(m["content"] for m in calls[-1] if isinstance(m.get("content"), str))
+        assert "[tool validation]" in feedback
+        assert "not valid JSON" in feedback
+        body = r.get_json()
+        assert any(p["type"] == "proposal" for p in body["content"])
+        # The invalid attempt never reaches the user — not its prose, not its JSON.
+        assert "Attempt one." not in body["reply"]
+        assert "toolRequest" not in body["reply"]
+
+    def test_oversized_content_corrects_instead_of_leaking(self, client, user_and_token, tmp_curio, alice_project, monkeypatch):
+        # Past PROPOSAL_CONTENT_MAX_CHARS the parser and the mint agree, so the
+        # model gets a correctable refusal naming the real field.
+        from utk_curio.backend.app.agents import content as content_mod
+
+        user, token = user_and_token
+        helper = self._helper()
+        r, calls, _, _ = self._run(
+            client, user, token, alice_project, monkeypatch,
+            replies=[
+                helper._create_tail_json(
+                    content="x" * (content_mod.PROPOSAL_CONTENT_MAX_CHARS + 1)),
+                helper._create_tail_json(content="print('small enough')"),
+                "Proposed.",
+            ],
+        )
+        feedback = "\n".join(m["content"] for m in calls[-1] if isinstance(m.get("content"), str))
+        assert "[tool validation]" in feedback
+        assert "params.content is" in feedback  # the error names the real field
+        body = r.get_json()
+        assert any(p["type"] == "proposal" for p in body["content"])
+        assert "x" * 200 not in body["reply"]
+
+    def test_persistent_failure_contains_the_raw_json(self, client, user_and_token, tmp_curio, alice_project, monkeypatch):
+        """The deliberate inverse of the plan cap, which asserts
+        ``"curio.v1" in body["reply"]``.
+
+        A plan tail is a spec the user can read, so dev/54 releases it at the
+        cap. A mutate request's params are an entire source file — releasing
+        that IS the #245 bug, so the block drops and the card explains instead.
+        """
+        user, token = user_and_token
+        broken = ('```curio.v1\n{"toolRequest": {"tool": "node.create", '
+                  '"params": {oops}\n```')
+        r, calls, _, _ = self._run(client, user, token, alice_project, monkeypatch,
+                                   replies=[broken])
+        body = r.get_json()
+        assert len(calls) == 4  # the shared MAX_TOOL_ROUNDS budget, then the cap
+        assert all(p["type"] != "proposal" for p in body["content"])
+        card = next(p for p in body["content"] if p["type"] == "card")
+        assert card["title"] == "Proposal not created"
+        assert "not valid JSON" in card["lines"][0]
+        assert "curio.v1" not in body["reply"]
+        assert "toolRequest" not in body["reply"]
+
+    def test_echoed_syntax_does_not_burn_a_round(self, client, user_and_token, tmp_curio, alice_project, monkeypatch):
+        # The tail instruction's own literal template is valid JSON. Correcting
+        # a model that merely quoted it would spend the budget on nothing.
+        user, token = user_and_token
+        echoed = ('To create a node I would send:\n\n```json\n'
+                  '{"toolRequest": {"tool": "<tool id>", "params": {}}}\n```')
+        r, calls, _, _ = self._run(client, user, token, alice_project, monkeypatch,
+                                   replies=[echoed])
+        assert len(calls) == 1
+        assert "<tool id>" in r.get_json()["reply"]  # fail-open, untouched
+
+    def test_ungranted_tool_is_not_claimed(self, client, user_and_token, tmp_curio, alice_project, monkeypatch):
+        # A request naming a tool this run does not hold stays the model's text.
+        import json as _json
+
+        user, token = user_and_token
+        block = _json.dumps({"toolRequest": {"tool": "package.install",
+                                             "params": {"dirName": "x@1"}}})
+        r, calls, _, _ = self._run(client, user, token, alice_project, monkeypatch,
+                                   replies=[f"Consider:\n\n```json\n{block}\n```"])
+        assert len(calls) == 1
+        assert "package.install" in r.get_json()["reply"]
+
+    def test_stream_holds_the_raw_request_tail(self, client, user_and_token, tmp_curio, alice_project, monkeypatch):
+        import json as _json
+
+        user, token = user_and_token
+        helper = self._helper()
+        att_id, _ = helper._setup(client, user=user, token=token, project_id=alice_project,
+                                  monkeypatch=monkeypatch, replies=["ignored"])
+        script = [
+            '```curio.v1\n{"toolRequest": {"tool": "node.create", "params": {oops}\n```',
+            helper._create_tail_json(content="print('fixed')"),
+            "Proposed.",
+        ]
+        calls = []
+
+        def _fake_stream(config, messages, **kwargs):
+            calls.append(messages)
+            reply = script[min(len(calls) - 1, len(script) - 1)]
+            for i in range(0, len(reply), 9):
+                yield reply[i:i + 9]
+
+        monkeypatch.setattr(
+            "utk_curio.backend.app.agents.services.stream_chat_completion", _fake_stream)
+        r = client.post(
+            f"/api/agents/projects/{alice_project}/attachments/{att_id}/run/stream",
+            json={"message": "build it"}, headers=_auth(token),
+        )
+        events = []
+        for block in r.get_data(as_text=True).strip().split("\n\n"):
+            lines = dict(l.split(": ", 1) for l in block.splitlines() if ": " in l)
+            if "event" in lines:
+                events.append((lines["event"], _json.loads(lines["data"])))
+        kinds = [k for k, _ in events]
+        assert "tool_revision" in kinds
+        # The invalid tail never streamed as text.
+        text = "".join(p.get("text", "") for k, p in events if k == "delta")
+        assert "curio.v1" not in text and "toolRequest" not in text
+        done = events[-1][1]
+        assert any(p["type"] == "proposal" for p in done["content"])
+
+
 class TestFenceAgnosticPlanRecognition:
     """dev/56 — the user's exact scenario: a valid plan in a ```json fence
     with prose after it must mint; the runtime meets the model where it

--- a/utk_curio/backend/tests/test_agents/test_routes.py
+++ b/utk_curio/backend/tests/test_agents/test_routes.py
@@ -2717,6 +2717,18 @@ class TestNodeCreate:
             f'"params": {{"nodeType": "{node_type}", "content": "{content}"{extra}}}}}}}\n```'
         )
 
+    def _create_tail_json(self, **params):
+        """The same block built with json.dumps (#245) — ``_create_tail`` is an
+        f-string and cannot express a multi-line source body."""
+        import json as _json
+
+        params.setdefault("nodeType", "curio.builtin/computation-analysis")
+        return (
+            "```curio.v1\n"
+            + _json.dumps({"toolRequest": {"tool": "node.create", "params": params}})
+            + "\n```"
+        )
+
     def _setup(self, client, user, token, project_id, monkeypatch, replies=None):
         from utk_curio.backend.app.projects.services import _user_dir_key
 
@@ -2824,6 +2836,60 @@ class TestNodeCreate:
         assert inserted["content"] == "print('new')"
         # Apply is deterministic — no quota consumed.
         assert ledger.aggregates(_user_dir_key(user))["runs"] == runs_before
+
+    def test_large_content_node_create_mints_and_applies(self, client, user_and_token, tmp_curio, alice_project, monkeypatch):
+        """Issue #245 — the reported bug, end to end.
+
+        A node body past the old 1KB params cap was refused by the tail parser
+        and the whole reply failed open, so the raw request JSON became the
+        chat message and no node ever reached the canvas. The mints have always
+        accepted content up to PROPOSAL_CONTENT_MAX_CHARS; only the parser
+        disagreed.
+        """
+        user, token = user_and_token
+        source = (
+            "import pandas as pd\n\n\n"
+            "def summarise(path, column):\n"
+            '    """Load a CSV and return the mean of one numeric column."""\n'
+            "    df = pd.read_csv(path)\n"
+            "    if column not in df.columns:\n"
+            '        raise ValueError(f"column {column} missing")\n'
+            '    series = pd.to_numeric(df[column], errors="coerce").dropna()\n'
+            '    return {"mean": float(series.mean()), "count": int(series.size)}\n'
+        ) * 40  # ~14KB: a realistic node, far past the old cap
+        assert len(source) > 4096
+        # extract_node_content trims the boundary, as it has always done.
+        stored = source.strip()
+        tail = self._create_tail_json(content=source, title="CSV mean", goal="summarise a column")
+        att_id, _ = self._setup(
+            client, token=token, user=user, project_id=alice_project, monkeypatch=monkeypatch,
+            replies=[tail, "Proposed a CSV summariser — review it above."],
+        )
+        r = self._run(client, token, alice_project, att_id)
+        assert r.status_code == 200
+        body = r.get_json()
+
+        proposal = self._proposal_from_run(r)
+        assert proposal["tool"] == "node.create"
+        assert proposal["status"] == "pending"
+        # The leak: none of the machine block may survive as chat prose.
+        assert "curio.v1" not in body["reply"]
+        assert "toolRequest" not in body["reply"]
+        assert "nodeType" not in body["reply"]
+        assert "import pandas" not in body["reply"]
+
+        resp = client.post(
+            f"/api/agents/projects/{alice_project}/attachments/{att_id}"
+            f"/proposals/{proposal['proposalId']}/apply",
+            headers=_auth(token),
+        )
+        assert resp.status_code == 200
+        created = resp.get_json()["createdNode"]
+        assert created["content"] == stored  # whole body, not truncated
+        nodes = self._spec_nodes(user, alice_project)
+        assert len(nodes) == 2
+        assert next(n for n in nodes if n["id"] == created["id"])["content"] == stored
+
         # The transcript logged the result card.
         turns = client.get(
             f"/api/agents/projects/{alice_project}/attachments/{att_id}/session",

--- a/utk_curio/llm-prompts/node_build_instruction.txt
+++ b/utk_curio/llm-prompts/node_build_instruction.txt
@@ -6,9 +6,9 @@ Follow this procedure, in order:
 
 2. Reuse first. Choose the node type ONLY from the "Available node templates" list appended to these instructions at run time. Prefer the closest existing template — built-in or from an installed package — that can execute or contain the required content. Never invent, guess, or abbreviate a template id; if the list is absent, you were not granted node creation and must answer in plain text instead.
 
-3. If the content is nontrivial (real code, a full grammar spec), you may delegate content generation before proposing: emit a delegate request for the "node.content.generate" capability with the node's intent and context as inputs, then use the returned content in your proposal.
+3. If the content is nontrivial (real code, a full grammar spec), you may delegate content generation before proposing: emit a delegate request for the "node.content.generate" capability with the node's intent and context as inputs, then put the returned content in the node.create request's params.content — do not repeat it in your reply.
 
-4. Propose exactly ONE node per request: emit one node.create tool request with the chosen template id and the complete content. A dataset-fetch request for an external source is a data-loading template whose content is the fetch code (request, parameters, parsing, error handling, output).
+4. Propose exactly ONE node per request: emit one node.create tool request with the chosen template id and the complete content. Put the whole code in the request's params.content field; never paste the node's code as a fenced code block in your reply text, because code in your reply is not a node. A dataset-fetch request for an external source is a data-loading template whose content is the fetch code (request, parameters, parsing, error handling, output).
 
 5. Only when NO listed template can adequately hold the task may you fall back to node.template.create. Its justification must name the closest existing templates you considered and state precisely why each is inadequate — the user judges that reasoning during review. Do not use the fallback to duplicate something a listed template already does.
 


### PR DESCRIPTION
Addresses #245.

## The bug

Ask the Node Builder for a node with real logic and the agent prints the node-specification JSON into the chat. No proposal card, no node on the canvas. The follow-up comment on the issue ("it delegated the work to Node Content Builder and gave me code that didn't work") is the same failure one round later, not a second bug: the delegate generates the code, the parent tries to propose it, and the request dies the same way.

## Root cause

Tool calls are not native function calls — the model ends its reply with a fenced block carrying `{"toolRequest": {"tool": "node.create", "params": {...}}}`, and `node.create`'s `content` param *is* the node's source code.

Three gates in `content.py` refused that:

| Gate | Limit | Exempted before this PR |
| --- | --- | --- |
| Tail body size (`parse_parts`) | `TAIL_MAX_BYTES` = 4096 | `dataflowPlan`, `dataflow.plan.write`, `package.draft.apply`, authoring delegations |
| Payload-key re-check | same | same |
| Params size (`_parse_tool_request`) | `_TOOL_PARAMS_MAX_BYTES` = 1024 | `_TOOL_PARAM_BUDGETS` — the same two |

`node.create`, `node.content.write` and `node.template.create` were on none of those lists, yet all three mints accept content up to `PROPOSAL_CONTENT_MAX_CHARS` = 65536. A 64x mismatch: the parser refused at 1KB what the mint accepts at 64KB.

The refusal then failed open — `extract_content` returns the reply untouched, `_handle_plan_reply` declines because the Node Builder holds no `dataflow.plan.write` grant, and the whole reply folds into the visible transcript. In streaming it was worse: `_stream_round` held a withheld tail only when it looked like a *plan*, so the raw JSON was painted on screen as it arrived.

Reproduced deterministically against `main`: a `node.create` carrying a ~1.9KB body (one 45-line pandas function) gives `parse_parts(...) -> None` and leaks the whole request.

A second, independent failure mode: `extract_content` requires the `curio.v1` fence *and* terminal position. Plans got fence-agnostic recovery (dev/56) and correction rounds (dev/54) precisely because models emit ` ```json ` or bare fences mid-reply. Tool requests never got that tolerance.

## The fix

**1. Budget the content field, not the tool.** The oversized thing is one named field whose bound already exists, so it is budgeted at the mint's own number and every other param keeps the classic cap.

Per-tool budgeting is the obvious move and is wrong: `_TOOL_PARAM_BUDGETS["node.create"] = PLAN_TAIL_MAX_BYTES` plus the two tail-gate edits makes the existing smuggle assertion in `test_large_package_draft_gets_the_draft_class_budget` *parse* an 8KB `pad` that must stay refused. Field scoping keeps that pin green unmodified. `node.template.create` nests its content at `params.template.content`, so the path is per-tool — handling only a top-level `content` key would have left the fallback rung of the reuse ladder broken at 1KB.

`_parse_tool_request` is split into a verbose sibling plus a thin wrapper, mirroring `_parse_dataflow_plan` / `_parse_dataflow_plan_verbose`, because the correction rounds need field-level errors.

**2. Fence-agnostic recovery + correction rounds**, the direct twins of the plan machinery: `content.tool_tail_diagnosis` and `content.extract_tool_request_attempt`, driven by `services._handle_tool_reply`, consulted only after `extract_content` found no request *and* `_handle_plan_reply` returned `"none"`. A recovered request falls through to the ordinary request path, so grant re-check, mint, the round cap and the dev/105 D2 free-refusal accounting all apply unchanged.

`extract_content` itself is untouched — recovery lives at the services layer, exactly as `extract_plan_attempt` does for plans — so the dev/90 A10 decorated-request contract is byte-identical.

An echo guard keeps the runtime from "correcting" a model that merely quoted the tail instruction's literal `{"tool": "<tool id>", "params": {}}`, which is valid JSON.

**3. Containment.** This deliberately diverges from the plan path, which *releases* its held tail at the cap (pinned as `"curio.v1" in body["reply"]`). A plan tail is a spec the user can read; a mutate request's params are an entire source file, and rendering it is the bug being fixed here. The block is excised and a "Proposal not created" card names precisely why, which is more actionable than the JSON. The streaming hold is generalized so the raw request never streams live either.

**4. Two prompt sentences** in `node_build_instruction.txt` pointing code at `params.content` on both the direct and delegated create paths. The fence syntax is deliberately *not* added to the prompt — `tail_instruction()` owns it so an edited intent can neither strip nor spoof it (dev/38).

No frontend change: the card renders through the existing `AgentChatCard` path.

## Verification

- `test_agents`: 952 passed, 1 skipped
- Full backend excluding e2e: 2645 passed. One failure, `test_one_million_row_load_and_preview`, confirmed failing identically on a stashed clean tree (a 38s sandbox round-trip — a timing test, unrelated).
- Agent e2e: 43/44. The one visual-baseline failure fails 20 of 21 on clean `origin/main` in the same workspace, so it is the fresh clone's missing baselines.

19 new tests, including the issue's own reproduction end to end: a 14KB node body mints a proposal, Apply inserts the node with byte-identical content, and `"toolRequest"`, `"nodeType"` and the code are all absent from the reply. Plus the `test_content.py` bounds matrix, fence-agnostic and non-terminal recovery, the correction round, the cap card, the echo guard, the ungranted-tool guard, and a streaming test asserting no delta ever carries the raw tail.

The existing smuggle and cap pins were deliberately left unmodified — that they still pass is the design's smoke test.

## Not covered

Manual verification against a live model has not been done; the reproduction in the issue is covered by an automated test rather than a hand-run session.

