### PR TITLE
Point five catalog e2e tests at the current drawer controls (#264)

### DIFF
--- a/utk_curio/backend/tests/test_frontend/test_agent_catalog.py
+++ b/utk_curio/backend/tests/test_frontend/test_agent_catalog.py
@@ -301,7 +301,11 @@ def test_add_agent_propagates_to_palette(
         and r.ok,
         timeout=30000,
     ):
-        accept_confirm_dialog(page, title=f"Remove {AGENT_NAME}?", button="Remove")
+        # The dialog is titled "Remove <name> from this project?" - the same
+        # sentence the Data and Node catalogs use since the copy was unified.
+        accept_confirm_dialog(
+            page, title=f"Remove {AGENT_NAME} from this project?", button="Remove"
+        )
 
     expect(
         card.get_by_role("button", name=re.compile(r"^Add to project"))

--- a/utk_curio/backend/tests/test_frontend/test_data_catalog.py
+++ b/utk_curio/backend/tests/test_frontend/test_data_catalog.py
@@ -282,15 +282,23 @@ def test_add_dataset_propagates_to_palette(
     # Server-side truth: the spec ref was persisted, not just the React state.
     assert _installed_flag() is True
 
-    # Round-trip. No window.confirm on this path, unlike package removal.
+    # Round-trip. Removal confirms in an app dialog now (#196, #197): the card
+    # click only opens "Remove <title>?", and the DELETE follows the confirm.
+    # The confirm button reads "Remove and delete" when no other dataflow uses
+    # the file, so match it by prefix.
     drawer = _open_drawer_from_menu(page)
+    _card(drawer, DATASET_ID).get_by_role(
+        "button", name="Remove from project", exact=True
+    ).click()
     with page.expect_response(
         lambda r: "/datasets/" in r.url and r.request.method == "DELETE",
         timeout=30000,
     ):
-        _card(drawer, DATASET_ID).get_by_role(
-            "button", name="Remove from project", exact=True
-        ).click()
+        accept_confirm_dialog(
+            page,
+            title=f"Remove {DATASET_TITLE}?",
+            button=re.compile(r"^Remove( and delete)?$"),
+        )
 
     expect(
         _card(drawer, DATASET_ID).get_by_role(

--- a/utk_curio/backend/tests/test_frontend/test_package_export_import.py
+++ b/utk_curio/backend/tests/test_frontend/test_package_export_import.py
@@ -301,13 +301,15 @@ def test_export_then_load_package_through_node_catalog(
         _import_archive(page, drawer, clone)
 
     # The clone is sideloaded, so it shows under "In project" but never under
-    # Browse, which lists the committed packages/ catalog. That tab renders
-    # MyPackagesList rather than PackageCard, so there is no data-pkg-dir to key
-    # on - the per-row Remove control's aria-label is the stable hook.
+    # Browse, which lists the committed packages/ catalog. Both tabs render
+    # PackageCard now (the per-row list went with 29a4e902), so the card is
+    # keyed by data-pkg-dir and its Remove control reads "Remove from project".
     tabs = drawer.get_by_role("navigation", name="Catalog sections")
     tabs.get_by_role("button", name="In project").click()
     expect(
-        drawer.get_by_role("button", name=f"Remove {CLONE_NAME}", exact=True)
+        drawer.locator(f'article[data-pkg-dir="{CLONE_DIR}"]').get_by_role(
+            "button", name="Remove from project", exact=True
+        )
     ).to_be_visible(timeout=30000)
 
     # 6. onPickArchive also writes the project lockfile - without that the
@@ -373,22 +375,27 @@ def test_export_from_the_drawer_in_dataflow_tab(
     page.wait_for_load_state("domcontentloaded")
 
     drawer = _open_drawer_from_menu(page)
-    # The export control lives on the "In project" rows, which render
-    # MyPackagesList (no data-pkg-dir there) - the aria-label uses the manifest
-    # NAME, while the palette accordion's uses a longer ".curio.zip archive" form.
+    # Export moved off the card and into the package's details modal
+    # (29a4e902): the "In project" tab renders PackageCard, whose avatar and
+    # "View details" both open PackageDetailModal, and Export is that modal's
+    # header action. The palette accordion keeps its own longer-named control.
     drawer.get_by_role("navigation", name="Catalog sections").get_by_role(
         "button", name="In project"
     ).click()
-    export_button = drawer.get_by_role("button", name=f"Export {PKG_NAME}", exact=True)
-    expect(export_button).to_be_visible(timeout=30000)
+    card = drawer.locator(f'article[data-pkg-dir="{PKG_DIR}"]')
+    expect(card).to_be_visible(timeout=30000)
 
-    # Visual baseline of the In project tab with its row actions. This is the
-    # surface whose export control was dead code until it was wired, so a
-    # baseline here records what "wired" looks like.
+    # Visual baseline of the In project tab with its card actions.
     save_workflow_test_screenshot(
         page, "package-export-drawer",
         test_name="test_export_from_the_drawer_in_dataflow_tab",
     )
+
+    card.get_by_role("button", name=f"View {PKG_NAME} details").click()
+    details = page.get_by_role("dialog", name="Package details")
+    expect(details).to_be_visible(timeout=15000)
+    export_button = details.get_by_role("button", name="Export", exact=True)
+    expect(export_button).to_be_visible(timeout=10000)
 
     with page.expect_download(timeout=30000) as download:
         export_button.click()

--- a/utk_curio/backend/tests/test_frontend/test_save_as_package.py
+++ b/utk_curio/backend/tests/test_frontend/test_save_as_package.py
@@ -248,14 +248,17 @@ def test_save_node_as_package_export_then_load_back(
 
     assert upload.value.status == 201, upload.value.text()[:500]
 
-    # 9. It is a real installed package now: listed under "In project" (which
-    #    renders MyPackagesList, so the per-row Remove label is the stable hook)
-    #    and present in the palette, since onPickArchive also writes the lockfile.
+    # 9. It is a real installed package now: listed under "In project" (a
+    #    PackageCard keyed by data-pkg-dir, whose Remove reads "Remove from
+    #    project" since 29a4e902) and present in the palette, since onPickArchive
+    #    also writes the lockfile.
     drawer.get_by_role("navigation", name="Catalog sections").get_by_role(
         "button", name="In project"
     ).click()
     expect(
-        drawer.get_by_role("button", name=f"Remove {NEW_PACKAGE_NAME}", exact=True)
+        drawer.locator(f'article[data-pkg-dir="{dir_name}"]').get_by_role(
+            "button", name="Remove from project", exact=True
+        )
     ).to_be_visible(timeout=30000)
 
     drawer.locator("header").get_by_role(


### PR DESCRIPTION
Addresses #264.

The five remaining failures are stale tests, not product defects. Each one was written against controls that later work deliberately replaced:

- `test_package_export_import.py` (both) and `test_save_as_package.py`: the Node Catalog's "In project" tab no longer renders `MyPackagesList` rows with an `aria-label` of `Remove <name>` / `Export <name>`; since 29a4e902 it renders `PackageCard`, whose Remove reads "Remove from project" and whose Export lives in `PackageDetailModal` (opened from "View <name> details"). The tests now scope to `article[data-pkg-dir=...]` and, for the drawer export, go through the details modal.
- `test_agent_catalog.py::test_add_agent_propagates_to_palette`: the Remove confirmation is titled "Remove <name> from this project?" since the catalog copy was unified (#196/#198); the test asked for "Remove <name>?".
- `test_data_catalog.py::test_add_dataset_propagates_to_palette`: dataset removal confirms in an app dialog now (#196/#197) - the test still said "No window.confirm on this path" and waited for a DELETE that could never come. It now accepts the confirm ("Remove" or "Remove and delete") inside the response wait.

No product code changes. Verified by collection locally; the e2e run on this branch is the proof - every other test in the suite was green on the previous main run.
