### PR TITLE
Let only a real account write the shared catalog (#222)

### DIFF
--- a/utk_curio/backend/app/datasets/application/mutations.py
+++ b/utk_curio/backend/app/datasets/application/mutations.py
@@ -209,6 +209,10 @@ class CatalogMutations:
     def publish_dataset(self, dataset_id: str, metadata: dict[str, Any], *, dataflow_id: str | None = None, live_outputs: list[dict[str, Any]] | None = None) -> dict[str, Any]:
         from utk_curio.backend.app.datasets.infrastructure.storage import catalog_root
 
+        # Publishing writes into the shared catalog tree, which every account
+        # reads. Gate it on the account before anything is computed (#222).
+        self._assert_can_manage_shared_catalog("publish")
+
         item = deepcopy(self._owner.get_dataset(dataset_id, dataflow_id=dataflow_id, live_outputs=live_outputs))
         for key in ("title", "description", "license", "tags"):
             if key in metadata:
@@ -243,6 +247,12 @@ class CatalogMutations:
 
         dir_name = f"{catalog_id}@1"
         dest = catalog_root() / dir_name
+        # Publishing is a write to a path derived from the dataset id, so two
+        # accounts can land on the same ``dest``. Check the incumbent's manifest
+        # BEFORE mkdir: creating the tree first is itself a mutation, so a
+        # refusal that runs after it has already damaged the entry it refused
+        # to touch (#222).
+        self._assert_can_publish_to(dest, catalog_id)
         (dest / "data").mkdir(parents=True, exist_ok=True)
 
         # Copy data file into the catalog data/ subdirectory. A publishable
@@ -810,6 +820,61 @@ class CatalogMutations:
         except Exception:  # noqa: BLE001
             pass
 
+    def _assert_can_manage_shared_catalog(self, verb: str) -> None:
+        """Raise 403 unless the caller is an account that may write shared state.
+
+        Separate from :meth:`_assert_is_publisher`, which asks "is this yours?".
+        This asks the prior question: is the caller an identity ownership can be
+        attributed to at all? Every guest sign-in resolves to one shared ``User``
+        row, so for a guest the answer is no and no ownership check downstream
+        can recover it.
+        """
+        from utk_curio.backend.app.users.capabilities import can_manage_shared_catalog
+
+        if not can_manage_shared_catalog(self.user):
+            raise DatasetCatalogError(
+                f"Guest sessions share one account, so they cannot {verb} "
+                f"datasets in the shared Data Catalog. Sign in to {verb}.",
+                403,
+            )
+
+    def _assert_can_publish_to(self, dest: "Path", catalog_id: str) -> None:
+        """Raise 403 when *dest* is already published by someone else.
+
+        The publish path is derived from the dataset id, so two accounts can
+        resolve to the same directory. Without this, publishing was an
+        unauthenticated overwrite of whatever was already there: the reporter of
+        #222 guessed a missing server-side check and this was it.
+
+        A *free* destination is the normal case and passes. So does one this
+        caller published -- republishing your own dataset is how an update is
+        applied. Mirrors :meth:`_assert_is_publisher` deliberately, including
+        failing closed on an unreadable manifest.
+        """
+        from utk_curio.backend.app.datasets.domain.manifest import (
+            ManifestError,
+            load_dataset_manifest_from_dir,
+        )
+
+        if not (dest / "manifest.json").is_file():
+            # Nothing published here (or a leftover with no recorded owner):
+            # there is no incumbent to protect.
+            return
+        caller = str(self.user) if self.user is not None else None
+        try:
+            publisher = load_dataset_manifest_from_dir(dest).publisher
+        except (ManifestError, OSError, ValueError):
+            # Present but unreadable -> the owner is unknowable, so fail closed
+            # rather than let a truncated manifest become an overwrite vector.
+            publisher = None
+        if not caller or publisher != caller:
+            raise DatasetCatalogError(
+                f"'{catalog_id}' is already published by someone else. "
+                f"Publish it under a different name, or ask its publisher to "
+                f"update it.",
+                403,
+            )
+
     def _assert_is_publisher(self, catalog_dir: "Path", dataset_id: str) -> None:
         """Raise 403 unless the caller published *catalog_dir*.
 
@@ -871,6 +936,17 @@ class CatalogMutations:
             raise DatasetCatalogError(f"Dataset '{dataset_id}' is not in the Data Catalog", 404)
 
         dir_name = catalog_dir.name
+
+        # Account gate, ahead of the ownership gate rather than instead of it.
+        # ``_assert_is_publisher`` skips a directory with no manifest so legacy
+        # leftovers stay removable, and it compares ``str(user)`` -- the same
+        # string for every shared guest. Both are right for a real account and
+        # both are holes for the guest, so the guest is refused first (#222).
+        #
+        # Placed AFTER the 404 above on purpose: ``delete_dataset`` cascades
+        # through here and re-raises a 403, so gating before the lookup would
+        # stop a guest deleting a dataset of their own that was never published.
+        self._assert_can_manage_shared_catalog("unpublish")
 
         # Ownership gate (security): only the user who published this dataset may
         # remove it from the SHARED catalog tree. Without this, any authenticated

--- a/utk_curio/backend/app/users/capabilities.py
+++ b/utk_curio/backend/app/users/capabilities.py
@@ -1,0 +1,55 @@
+"""Account capability predicates.
+
+One place to answer "may this account do X?" for rules that turn on WHO the
+caller is rather than on what they own. Ownership questions stay with the
+resource (``CatalogMutations._assert_is_publisher``); this module answers the
+prior question of whether the account may touch shared state at all.
+
+Lives under ``users/`` so datasets, packages and agents can all import it
+without the circular-import dance ``packages/services.py`` works around with a
+local copy of ``_user_dir_key``.
+"""
+from __future__ import annotations
+
+
+def is_shared_guest(user) -> bool:
+    """True for the one account every guest sign-in resolves to.
+
+    ``users.services.signin_guest`` always returns the row named by
+    ``CURIO_SHARED_GUEST_USERNAME``, so every visitor browsing as a guest is
+    literally the same ``User``. Any rule that compares identity therefore
+    cannot tell two guests apart -- including ``manifest.publisher ==
+    str(user)``, because ``User.__repr__`` yields the same string for all of
+    them.
+    """
+    from utk_curio.backend.config import CURIO_SHARED_GUEST_USERNAME
+
+    return bool(
+        user is not None
+        and getattr(user, "is_guest", False)
+        and getattr(user, "username", None) == CURIO_SHARED_GUEST_USERNAME
+    )
+
+
+def can_manage_shared_catalog(user) -> bool:
+    """Whether *user* may publish to, or remove from, a shared catalog tree.
+
+    A shared catalog is global: one directory tree every account reads. A write
+    there is not scoped to the writer, so it needs an account the platform can
+    hold responsible for it. The shared guest is not one -- it is a single row
+    shared by every anonymous visitor, so "the publisher" and "some other
+    guest" are the same principal and an ownership check cannot separate them
+    (#222).
+
+    Note this is deliberately NOT a check on the *dataset*: a guest may still
+    import, compute and delete datasets in the guest store. What it withholds
+    is reaching into state other accounts can see.
+
+    ``None`` passes. It is the internal/system caller -- the context that
+    publishes as ``"Data Catalog"`` rather than as a user -- and it cannot
+    arrive from a request, because every dataset route is behind
+    ``@require_auth``. Authentication is the route's job; this predicate only
+    answers the question authentication cannot: whether a real, distinguishable
+    account is behind the call.
+    """
+    return not is_shared_guest(user)

--- a/utk_curio/backend/tests/test_datasets/test_guest_catalog_writes.py
+++ b/utk_curio/backend/tests/test_datasets/test_guest_catalog_writes.py
@@ -1,0 +1,262 @@
+"""Regression tests: shared-guest sessions cannot write the shared catalog (#222).
+
+Reported as "a shared guest can delete published datasets". The publisher gate
+added by ``DEL-OWNERSHIP`` (see ``test_delete_ownership.py``) does not stop it,
+for a reason that is structural rather than a missing check: every guest sign-in
+resolves to ONE ``User`` row (``users.services.signin_guest`` ->
+``_shared_guest_user``), so ``manifest.publisher == str(user)`` is true for guest
+B on anything guest A published -- ``User.__repr__`` yields ``<User
+'guest_shared'>`` for all of them.
+
+Investigating it surfaced a second, worse hole the report only guessed at:
+``publish_dataset`` never checked its DESTINATION. Any authenticated user could
+publish over another account's entry, overwriting it. That one is not
+guest-specific, so it is covered here for a regular user too.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from utk_curio.backend.app.datasets.domain.manifest import DatasetManifest, write_manifest
+from utk_curio.backend.app.datasets.infrastructure import storage as ds_storage
+from utk_curio.backend.tests.test_datasets.computed_test_helpers import auth_headers
+
+
+def _stub_publish_source(monkeypatch, dataset_id: str, local_file: Path) -> None:
+    """Make ``publish_dataset`` see *local_file* as the dataset's on-disk data.
+
+    ``publish_dataset`` reads the item through ``self._owner.get_dataset`` -- the
+    service facade, which the route constructs per request. Patching the facade
+    METHOD (rather than the instance) is what reaches that request-built object,
+    and it is the same seam ``test_publish_dataset.py`` uses. Building a real
+    account-store entry per test would only obscure what is being asserted.
+    """
+    from utk_curio.backend.app.datasets.application.catalog_service import (
+        DatasetCatalogService,
+    )
+
+    def _fake_get_dataset(self, *a, **k):
+        return {
+            "id": dataset_id,
+            "title": "Stub",
+            "format": "csv",
+            "path": local_file.as_posix(),
+            "origin": "computed",
+            "producerNodeId": "n1",
+        }
+
+    monkeypatch.setattr(DatasetCatalogService, "get_dataset", _fake_get_dataset)
+
+
+def _make_user(db, username: str, token: str, *, is_guest: bool = False):
+    from utk_curio.backend.app.users.models import User, UserSession
+
+    u = User(
+        username=username,
+        name=username.title(),
+        email=f"{username}@test.com",
+        is_guest=is_guest,
+    )
+    db.session.add(u)
+    db.session.flush()
+    db.session.add(UserSession(user_id=u.id, token=token))
+    db.session.commit()
+    return u
+
+
+def _make_shared_guest(db, token: str):
+    """The single account every guest sign-in lands on."""
+    from utk_curio.backend.config import CURIO_SHARED_GUEST_USERNAME
+
+    return _make_user(db, CURIO_SHARED_GUEST_USERNAME, token, is_guest=True)
+
+
+def _publish_dir(catalog_root: Path, dataset_id: str, publisher: str) -> Path:
+    d = catalog_root / f"{dataset_id}@1"
+    (d / "data").mkdir(parents=True)
+    (d / "data" / "out.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    write_manifest(
+        DatasetManifest(
+            id=dataset_id, name="Owned dataset", version="1.0.0", format="csv",
+            description="", publisher=publisher, license="MIT", tags=[],
+            data_file="data/out.csv", major=1,
+        ),
+        d,
+    )
+    return d
+
+
+@pytest.fixture()
+def catalog_root(tmp_path, monkeypatch):
+    root = tmp_path / "shared_catalog"
+    root.mkdir()
+    monkeypatch.setattr(ds_storage, "catalog_root", lambda: root)
+    return root
+
+
+# --------------------------------------------------------------------------
+# The reported bug: a guest removing another guest's published dataset.
+# --------------------------------------------------------------------------
+
+def test_guest_cannot_delete_or_unpublish_a_guest_published_dataset(
+    app, db, client, catalog_root
+):
+    """The exact reported path, and the one the publisher gate cannot catch.
+
+    The dataset is published BY the shared guest, so ``publisher ==
+    str(caller)`` holds for the guest doing the deleting. Only an account-level
+    rule can refuse this.
+    """
+    guest = _make_shared_guest(db, "guest-tok")
+    dataset_id = "computed.published-by-a-guest"
+    pub_dir = _publish_dir(catalog_root, dataset_id, publisher=str(guest))
+
+    for url in (f"/api/datasets/{dataset_id}", f"/api/datasets/publish/{dataset_id}"):
+        resp = client.delete(url, headers=auth_headers("guest-tok"))
+        assert resp.status_code == 403, (url, resp.get_data(as_text=True))
+
+    # The shared catalog copy survives, data file and all.
+    assert pub_dir.is_dir()
+    assert (pub_dir / "data" / "out.csv").is_file()
+    assert (pub_dir / "manifest.json").is_file()
+
+
+def test_guest_cannot_remove_a_manifestless_leftover(app, db, client, catalog_root):
+    """The no-manifest escape hatch is closed for guests, not for everyone.
+
+    ``_assert_is_publisher`` deliberately skips a directory with no manifest so
+    legacy leftovers stay removable (``test_delete_ownership`` pins that). For a
+    guest that skip is a way straight past the gate, so the account rule has to
+    run first. See the sibling test below for the half that must keep working.
+    """
+    _make_shared_guest(db, "guest-tok")
+    dataset_id = "computed.leftover"
+    pub_dir = _publish_dir(catalog_root, dataset_id, publisher="someone-else")
+    (pub_dir / "manifest.json").unlink()
+
+    resp = client.delete(
+        f"/api/datasets/publish/{dataset_id}", headers=auth_headers("guest-tok")
+    )
+    assert resp.status_code == 403, resp.get_data(as_text=True)
+    assert pub_dir.is_dir()
+
+
+def test_a_real_account_can_still_remove_a_manifestless_leftover(
+    app, db, client, catalog_root
+):
+    """The guest rule must not stiffen the gate for everyone else.
+
+    Guards against "fix the guest hole by failing closed on a missing
+    manifest", which would strand corrupt leftovers in the shared catalog with
+    no way to remove them.
+    """
+    _make_user(db, "alice", "alice-tok")
+    dataset_id = "computed.leftover"
+    pub_dir = _publish_dir(catalog_root, dataset_id, publisher="someone-else")
+    (pub_dir / "manifest.json").unlink()
+
+    resp = client.delete(
+        f"/api/datasets/publish/{dataset_id}", headers=auth_headers("alice-tok")
+    )
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert not pub_dir.exists()
+
+
+def test_guest_delete_of_an_unpublished_dataset_is_not_blocked(
+    app, db, client, catalog_root
+):
+    """A guest still owns the guest store; the rule is about SHARED state.
+
+    ``delete_dataset`` cascades through ``unpublish_dataset`` and re-raises any
+    403, so an account gate placed before the "not published" 404 would stop a
+    guest deleting a dataset of their own that was never published. The gate
+    therefore sits after the lookup. A 404 here means the cascade got past the
+    account rule and found nothing to unpublish, which is the correct path.
+    """
+    _make_shared_guest(db, "guest-tok")
+
+    resp = client.delete(
+        "/api/datasets/publish/computed.never-published",
+        headers=auth_headers("guest-tok"),
+    )
+    assert resp.status_code == 404, resp.get_data(as_text=True)
+
+
+# --------------------------------------------------------------------------
+# The hole found while investigating: publish never checked its destination.
+# --------------------------------------------------------------------------
+
+def test_a_user_cannot_publish_over_another_users_dataset(
+    app, db, client, catalog_root, monkeypatch, tmp_path
+):
+    """The write-side hole: publish resolved a path and mkdir'd into it.
+
+    ``dest`` is derived from the dataset id, so two accounts collide on it.
+    Before the fix this overwrote the incumbent's manifest and data with no
+    check at all.
+    """
+    alice = _make_user(db, "alice", "alice-tok")
+    _make_user(db, "bob", "bob-tok")
+
+    dataset_id = "computed.contested"
+    pub_dir = _publish_dir(catalog_root, dataset_id, publisher=str(alice))
+
+    bob_file = tmp_path / "bob.csv"
+    bob_file.write_text("x\n9\n", encoding="utf-8")
+    _stub_publish_source(monkeypatch, dataset_id, bob_file)
+
+    resp = client.post(
+        "/api/datasets/publish",
+        json={"datasetId": dataset_id, "title": "Bob version"},
+        headers=auth_headers("bob-tok"),
+    )
+    assert resp.status_code == 403, resp.get_data(as_text=True)
+
+    # Alice's entry is byte-for-byte intact -- a 403 that had already written
+    # would still have destroyed what it refused to touch.
+    assert (pub_dir / "data" / "out.csv").read_text(encoding="utf-8") == "a,b\n1,2\n"
+    from utk_curio.backend.app.datasets.domain.manifest import (
+        load_dataset_manifest_from_dir,
+    )
+    assert load_dataset_manifest_from_dir(pub_dir).publisher == str(alice)
+
+
+def test_publisher_can_still_republish_their_own_dataset(
+    app, db, client, catalog_root, monkeypatch, tmp_path
+):
+    """Republishing your own entry is how an update is applied -- keep it working."""
+    alice = _make_user(db, "alice", "alice-tok")
+    dataset_id = "computed.mine"
+    pub_dir = _publish_dir(catalog_root, dataset_id, publisher=str(alice))
+
+    newer = tmp_path / "newer.csv"
+    newer.write_text("a,b\n3,4\n", encoding="utf-8")
+    _stub_publish_source(monkeypatch, dataset_id, newer)
+
+    resp = client.post(
+        "/api/datasets/publish",
+        json={"datasetId": dataset_id, "title": "Mine, updated"},
+        headers=auth_headers("alice-tok"),
+    )
+    assert resp.status_code == 201, resp.get_data(as_text=True)
+    assert (pub_dir / "data" / "newer.csv").is_file()
+
+
+def test_guest_cannot_publish_at_all(
+    app, db, client, catalog_root, monkeypatch, tmp_path
+):
+    """Publishing attributes authorship to an account. A guest has none to give."""
+    _make_shared_guest(db, "guest-tok")
+    src = tmp_path / "g.csv"
+    src.write_text("a\n1\n", encoding="utf-8")
+    _stub_publish_source(monkeypatch, "computed.guest-thing", src)
+
+    resp = client.post(
+        "/api/datasets/publish",
+        json={"datasetId": "computed.guest-thing", "title": "Guest thing"},
+        headers=auth_headers("guest-tok"),
+    )
+    assert resp.status_code == 403, resp.get_data(as_text=True)
+    assert not (catalog_root / "computed.guest-thing@1").exists()

--- a/utk_curio/frontend/urban-workflows/src/pages/dataHub/DataCatalogBrowseDrawer.tsx
+++ b/utk_curio/frontend/urban-workflows/src/pages/dataHub/DataCatalogBrowseDrawer.tsx
@@ -18,6 +18,7 @@ import {
   isDatasetPublishedToCatalog,
   isUserOwnedDataset,
 } from "../../services/datasetCatalog";
+import { useUserContext } from "../../providers/UserProvider";
 import { DataCatalogGeoPreview } from "./DataCatalogGeoPreview";
 import { datasetCount, formatBytes, metaLeft } from "./dataHubBrowseFormat";
 import styles from "../catalog/CatalogBrowseLayout.module.css";
@@ -92,6 +93,12 @@ function DataCatalogBrowseDrawerContent({
 }: DataCatalogBrowseDrawerContentProps) {
   const crs = dataset.schema?.crs ?? null;
   const published = isDatasetPublishedToCatalog(dataset);
+  // Every guest sign-in shares ONE account, so a guest publishing writes an
+  // entry whose recorded publisher is "all guests", and any guest can then
+  // withdraw any other's (#222). The server refuses both regardless; withholding
+  // the pill keeps the UI from offering an action that can only fail.
+  const { isSharedGuest } = useUserContext();
+
   const showPublishPill = shouldShowPublishPill({
     isPublished: published,
     allowPublish: catalogPublishAllowed,
@@ -101,7 +108,11 @@ function DataCatalogBrowseDrawerContent({
     // always gated on ownership (`pkg.readOnly !== true`, `agent.publishable`);
     // this one did not. `isUserOwnedDataset` reads the store folder, which does
     // not move when installing flips `origin` from hub to imported.
-    canPublish: isUserOwnedDataset(dataset),
+    //
+    // The guest clause rides in the same slot deliberately: publish and
+    // unpublish are one control here, so a separate gate would have to be
+    // repeated for both halves and could drift between them.
+    canPublish: isUserOwnedDataset(dataset) && !isSharedGuest,
   });
 
   return (

--- a/utk_curio/frontend/urban-workflows/src/providers/UserProvider.tsx
+++ b/utk_curio/frontend/urban-workflows/src/providers/UserProvider.tsx
@@ -23,6 +23,17 @@ interface UserProviderProps {
   skipProjectPage: boolean;
   allowGuest: boolean;
   sharedGuestUsername: string;
+  /**
+   * Is the session browsing as the ONE account every guest sign-in resolves to?
+   *
+   * Not the same question as ``user.is_guest``. The shared guest is a single
+   * ``User`` row that every anonymous visitor shares, so anything scoped to
+   * "this account" -- its dataset store, and the ``publisher`` recorded when it
+   * publishes -- is really scoped to "all guests at once". Surfaces that offer
+   * to write shared state use this to withhold the control; the server refuses
+   * the request regardless (#222).
+   */
+  isSharedGuest: boolean;
   signup: (data: {
     name: string;
     username: string;
@@ -56,6 +67,7 @@ export const UserContext = createContext<UserProviderProps>({
   skipProjectPage: false,
   allowGuest: false,
   sharedGuestUsername: "guest_shared",
+  isSharedGuest: false,
   signup: async () => null,
   signin: async () => null,
   signinGuest: async () => null,
@@ -287,6 +299,9 @@ const UserProvider = ({ children }: { children: React.ReactNode }) => {
         skipProjectPage,
         allowGuest,
         sharedGuestUsername,
+        isSharedGuest: Boolean(
+          user?.is_guest && user.username === sharedGuestUsername
+        ),
         signup,
         signin,
         signinGuest,

--- a/utk_curio/frontend/urban-workflows/src/tests/catalog/guestCatalogAffordances.test.tsx
+++ b/utk_curio/frontend/urban-workflows/src/tests/catalog/guestCatalogAffordances.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * A shared guest is offered no shared-catalog writes (#222).
+ *
+ * Reported as "a shared guest can delete published datasets". The interesting
+ * part is why the existing ownership rule does not catch it: every guest
+ * sign-in resolves to ONE ``User`` row, so a dataset a guest published records
+ * that shared account as its publisher, and the next guest along passes
+ * ``publisher === str(caller)`` on it. Ownership cannot separate two principals
+ * that are the same principal.
+ *
+ * The authoritative fix is server-side
+ * (``utk_curio/backend/tests/test_datasets/test_guest_catalog_writes.py``); this
+ * covers the affordance, so the UI does not offer a write that can only 403.
+ *
+ * Note what is NOT asserted here: that a guest loses Delete on their own
+ * imported/computed datasets. They keep it, and the backend keeps allowing it —
+ * the rule is about state other accounts can see, not about the guest store.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// UserProvider imports refreshPackageRegistry, which drags in the registry ->
+// adapters -> vega chain that will not load under jsdom. Same stub the other
+// suites that touch UserContext use.
+jest.mock("../../registry/packageRegistryBootstrap", () => ({
+  refreshPackageRegistry: jest.fn(),
+}));
+
+// The drawer's hero fetches a preview on mount. Nothing here is about the
+// preview, and its async setState lands after the assertions as an act()
+// warning, so stub it out rather than wait on it.
+jest.mock("../../pages/dataHub/DataCatalogGeoPreview", () => ({
+  DataCatalogGeoPreview: () => null,
+}));
+
+import { DataCatalogBrowseDrawer } from "../../pages/dataHub/DataCatalogBrowseDrawer";
+import { UserContext } from "../../providers/UserProvider";
+import type { DatasetCatalogItem } from "../../services/datasetCatalog";
+
+/** An account-owned dataset: ``imported.`` store folder ⇒ isUserOwnedDataset. */
+const OWN_DATASET = {
+  id: "imported.mine",
+  dirName: "imported.mine@1",
+  title: "My upload",
+  format: "csv",
+  origin: "imported",
+  updatedAt: "2026-01-01T00:00:00Z",
+} as unknown as DatasetCatalogItem;
+
+function renderDrawer(isSharedGuest: boolean) {
+  const ctx = { isSharedGuest } as any;
+  return render(
+    <UserContext.Provider value={ctx}>
+      <DataCatalogBrowseDrawer
+        dataset={OWN_DATASET}
+        publishingId={null}
+        catalogPublishAllowed
+        onPublish={jest.fn()}
+        onUnpublish={jest.fn()}
+        onAddToAllProjects={jest.fn()}
+        onRemoveFromAllProjects={jest.fn()}
+        onClose={jest.fn()}
+        onViewDetails={jest.fn()}
+      />
+    </UserContext.Provider>,
+  );
+}
+
+/** The pill renders as Publish or Unpublish; either one is a shared-catalog write. */
+function publishControl() {
+  return screen.queryByRole("button", { name: /publish/i });
+}
+
+describe("the publish control on a dataset the account owns", () => {
+  test("a signed-in account is offered it", () => {
+    renderDrawer(false);
+    // Guards the negative test below: if the control were absent for everyone,
+    // that test would pass while proving nothing.
+    expect(publishControl()).not.toBeNull();
+  });
+
+  test("a shared guest is not", () => {
+    renderDrawer(true);
+    expect(publishControl()).toBeNull();
+  });
+});


### PR DESCRIPTION
Addresses #222.

A shared guest could delete published datasets. The publisher gate added by `DEL-OWNERSHIP` does not stop it, for a structural reason: every guest sign-in resolves to one `User` row (`signin_guest` -> `_shared_guest_user`), so `manifest.publisher == str(user)` is true for guest B on anything guest A published. `User.__repr__` is `<User 'guest_shared'>` for all of them. Ownership cannot separate two principals that are the same principal.

Investigating it surfaced a second, worse hole the report only guessed at. `CatalogMutations.publish_dataset` never checked its DESTINATION: the path is derived from the dataset id, so any authenticated user could publish over another account's entry. Not guest-specific, and the reporter's instinct that a server-side check was missing was right — this was it.

## What changed

- `users/capabilities.py` — one place answering "may this account write shared state?", importable by datasets, packages and agents.
- `_assert_can_manage_shared_catalog` gates publish and unpublish, in the SERVICE rather than on the route, so every caller is covered.
- `_assert_can_publish_to` checks the incumbent's manifest **before** the `mkdir` — creating the tree is itself a mutation, so a refusal that runs after it has already damaged what it refused to touch.
- Frontend gating second, as affordance not enforcement: `isSharedGuest` on `UserProvider`, folded into the existing `canPublish` slot.

## Notes

The plan said to fail closed on a missing `manifest.json`. That would have broken `test_delete_ownership.py::test_a_directory_with_no_manifest_stays_removable` — a deliberate test keeping corrupt leftovers removable. Instead the guest is refused *before* that skip is reached, so real accounts keep the cleanup path. Both halves are pinned.

`user=None` passes the gate: it is the internal/system caller that publishes as `"Data Catalog"`, and every dataset route is behind `@require_auth`, so it cannot arrive from a request.

## Tests

`test_guest_catalog_writes.py` — 7 cases: guest refused on delete, unpublish, and publish-over; the manifestless leftover refused for a guest but still removable by a real account; a guest deleting their own never-published dataset still works; the owner can still republish. Each asserts the filesystem is untouched after a refusal.
