### PR TITLE
Fail a partial autk data load, and stop hardcoding the backend port (#248)

### DIFF
--- a/utk_curio/backend/tests/test_frontend/utils.py
+++ b/utk_curio/backend/tests/test_frontend/utils.py
@@ -93,13 +93,28 @@ def sandbox_auth_header() -> dict:
     return {'X-Curio-Sandbox-Token': token} if token else {}
 
 
+def sandbox_base_url() -> str:
+    """``http://host:port`` for the sandbox these tests should talk to.
+
+    ``CURIO_E2E_SANDBOX_PORT`` is the documented knob (README, and what
+    ``e2e_existing_servers`` waits on), so it wins; ``FLASK_SANDBOX_PORT`` is
+    honoured as a fallback because ``main.py`` exports it for the stack it
+    started. Reading only the latter is what made every ``test_node_execution``
+    case on a non-default-port stack die on a 401 from :2000/exec - 28 failures
+    that read exactly like the bug under investigation in #248.
+    """
+    host = (os.environ.get('CURIO_E2E_SANDBOX_HOST')
+            or os.environ.get('FLASK_SANDBOX_HOST', '127.0.0.1'))
+    port = (os.environ.get('CURIO_E2E_SANDBOX_PORT')
+            or os.environ.get('FLASK_SANDBOX_PORT', '2000'))
+    return f'http://{host}:{int(port)}'
+
+
 def load_artifact_as_dict(artifact_id: str) -> dict:
     """Fetch a stored artifact from the sandbox and return its parsed representation."""
     import requests as _req
-    sandbox_host = os.environ.get('FLASK_SANDBOX_HOST', '127.0.0.1')
-    sandbox_port = int(os.environ.get('FLASK_SANDBOX_PORT', '2000'))
     resp = _req.get(
-        f'http://{sandbox_host}:{sandbox_port}/get',
+        f'{sandbox_base_url()}/get',
         params={'fileName': artifact_id},
         headers=sandbox_auth_header(),
         timeout=(SANDBOX_CONNECT_TIMEOUT_S, SANDBOX_GET_TIMEOUT_S),
@@ -623,9 +638,7 @@ def execute_workflow_programmatically(spec, seed: int = 42) -> dict[str, str]:
     """
     import requests as _req
 
-    sandbox_host = os.environ.get('FLASK_SANDBOX_HOST', '127.0.0.1')
-    sandbox_port = int(os.environ.get('FLASK_SANDBOX_PORT', '2000'))
-    sandbox_url = f'http://{sandbox_host}:{sandbox_port}'
+    sandbox_url = sandbox_base_url()
 
     from .workflow_spec import PY_CODE_TYPES
 

--- a/utk_curio/frontend/urban-workflows/src/adapters/node/autkGrammarBehavior.tsx
+++ b/utk_curio/frontend/urban-workflows/src/adapters/node/autkGrammarBehavior.tsx
@@ -1841,26 +1841,31 @@ function firstCoordinate(coords: any): [number, number] | null {
 // host/port, no route prefix) exactly as a Python node would read it.
 // Absolute URIs (http://, https://, data:, blob:, …) are passed through unchanged.
 // Applies to all file-URL fields across every data source type.
+// Stand-in for "the backend, as reachable from the sandbox" inside a URL that
+// will be fetched by the sandbox's Node subprocess.
+// ``utk_curio/sandbox/app/worker.py::execute_js_code`` replaces it with the
+// backend's real base URL at execution time.
+//
+// Why a token rather than a URL: the browser cannot know which address that
+// subprocess must use. The two run in different network namespaces whenever
+// Curio is containerised (a host-published 5022 is still 5002 inside), so the
+// port the page was served against is not usable there - and neither is any
+// constant. This used to force :5002 for a loopback backend, which meant every
+// OSM/PBF load on a stack NOT using the default port failed with
+// "fetch failed" and silently fell back to the in-browser loader (#248).
+// Resolving it in the process that performs the fetch is correct in all three
+// cases: default ports, a custom-port stack, and a remapped container port.
+export const SANDBOX_BACKEND_URL_TOKEN = '__CURIO_BACKEND_URL__';
+
 function resolveDataSourceUrls(spec: any, forBackend = false): any {
     if (!Array.isArray(spec.data) || spec.data.length === 0) return spec;
 
-    let backendUrl = (process.env.BACKEND_URL || 'http://localhost:5002').replace(/\/$/, '');
-    // When the URL will be fetched by the sandbox's Node.js subprocess (the data
-    // section runs there), force the loopback host to 127.0.0.1 — node's fetch
-    // can stall on `localhost` resolving to IPv6 ::1. The /file/ route is
-    // unauthenticated, so the node fetch needs no token.
-    if (forBackend) {
-        backendUrl = backendUrl.replace(/:\/\/localhost(:|\/|$)/, '://127.0.0.1$1');
-        // The sandbox is co-located with the backend in the SAME container, so
-        // it reaches it on the backend's fixed *internal* port (5002). Any host
-        // port remapping (e.g. CI on a shared host publishes 5002 as 5022 to
-        // avoid colliding with another stack) does NOT apply inside the
-        // container — fetching the host-mapped port from in-container yields
-        // "fetch failed" and the OSM/PBF data load comes back empty. Force the
-        // internal port for a loopback backend; a public BACKEND_URL (prod) has
-        // no 127.0.0.1 host and is left unchanged.
-        backendUrl = backendUrl.replace(/^(https?:\/\/127\.0\.0\.1):\d+/, '$1:5002');
-    }
+    // For the browser, the host-published URL the page itself talks to. For the
+    // sandbox, the token above - deliberately not a URL. The /file/ route is
+    // unauthenticated, so the node fetch needs no token of the auth kind.
+    const backendUrl = forBackend
+        ? SANDBOX_BACKEND_URL_TOKEN
+        : (process.env.BACKEND_URL || 'http://localhost:5002').replace(/\/$/, '');
     const urlFields = ['pbfFileUrl', 'csvFileUrl', 'jsonFileUrl', 'geojsonFileUrl'];
     const isAbsolute = (url: string) => /^[a-z][a-z\d+\-.]*:/i.test(url);
 

--- a/utk_curio/frontend/urban-workflows/src/adapters/node/autkGrammarBehavior.tsx
+++ b/utk_curio/frontend/urban-workflows/src/adapters/node/autkGrammarBehavior.tsx
@@ -777,6 +777,56 @@ export function attachMapInteractionZoomFix(canvas: HTMLCanvasElement): () => vo
     };
 }
 
+// Table names a data spec is contractually asking autk-db to create.
+//
+// The point is to tell a load that came back SHORT apart from one that came back
+// empty. autk-db's `loadOsm` walks `autoLoadLayers.layers` sequentially and lets
+// a per-layer failure propagate, so a throw partway leaves the earlier tables
+// registered and the later ones absent. Both loaders below used to publish
+// whatever `getLayerTables()` happened to hold, which surfaces downstream as an
+// opaque "Table <last layer> not found" from a node two hops away, with the node
+// that actually failed showing "Done" (#248).
+//
+// Naming mirrors autk-db's own, which derives a layer table as
+// `outputTableName || `${osmInputTableName}_${layer}``.
+export function requestedLayerTables(dataSources: any[]): string[] {
+    const names: string[] = [];
+    for (const source of dataSources ?? []) {
+        const { type, ...rest } = (source ?? {}) as any;
+        if (type === 'osm') {
+            // Per-layer tables only. `${outputTableName}` and
+            // `${outputTableName}_boundaries` are excluded deliberately:
+            // `autoLoadLayers.dropOsmTable` drops those once the layers have been
+            // split out, so expecting them would fail every spec that sets it.
+            const layers = rest?.autoLoadLayers?.layers;
+            if (rest?.outputTableName && Array.isArray(layers)) {
+                for (const layer of layers) names.push(`${rest.outputTableName}_${layer}`);
+            }
+        } else if (type === 'geojson' || type === 'csv' || type === 'json') {
+            if (rest?.outputTableName) names.push(rest.outputTableName);
+        }
+        // `join` is skipped on purpose: its MODIFY_ROOT/CREATE_TABLE output
+        // rewrites a table another source already created rather than adding a
+        // layer of its own, so expecting one would report a phantom miss.
+    }
+    return Array.from(new Set(names));
+}
+
+// Message for a load that produced layers, but not the ones the spec asked for.
+// Shared by both loaders so the two paths report a short load identically.
+//
+// `errors` is what makes this safe to throw on rather than merely warn about:
+// autk-db propagates rather than swallows, so a table missing *because the load
+// broke* always arrives with a caught reason, while a sparse-but-successful
+// query area does not (`loadOsmLayer` creates the table even at zero features,
+// and autk-db counts rows on it immediately after). Missing with no recorded
+// error is therefore a warning, not a failure.
+function missingLayerMessage(missing: string[], errors: string[]): string {
+    return `autk data load produced ${missing.length} fewer table(s) than the spec asked for`
+        + ` - missing: ${missing.join(', ')}`
+        + (errors.length > 0 ? ` (${errors.join('; ')})` : '');
+}
+
 // Compile a grammar `data` section into autk-db JavaScript to run in the backend
 // Node.js sandbox. The single top-level `import` is rewritten to `await import()`
 // by execute_js_code; the rest is the body of the async function the sandbox
@@ -796,6 +846,10 @@ const AutkDb = __autkDbMod.AutkDb || __autkDbMod.AutkSpatialDb;
 const DEFAULT_WORKSPACE_COORDINATE_FORMAT = __autkDbMod.DEFAULT_WORKSPACE_COORDINATE_FORMAT || 'EPSG:3395';
 if (typeof AutkDb !== 'function') throw new Error('@urban-toolkit/autk-db: neither AutkDb nor AutkSpatialDb is exported');
 const __sources = ${JSON.stringify(dataSources)};
+// Computed host-side by requestedLayerTables so the naming rules live in ONE
+// place rather than being restated inside this emitted string.
+const __expectedTables = ${JSON.stringify(requestedLayerTables(dataSources))};
+const __loadErrors = [];
 const db = new AutkDb();
 await db.init();
 for (const source of __sources) {
@@ -820,8 +874,35 @@ for (const source of __sources) {
     else if (type === 'join' && typeof db.spatialQuery === 'function') await db.spatialQuery(rest);
     else console.log('[autk-grammar] unsupported data source type "' + type + '" - skipped');
   } catch (e) {
+    // Recorded, not discarded: this reason is the only account of WHY a layer is
+    // missing, and the contract check below attaches it to the thrown error.
+    __loadErrors.push(type + ': ' + ((e && e.message) || String(e)));
     console.log('[autk-grammar] data load failed for source type "' + type + '": ' + (e && e.message));
   }
+}
+let __tables = [];
+try {
+  __tables = db.getLayerTables ? db.getLayerTables() : [];
+} catch (e) {
+  // A partially-loaded DB can throw here rather than return [] - treat it as
+  // "no usable tables" and let the contract check report it.
+  __loadErrors.push('getLayerTables: ' + ((e && e.message) || String(e)));
+}
+const __have = new Set(__tables.map((t) => t.name));
+const __missing = __expectedTables.filter((n) => !__have.has(n));
+if (__missing.length > 0) {
+  const __detail = 'missing: ' + __missing.join(', ')
+    + (__loadErrors.length > 0 ? ' (' + __loadErrors.join('; ') + ')' : '');
+  if (__loadErrors.length > 0) {
+    // Mirrors missingLayerMessage() host-side. Throwing is the whole point: it
+    // turns a silent short load into a failed execution, which both reports the
+    // real reason on THIS node and lets runDataInBackend's existing retry take a
+    // second attempt at what is usually a transient PBF/stream hiccup.
+    throw new Error('autk data load produced ' + __missing.length
+      + ' fewer table(s) than the spec asked for - ' + __detail);
+  }
+  console.log('[autk-grammar] ' + __detail
+    + ' - no load error recorded, treating as a genuinely empty query area');
 }
 const __epsg = String(DEFAULT_WORKSPACE_COORDINATE_FORMAT).match(/(\\d+)/)?.[1] ?? '3395';
 // Tag each layer with the CRS its coordinates are ACTUALLY in. autk-db 2.0.1
@@ -868,7 +949,7 @@ const __buildingHeight = (props) => {
   return top > base ? null : base + 6;
 };
 const __out = [];
-for (const t of (db.getLayerTables ? db.getLayerTables() : [])) {
+for (const t of __tables) {
   const geojson = await db.getLayer(t.name);
   let type = t.type ?? 'polygons';
   if (type === 'buildings' && Array.isArray(geojson?.features)) {
@@ -1142,6 +1223,29 @@ async function loadSpecLayers(spec: any): Promise<Array<{ name: string; type: st
     const usable = layers.filter(
         (l): l is { name: string; type: string; geojson: FeatureCollection } => l != null,
     );
+    // Same contract check as the sandbox emit: a load that came back short is a
+    // failure, not a success with fewer layers. Without this, the caller's
+    // "backend failed, fall back in-browser" path would quietly publish the same
+    // short layer array the backend path just refused to.
+    //
+    // Diffed against `usable` - what a consumer actually receives. A layer that
+    // was never created and one that exists but could not be exported are the
+    // same loss downstream: the array comes back short either way. An empty
+    // layer is NOT caught by this, because getLayer returns an empty
+    // FeatureCollection for it and it stays in `usable`; only a getLayer that
+    // throws counts, and that is a defect rather than sparse data.
+    const requested = requestedLayerTables(spec?.data ?? []);
+    if (requested.length > 0) {
+        const have = new Set(usable.map((l) => l.name));
+        const missing = requested.filter((n) => !have.has(n));
+        if (missing.length > 0) {
+            if (loadErrors.length > 0) {
+                throw new Error(missingLayerMessage(missing, loadErrors));
+            }
+            console.warn(`[autk-grammar] ${missingLayerMessage(missing, [])} - no load `
+                + `error recorded, treating as a genuinely empty query area`);
+        }
+    }
     // A load that asked for sources but produced no usable layer AND hit errors
     // is a real failure (e.g. every PBF range fetch 404'd) — throw an ATTRIBUTED
     // error so the node reports the reason, instead of crashing later with an

--- a/utk_curio/frontend/urban-workflows/src/tests/adapters/node/behaviors.test.tsx
+++ b/utk_curio/frontend/urban-workflows/src/tests/adapters/node/behaviors.test.tsx
@@ -93,7 +93,7 @@ import { useVegaBehavior } from '../../../adapters/node/vegaBehavior';
 import { useSimpleVisBehavior } from '../../../adapters/node/simpleVisBehavior';
 import { useMergeFlowBehavior } from '../../../adapters/node/mergeFlowBehavior';
 import { useDataPoolBehavior } from '../../../adapters/node/dataPoolBehavior';
-import { useAutkGrammarBehavior, attachMapInteractionZoomFix, requestedLayerTables } from '../../../adapters/node/autkGrammarBehavior';
+import { useAutkGrammarBehavior, attachMapInteractionZoomFix, requestedLayerTables, SANDBOX_BACKEND_URL_TOKEN } from '../../../adapters/node/autkGrammarBehavior';
 import { __resetWebGpuSupportCache } from '../../../utils/webgpuSupport';
 
 function makeMockData(overrides: Partial<NodeBehaviorData> = {}): NodeBehaviorData {
@@ -774,6 +774,47 @@ describe('Behavior hooks — NodeBehaviorHook contract conformance', () => {
 
       mockAutkDbGetLayerTables.mockReset();
       mockAutkDbGetLayerTables.mockReturnValue([]);
+    });
+
+    // The browser must not put a host or port in a URL the SANDBOX will fetch:
+    // the two are in different network namespaces under Docker, and on a
+    // custom-port stack no constant is right. Forcing :5002 here made every
+    // OSM/PBF load fail with "fetch failed" on any non-default-port stack,
+    // which silently pushed each Autark data load onto the in-browser
+    // fallback (#248).
+    test('data-only node: the sandbox gets a backend-URL token, never an address (#248)', async () => {
+      let sentCode = '';
+      const interpretCode = jest.fn(
+        (_unresolved, code, _input, _inputTypes, cb) => {
+          sentCode = code;
+          cb({ stdout: [], stderr: '', output: { path: 'art-1', dataType: 'list' } });
+        },
+      );
+
+      const result = await callBehavior(useAutkGrammarBehavior, {
+        jsInterpreter: { interpretCode } as any,
+      });
+
+      await act(async () => {
+        await result.current.applyGrammar!(JSON.stringify({
+          data: [{
+            type: 'osm',
+            pbfFileUrl: 'docs/examples/data/niteroi.osm.pbf',
+            outputTableName: 'table_osm',
+            autoLoadLayers: { layers: ['roads'] },
+          }],
+        }));
+      });
+
+      // The relative path is still resolved against a base .
+      expect(sentCode).toContain(
+        `${SANDBOX_BACKEND_URL_TOKEN}/file/docs/examples/data/niteroi.osm.pbf`,
+      );
+      // . but that base is the token the sandbox resolves at execution time,
+      // not an address guessed in the browser.
+      expect(sentCode).not.toContain('5002');
+      expect(sentCode).not.toContain('127.0.0.1');
+      expect(sentCode).not.toContain('localhost');
     });
   });
 

--- a/utk_curio/frontend/urban-workflows/src/tests/adapters/node/behaviors.test.tsx
+++ b/utk_curio/frontend/urban-workflows/src/tests/adapters/node/behaviors.test.tsx
@@ -93,7 +93,7 @@ import { useVegaBehavior } from '../../../adapters/node/vegaBehavior';
 import { useSimpleVisBehavior } from '../../../adapters/node/simpleVisBehavior';
 import { useMergeFlowBehavior } from '../../../adapters/node/mergeFlowBehavior';
 import { useDataPoolBehavior } from '../../../adapters/node/dataPoolBehavior';
-import { useAutkGrammarBehavior, attachMapInteractionZoomFix } from '../../../adapters/node/autkGrammarBehavior';
+import { useAutkGrammarBehavior, attachMapInteractionZoomFix, requestedLayerTables } from '../../../adapters/node/autkGrammarBehavior';
 import { __resetWebGpuSupportCache } from '../../../utils/webgpuSupport';
 
 function makeMockData(overrides: Partial<NodeBehaviorData> = {}): NodeBehaviorData {
@@ -561,6 +561,270 @@ describe('Behavior hooks — NodeBehaviorHook contract conformance', () => {
       mockAutkDbLoadOsm.mockResolvedValue(undefined);
       mockAutkDbGetLayerTables.mockReset();
       mockAutkDbGetLayerTables.mockReturnValue([]);
+    });
+
+    // Regression for #248. autk-db's loadOsm walks autoLoadLayers.layers in
+    // order and lets a per-layer failure propagate, so a throw partway leaves
+    // the earlier tables registered and the later ones absent. Both loaders used
+    // to publish whatever getLayerTables() held, so the node that actually
+    // failed went green and the breakage surfaced two nodes downstream as
+    // "Table table_osm_roads not found" from a spatialQuery.
+    test('data-only node: a SHORT load fails the node and names the missing table (#248)', async () => {
+      const interpretCode = jest.fn(
+        (_unresolved, _code, _input, _inputTypes, cb) =>
+          cb({ stdout: [], stderr: 'sandbox short load', output: { path: '', dataType: 'str' } }),
+      );
+      // The exact #248 state: the load broke partway (a recorded reason) and
+      // three of the four requested layers exist. `roads` is last in the spec,
+      // so `roads` is the one that goes missing.
+      mockAutkDbLoadOsm.mockReset();
+      mockAutkDbLoadOsm.mockRejectedValue(new Error('undici assert(!this.paused)'));
+      mockAutkDbGetLayerTables.mockReset();
+      mockAutkDbGetLayerTables.mockReturnValue([
+        { name: 'table_osm_surface', type: 'surface' },
+        { name: 'table_osm_parks', type: 'parks' },
+        { name: 'table_osm_water', type: 'water' },
+      ]);
+
+      const setOutput = jest.fn();
+      const outputCallback = jest.fn();
+      const result = await callBehavior(
+        useAutkGrammarBehavior,
+        { jsInterpreter: { interpretCode } as any, outputCallback },
+        { setOutput },
+      );
+
+      await act(async () => {
+        await result.current.applyGrammar!(JSON.stringify({
+          data: [{
+            type: 'osm',
+            pbfFileUrl: 'docs/examples/data/niteroi.osm.pbf',
+            outputTableName: 'table_osm',
+            autoLoadLayers: { dropOsmTable: true, layers: ['surface', 'parks', 'water', 'roads'] },
+          }],
+          // no map / plot => data-only node
+        }));
+      });
+
+      // The node ends in error naming the table that is missing, and why .
+      const errCall = setOutput.mock.calls.find((c: any[]) => c[0]?.code === 'error');
+      expect(errCall).toBeTruthy();
+      expect(errCall![0].content).toContain('table_osm_roads');
+      expect(errCall![0].content).toContain('undici');
+      // . and the three layers that DID load are never published downstream, so
+      // no consumer can trip over the missing fourth.
+      expect(outputCallback).not.toHaveBeenCalled();
+      // dropOsmTable drops the raw osm tables on purpose - they must not be
+      // reported as missing, or every spec that sets it would fail.
+      expect(errCall![0].content).not.toContain('table_osm_boundaries');
+
+      mockAutkDbLoadOsm.mockReset();
+      mockAutkDbLoadOsm.mockResolvedValue(undefined);
+      mockAutkDbGetLayerTables.mockReset();
+      mockAutkDbGetLayerTables.mockReturnValue([]);
+    });
+
+    // The recovery half of #248: a short load is usually a transient in a
+    // city-scale PBF read, and making it a failure is what finally reaches
+    // runDataInBackend's existing retry (which only ever fired on "no
+    // output.path", a shape a partial load never produced).
+    test('data-only node: a load that fails once then succeeds recovers on the retry (#248)', async () => {
+      let attempt = 0;
+      const interpretCode = jest.fn(
+        (_unresolved, _code, _input, _inputTypes, cb) => {
+          attempt += 1;
+          cb(attempt === 1
+            ? {
+              stdout: [],
+              stderr: 'autk data load produced 1 fewer table(s) than the spec asked for'
+                + ' - missing: table_osm_roads',
+              output: { path: '', dataType: 'str' },
+            }
+            : { stdout: [], stderr: '', output: { path: 'art-ok', dataType: 'list' } });
+        },
+      );
+
+      const setOutput = jest.fn();
+      const outputCallback = jest.fn();
+      const result = await callBehavior(
+        useAutkGrammarBehavior,
+        { jsInterpreter: { interpretCode } as any, outputCallback },
+        { setOutput },
+      );
+
+      await act(async () => {
+        await result.current.applyGrammar!(JSON.stringify({
+          data: [{
+            type: 'osm',
+            pbfFileUrl: 'docs/examples/data/niteroi.osm.pbf',
+            outputTableName: 'table_osm',
+            autoLoadLayers: { layers: ['surface', 'parks', 'water', 'roads'] },
+          }],
+        }));
+      });
+
+      expect(interpretCode).toHaveBeenCalledTimes(2);
+      // Recovered: the artifact ref goes downstream and the node is not in error.
+      expect(outputCallback).toHaveBeenCalledWith('node-1', { path: 'art-ok', dataType: 'list' });
+      expect(setOutput.mock.calls.find((c: any[]) => c[0]?.code === 'error')).toBeFalsy();
+    });
+
+    // The other side of the predicate: missing WITHOUT a recorded error is a
+    // genuinely empty query area (autk-db creates a layer table even at zero
+    // features), so it must warn rather than fail. This is what keeps the
+    // contract check from turning sparse data into a red node.
+    test('data-only node: an empty query area with no load error does not fail (#248)', async () => {
+      const interpretCode = jest.fn(
+        (_unresolved, _code, _input, _inputTypes, cb) =>
+          cb({ stdout: [], stderr: 'sandbox down', output: { path: '', dataType: 'str' } }),
+      );
+      // Load succeeded (nothing recorded), it just found nothing.
+      mockAutkDbLoadOsm.mockReset();
+      mockAutkDbLoadOsm.mockResolvedValue(undefined);
+      mockAutkDbGetLayerTables.mockReset();
+      mockAutkDbGetLayerTables.mockReturnValue([]);
+
+      const setOutput = jest.fn();
+      const result = await callBehavior(
+        useAutkGrammarBehavior,
+        { jsInterpreter: { interpretCode } as any },
+        { setOutput },
+      );
+
+      await act(async () => {
+        await result.current.applyGrammar!(JSON.stringify({
+          data: [{
+            type: 'osm',
+            pbfFileUrl: 'docs/examples/data/niteroi.osm.pbf',
+            outputTableName: 'table_osm',
+            autoLoadLayers: { layers: ['parks'] },
+          }],
+        }));
+      });
+
+      const errCall = setOutput.mock.calls.find((c: any[]) => c[0]?.code === 'error');
+      expect(errCall?.[0]?.content ?? '').not.toContain('fewer table');
+    });
+
+    // The case the seven-workflow e2e run turned up: the layers exist in the DB
+    // but getLayer() throws "Cannot read properties of null" for some of them,
+    // so the array published downstream is short. That is the same loss as a
+    // table that was never created - a consumer asking for table_osm_roads
+    // cannot tell the two apart - so it has to fail here too. An genuinely
+    // EMPTY layer is not affected: getLayer returns an empty FeatureCollection
+    // for it and it stays in the published array.
+    test('data-only node: a requested layer that cannot be exported also fails (#248)', async () => {
+      const interpretCode = jest.fn(
+        (_unresolved, _code, _input, _inputTypes, cb) =>
+          cb({ stdout: [], stderr: 'osm: fetch failed', output: { path: '', dataType: 'str' } }),
+      );
+      // The load itself succeeded and created all four tables .
+      mockAutkDbLoadOsm.mockReset();
+      mockAutkDbLoadOsm.mockResolvedValue(undefined);
+      mockAutkDbGetLayerTables.mockReset();
+      mockAutkDbGetLayerTables.mockReturnValue([
+        { name: 'table_osm_surface', type: 'surface' },
+        { name: 'table_osm_parks', type: 'parks' },
+        { name: 'table_osm_water', type: 'water' },
+        { name: 'table_osm_roads', type: 'roads' },
+      ]);
+      // . but two of them are empty, so exporting them throws.
+      const { AutkDb } = require('@urban-toolkit/autk-db');
+      (AutkDb as jest.Mock).mockImplementationOnce(() => ({
+        init: jest.fn().mockResolvedValue(undefined),
+        loadOsm: (...a: any[]) => mockAutkDbLoadOsm(...a),
+        loadGeojson: jest.fn().mockResolvedValue(undefined),
+        loadCsv: jest.fn().mockResolvedValue(undefined),
+        loadJson: jest.fn().mockResolvedValue(undefined),
+        getLayerTables: (...a: any[]) => mockAutkDbGetLayerTables(...a),
+        getLayer: jest.fn((name: string) => (
+          name === 'table_osm_parks' || name === 'table_osm_water'
+            ? Promise.reject(new TypeError("Cannot read properties of null (reading 'length')"))
+            : Promise.resolve({ type: 'FeatureCollection', features: [] })
+        )),
+      }));
+
+      const setOutput = jest.fn();
+      const result = await callBehavior(
+        useAutkGrammarBehavior,
+        { jsInterpreter: { interpretCode } as any },
+        { setOutput },
+      );
+
+      await act(async () => {
+        await result.current.applyGrammar!(JSON.stringify({
+          data: [{
+            type: 'osm',
+            pbfFileUrl: 'docs/examples/data/niteroi.osm.pbf',
+            outputTableName: 'table_osm',
+            autoLoadLayers: { layers: ['surface', 'parks', 'water', 'roads'] },
+          }],
+        }));
+      });
+
+      // Reported by name, with the export failure as the reason, rather than
+      // handing a two-layer array to a node that asked for four.
+      const errCall = setOutput.mock.calls.find((c: any[]) => c[0]?.code === 'error');
+      expect(errCall).toBeTruthy();
+      expect(errCall![0].content).toContain('table_osm_parks');
+      expect(errCall![0].content).toContain('table_osm_water');
+      // The two that DID export are not reported as missing.
+      expect(errCall![0].content).not.toContain('table_osm_surface');
+      expect(errCall![0].content).not.toContain('table_osm_roads');
+
+      mockAutkDbGetLayerTables.mockReset();
+      mockAutkDbGetLayerTables.mockReturnValue([]);
+    });
+  });
+
+  // The naming rules the contract check is built on. Kept as a direct unit test
+  // because a wrong name here is invisible in the happy path and shows up only
+  // as a phantom "missing table" failure - or, worse, as the silent short load
+  // of #248 going undetected.
+  describe('requestedLayerTables (autk data-spec contract)', () => {
+    test('osm: one table per requested layer, using autk-db naming', () => {
+      expect(requestedLayerTables([{
+        type: 'osm',
+        outputTableName: 'table_osm',
+        autoLoadLayers: { layers: ['surface', 'parks', 'water', 'roads'] },
+      }])).toEqual([
+        'table_osm_surface', 'table_osm_parks', 'table_osm_water', 'table_osm_roads',
+      ]);
+    });
+
+    test('osm: dropOsmTable does not make the raw osm tables expected', () => {
+      const names = requestedLayerTables([{
+        type: 'osm',
+        outputTableName: 'table_osm',
+        autoLoadLayers: { dropOsmTable: true, layers: ['roads'] },
+      }]);
+      expect(names).toEqual(['table_osm_roads']);
+      expect(names).not.toContain('table_osm');
+      expect(names).not.toContain('table_osm_boundaries');
+    });
+
+    test('geojson / csv / json: the declared outputTableName', () => {
+      expect(requestedLayerTables([
+        { type: 'geojson', outputTableName: 'g' },
+        { type: 'csv', outputTableName: 'c' },
+        { type: 'json', outputTableName: 'j' },
+      ])).toEqual(['g', 'c', 'j']);
+    });
+
+    test('join: expects nothing (it rewrites a table another source created)', () => {
+      expect(requestedLayerTables([{
+        type: 'join',
+        tableRootName: 'table_osm_roads',
+        tableJoinName: 'lst',
+        output: { type: 'MODIFY_ROOT' },
+      }])).toEqual([]);
+    });
+
+    test('tolerates specs with nothing to promise', () => {
+      expect(requestedLayerTables([])).toEqual([]);
+      expect(requestedLayerTables(undefined as any)).toEqual([]);
+      // osm with no autoLoadLayers splits no layers, so it promises no layer table.
+      expect(requestedLayerTables([{ type: 'osm', outputTableName: 'table_osm' }])).toEqual([]);
     });
   });
 

--- a/utk_curio/sandbox/app/worker.py
+++ b/utk_curio/sandbox/app/worker.py
@@ -622,6 +622,34 @@ def is_node_internal_stream_crash(exit_code, stdout_lines, stderr_lines) -> bool
     return all(marker in stderr_text for marker in _NODE_INTERNAL_STREAM_CRASH_MARKERS)
 
 
+# Placeholder the frontend puts where a backend URL belongs in code destined for
+# this sandbox (autkGrammarBehavior.SANDBOX_BACKEND_URL_TOKEN). It is resolved
+# here, in the process that actually performs the fetch, rather than guessed in
+# the browser bundle.
+_SANDBOX_BACKEND_URL_TOKEN = '__CURIO_BACKEND_URL__'
+
+
+def backend_base_url():
+    """``http://host:port`` for the backend, as reachable from this process.
+
+    ``main.py::set_environment_variables`` exports FLASK_BACKEND_HOST/PORT and
+    start_sandbox passes the environment through, so a sandbox launched with the
+    stack always has the true values - including on a custom-port stack, where
+    the browser's own port would be wrong, and inside a container, where a
+    host-published port is not the one to dial.
+
+    The loopback host is normalised to 127.0.0.1: Node's fetch can stall when
+    ``localhost`` resolves to IPv6 ::1 while Flask listens on IPv4 only.
+    """
+    import os
+
+    host = os.environ.get('FLASK_BACKEND_HOST') or '127.0.0.1'
+    port = os.environ.get('FLASK_BACKEND_PORT') or '5002'
+    if host in ('localhost', '0.0.0.0', '::', '[::]'):
+        host = '127.0.0.1'
+    return f'http://{host}:{port}'
+
+
 def execute_js_code(code, file_path, node_type, data_type, launch_dir=None, session_id=None, save_dataset=True):
     """
     Execute user JavaScript code in an isolated Node.js subprocess.
@@ -649,6 +677,11 @@ def execute_js_code(code, file_path, node_type, data_type, launch_dir=None, sess
 
     t0 = time.perf_counter()
     cwd = launch_dir or os.getcwd()
+
+    # Resolve the frontend's backend-URL placeholder now, while the real host and
+    # port are in this process's environment. Done before the import rewriting
+    # below so the substituted code is what gets parsed and run.
+    code = code.replace(_SANDBOX_BACKEND_URL_TOKEN, backend_base_url())
 
     try:
         # Load input from Python DuckDB (same pattern as execute_code).

--- a/utk_curio/sandbox/tests/test_sandbox.py
+++ b/utk_curio/sandbox/tests/test_sandbox.py
@@ -27,6 +27,44 @@ _SKIP_NO_AUTK_DB = unittest.skipUnless(
 )
 
 
+# The contract check compileDataSpecToAutkDbJs() now emits after its load loop
+# (#248). Kept as a literal mirror, like the data-section test above: the Jest
+# suite covers the host-side decision, but only running it in the real Node
+# subprocess proves the GENERATED code parses and behaves there.
+_CONTRACT_CHECK_JS = (
+    "import * as __autkDbMod from '@urban-toolkit/autk-db';\n"
+    "const AutkDb = __autkDbMod.AutkDb || __autkDbMod.AutkSpatialDb;\n"
+    "const __sources = [{{ type: 'geojson', geojsonObject: {{ type: 'FeatureCollection', "
+    "features: [{{ type: 'Feature', geometry: {{ type: 'Point', coordinates: [-87.63, 41.88] }}, "
+    "properties: {{ name: 'a' }} }}] }}, outputTableName: 'probe_pts' }}];\n"
+    "const __expectedTables = ['probe_pts', 'probe_missing'];\n"
+    "const __loadErrors = {load_errors};\n"
+    "const db = new AutkDb();\n"
+    "await db.init();\n"
+    "for (const source of __sources) {{ const {{ type, ...rest }} = source; "
+    "if (type === 'geojson') await db.loadGeojson(rest); }}\n"
+    "let __tables = [];\n"
+    "try {{ __tables = db.getLayerTables ? db.getLayerTables() : []; }}\n"
+    "catch (e) {{ __loadErrors.push('getLayerTables: ' + ((e && e.message) || String(e))); }}\n"
+    "const __have = new Set(__tables.map((t) => t.name));\n"
+    "const __missing = __expectedTables.filter((n) => !__have.has(n));\n"
+    "if (__missing.length > 0) {{\n"
+    "  const __detail = 'missing: ' + __missing.join(', ')\n"
+    "    + (__loadErrors.length > 0 ? ' (' + __loadErrors.join('; ') + ')' : '');\n"
+    "  if (__loadErrors.length > 0) {{\n"
+    "    throw new Error('autk data load produced ' + __missing.length\n"
+    "      + ' fewer table(s) than the spec asked for - ' + __detail);\n"
+    "  }}\n"
+    "  console.log('[autk-grammar] ' + __detail\n"
+    "    + ' - no load error recorded, treating as a genuinely empty query area');\n"
+    "}}\n"
+    "const __out = [];\n"
+    "for (const t of __tables) {{ const geojson = await db.getLayer(t.name); "
+    "__out.push({{ name: t.name, type: t.type ?? 'polygons', geojson }}); }}\n"
+    "return __out;"
+)
+
+
 class TestSandbox(unittest.TestCase):
 
     @classmethod
@@ -176,6 +214,58 @@ class TestSandbox(unittest.TestCase):
         self.assertEqual(layer['name'], 'probe_pts')
         self.assertEqual(layer['geojson']['type'], 'FeatureCollection')
         self.assertEqual(len(layer['geojson']['features']), 1)
+
+    @_SKIP_NO_NODE
+    @_SKIP_NO_AUTK_DB
+    def test_exec_js_autk_short_load_fails_the_node(self):
+        """A data load that comes back SHORT fails, naming the missing table.
+
+        This is #248: autk-db's loadOsm walks autoLoadLayers.layers in order and
+        lets a per-layer failure propagate, so a throw partway leaves the earlier
+        tables registered and the later ones absent. The emit used to publish
+        whatever getLayerTables() held, so the node that failed reported "Done"
+        and a consumer two hops downstream died on "Table table_osm_roads not
+        found". Failing here is also what makes the loss reachable by
+        runDataInBackend's retry: `success: false` returns an empty output.path,
+        the one shape that retry has always keyed on.
+        """
+        from utk_curio.sandbox.app.worker import execute_js_code, _worker_init
+        _worker_init()
+
+        result = execute_js_code(
+            _CONTRACT_CHECK_JS.format(load_errors="['osm: undici assert(!this.paused)']"),
+            '', 'AUTK_GRAMMAR', '', launch_dir=_REPO_ROOT, session_id=None,
+        )
+        self.assertIn('probe_missing', result['stderr'])
+        self.assertIn('fewer table(s) than the spec asked for', result['stderr'])
+        # The recorded reason travels with the failure - it is the only account
+        # of WHY the layer is missing, and used to be discarded to a console.log.
+        self.assertIn('undici', result['stderr'])
+        # No artifact: the short layer array must not reach a downstream node,
+        # and an empty path is what triggers the caller's retry.
+        self.assertEqual(result['output']['path'], '')
+
+    @_SKIP_NO_NODE
+    @_SKIP_NO_AUTK_DB
+    def test_exec_js_autk_empty_area_still_succeeds(self):
+        """Missing tables with NO recorded error is a sparse area, not a failure.
+
+        The other half of the predicate. autk-db creates a layer table even at
+        zero features, so a missing table always coincides with a caught reason
+        when the load actually broke - which is what lets the check above throw
+        without turning a genuinely empty query area into a red node.
+        """
+        from utk_curio.sandbox.app.worker import execute_js_code, _worker_init
+        from utk_curio.sandbox.util.parsers import load_from_duckdb
+        _worker_init()
+
+        result = execute_js_code(
+            _CONTRACT_CHECK_JS.format(load_errors='[]'),
+            '', 'AUTK_GRAMMAR', '', launch_dir=_REPO_ROOT, session_id=None,
+        )
+        self.assertEqual(result['stderr'], '', msg=result.get('stderr'))
+        layers = load_from_duckdb(result['output']['path'], session_id=None)
+        self.assertEqual([l['name'] for l in layers], ['probe_pts'])
 
 
 class TestProjDataDir(unittest.TestCase):

--- a/utk_curio/sandbox/tests/test_sandbox.py
+++ b/utk_curio/sandbox/tests/test_sandbox.py
@@ -215,6 +215,68 @@ class TestSandbox(unittest.TestCase):
         self.assertEqual(layer['geojson']['type'], 'FeatureCollection')
         self.assertEqual(len(layer['geojson']['features']), 1)
 
+    def test_backend_base_url_follows_the_running_stack(self):
+        """The backend URL handed to JS comes from the environment, not a constant.
+
+        The frontend cannot know which address the sandbox subprocess must dial -
+        under Docker the two are in different network namespaces, and on a
+        custom-port stack the page's own port is not the sandbox's. It used to
+        force :5002 for any loopback backend, so every OSM/PBF load on a
+        non-default-port stack died with "fetch failed" (#248).
+        """
+        import os
+        from utk_curio.sandbox.app.worker import backend_base_url
+
+        saved = {k: os.environ.get(k) for k in ('FLASK_BACKEND_HOST', 'FLASK_BACKEND_PORT')}
+        try:
+            os.environ['FLASK_BACKEND_HOST'] = 'localhost'
+            os.environ['FLASK_BACKEND_PORT'] = '5248'
+            # localhost is normalised: Node's fetch can stall on ::1 while Flask
+            # listens on IPv4 only.
+            self.assertEqual(backend_base_url(), 'http://127.0.0.1:5248')
+
+            os.environ['FLASK_BACKEND_HOST'] = '0.0.0.0'
+            self.assertEqual(backend_base_url(), 'http://127.0.0.1:5248')
+
+            os.environ['FLASK_BACKEND_HOST'] = 'backend.internal'
+            self.assertEqual(backend_base_url(), 'http://backend.internal:5248')
+
+            # Standalone sandbox with nothing exported: the documented default.
+            del os.environ['FLASK_BACKEND_HOST']
+            del os.environ['FLASK_BACKEND_PORT']
+            self.assertEqual(backend_base_url(), 'http://127.0.0.1:5002')
+        finally:
+            for k, v in saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+    @_SKIP_NO_NODE
+    def test_exec_js_substitutes_the_backend_url_token(self):
+        """The placeholder is replaced before the user code runs."""
+        import os
+        from utk_curio.sandbox.app.worker import execute_js_code, _worker_init
+        from utk_curio.sandbox.util.parsers import load_from_duckdb
+        _worker_init()
+
+        saved = os.environ.get('FLASK_BACKEND_PORT')
+        os.environ['FLASK_BACKEND_PORT'] = '5248'
+        try:
+            result = execute_js_code(
+                "return '__CURIO_BACKEND_URL__/file/docs/examples/data/niteroi.osm.pbf';",
+                '', 'JS_COMPUTATION', '', launch_dir=_REPO_ROOT, session_id=None,
+            )
+            self.assertEqual(result['stderr'], '', msg=result.get('stderr'))
+            value = load_from_duckdb(result['output']['path'], session_id=None)
+            self.assertEqual(
+                value, 'http://127.0.0.1:5248/file/docs/examples/data/niteroi.osm.pbf')
+        finally:
+            if saved is None:
+                os.environ.pop('FLASK_BACKEND_PORT', None)
+            else:
+                os.environ['FLASK_BACKEND_PORT'] = saved
+
     @_SKIP_NO_NODE
     @_SKIP_NO_AUTK_DB
     def test_exec_js_autk_short_load_fails_the_node(self):


### PR DESCRIPTION
Fixes the Autark half of #248, and the port bug underneath it.

## What was wrong

Two independent defects, both of which present as "workflows fail `test_node_execution` intermittently under the full matrix, pass in isolation".

**1. A partial autk data load was reported as success.** `autk-db`'s `loadOsm` walks `autoLoadLayers.layers` sequentially and lets a per-layer failure propagate, so a throw partway leaves the earlier tables registered and the later ones absent. Both loaders — `compileDataSpecToAutkDbJs` (sandbox) and `loadSpecLayers` (in-browser) — caught that into a `console.log` and then published whatever `getLayerTables()` happened to hold. The node that actually failed showed **Done**, and the loss surfaced two nodes downstream as the opaque error #248 captured:

```
Node niteroi-join (JS_COMPUTATION) execution failed with Error
TableNotFoundError: Table table_osm_roads not found
```

`roads` is last in `08`'s spec, which is why that is the name that goes missing.

**2. The browser hardcoded port 5002 for the sandbox's fetch.** `resolveDataSourceUrls(spec, forBackend=true)` rewrote any loopback backend to `:5002`. On any stack not using the default port, every Autark PBF load therefore died with `osm: fetch failed` and silently fell back to the in-browser loader — which streams a city-scale PBF in headless Chromium and loses layers nondeterministically under load. **This is the actual driver of #248**: the reporter ran on 5502/2500/8500, so every Autark data load on that stack was taking the unreliable path.

## What changed

- **`requestedLayerTables()`** derives the tables a data spec asks `autk-db` to create (mirroring its own `outputTableName || \`${osmInputTableName}_${layer}\`` naming), computed once host-side and inlined into the emitted sandbox script so the rules are not restated. A short load now throws, naming the missing tables and carrying the recorded reason. `dropOsmTable` is accounted for; a `join` source expects nothing.
- Failing makes the loss reachable by **`runDataInBackend`'s existing retry** — it only ever fired on "no `output.path`", a shape a partial load never produced. No new retry code.
- **`SANDBOX_BACKEND_URL_TOKEN`** replaces the guessed URL. `worker.py::backend_base_url()` resolves it at execution time from `FLASK_BACKEND_HOST`/`FLASK_BACKEND_PORT`, which `main.py` already exports and `start_sandbox` already passes through. Correct for default ports, custom ports, and remapped container ports alike; the original IPv6-stall reason for normalising `localhost` → `127.0.0.1` is preserved.
- **`sandbox_base_url()`** in the e2e helpers reads `CURIO_E2E_SANDBOX_PORT` first. Two call sites read only `FLASK_SANDBOX_PORT`, so on a non-default-port stack every `test_node_execution` case died early on a `401` from `:2000/exec` — the trap called out in the issue's Additional Information.

No example workflow JSON was touched. The examples are correct; the loader was misreporting whether it had satisfied them.

## Verification

Measured on a dedicated 5248/2248/8248 stack, comparing unmodified `main` against this branch on the same machine.

| Full E2E matrix (125 tests) | `main` | this branch |
|---|---|---|
| Autark/PBF failures | 6 | **0** |
| `TableNotFoundError` | present | **0** |
| `osm: fetch failed` | 32 | **0** |

The seven workflows named in the issue: **8 passed, 0 failed** (they were 6 failed).

- Frontend Jest: 163 suites / 1910 tests pass. Each new test was confirmed to fail without its fix.
- Sandbox pytest: 14/14 in the file, 289 pass / 55 skip for the directory.
- `tsc --noEmit`: unchanged (3 pre-existing errors in untouched test files).
- Port fix isolated: the same test **fails** with `401 ... http://127.0.0.1:2000/exec` on the old logic and **passes** on the new.

New tests cover the naming rules across all four source types, a short load, retry-then-recover, an empty query area, a layer that cannot be exported, `backend_base_url()` across four host/port shapes, and token substitution end-to-end through the real Node subprocess.

## Not fixed here

- **A second, independent load-dependent flake in the Vega family.** The post-fix matrix has 2 failures — `04-vega-lite-multi-flow-dashboard` (a `VIS_VEGA` node errors, with no error text captured) and `05-vega-lite-multi-view-drilldown` (10s timeout waiting for Done). Both pass in isolation and neither was failing before. This is very likely the family the issue's `DataPool_Vega.json` / `DataPool_Vega_2.json` entries belong to — those two now pass, including under the full matrix. Worth its own issue.
- **`08`'s merge path.** Separately from the layer loss, `niteroi-merge` can deliver `null` to `niteroi-join`. Not reproduced after these fixes, but it was observed and is not addressed.
- The two hypotheses in the issue body are ruled out: `execute_js_code` gives every JS node a fresh Node subprocess, and `table_osm_roads` is created and consumed inside a single node's script, so no cross-node or cross-workflow database state is involved.
