### PR TITLE
Parallel e2e: one backend+sandbox pair per xdist worker

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -116,9 +116,9 @@ jobs:
       # CURIO_E2E_SANDBOX_PORT below. Each worker is a Chromium + backend +
       # sandbox (~3 GiB) inside the one container, on a host that also runs
       # the prod stacks, and no N beats the longest group (test_agent_runs_e2e,
-      # ~2 min here). Start at 2; raise once the pass set matches the serial
-      # run, watching memory and nvidia-smi.
-      CURIO_E2E_PARALLEL: "2"
+      # ~2 min here). 4 to begin with; raise once the pass set matches the
+      # serial run, watching memory and nvidia-smi.
+      CURIO_E2E_PARALLEL: "4"
       BACKEND_URL: "http://localhost:5022"
       # Host-side Playwright targets the remapped ports (utils.py
       # e2e_existing_servers / _backend_base_url_for_config read these).

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -13,6 +13,7 @@ on:
       - 'docker-compose.ci.yml'
       - 'docker-compose.ci-isolated.yml'
       - 'docker-compose.ci-exec-user.yml'
+      - 'docker-compose.ci-shards.yml'
       - '.github/workflows/docker-compose.yml'
       # scripts/test.sh is this workflow's entry point; the authoring helpers
       # (new_package.py, regen_integrity.py) are covered by the test suite too.
@@ -39,6 +40,7 @@ on:
       - 'docker-compose.ci.yml'
       - 'docker-compose.ci-isolated.yml'
       - 'docker-compose.ci-exec-user.yml'
+      - 'docker-compose.ci-shards.yml'
       - '.github/workflows/docker-compose.yml'
       # scripts/test.sh is this workflow's entry point; the authoring helpers
       # (new_package.py, regen_integrity.py) are covered by the test suite too.
@@ -92,7 +94,7 @@ jobs:
       # workflow deps, library manager, project save/load, ...). Every
       # `docker compose` step below reads COMPOSE_FILE, so setting it here is
       # enough. See docker-compose.ci.yml for why this isn't the deploy overlay.
-      COMPOSE_FILE: docker-compose.yml:docker-compose.ci.yml
+      COMPOSE_FILE: docker-compose.yml:docker-compose.ci.yml:docker-compose.ci-shards.yml
       # Hardware WebGPU path (see conftest.py browser_type_launch_args).
       CURIO_WEBGPU_BACKEND: hardware
       CURIO_REQUIRE_HARDWARE_WEBGPU: "1"
@@ -107,6 +109,18 @@ jobs:
       CURIO_PORT_2000: "2020"
       CURIO_PORT_5002: "5022"
       CURIO_PORT_8080: "8100"
+      # Extra e2e shards (docker-compose.ci-shards.yml): shard k's backend is
+      # container 5002+k on host 5022+k, its sandbox container 2000+k on host
+      # 2020+k -- the arithmetic backend/tests/shards.py does from
+      # CURIO_E2E_BACKEND_PORT / CURIO_E2E_SANDBOX_PORT below. Start at 2
+      # workers; raise once the pass set matches the serial run.
+      CURIO_E2E_PARALLEL: "2"
+      CURIO_PORT_5003: "5023"
+      CURIO_PORT_2001: "2021"
+      CURIO_PORT_5004: "5024"
+      CURIO_PORT_2002: "2022"
+      CURIO_PORT_5005: "5025"
+      CURIO_PORT_2003: "2023"
       BACKEND_URL: "http://localhost:5022"
       # Host-side Playwright targets the remapped ports (utils.py
       # e2e_existing_servers / _backend_base_url_for_config read these).
@@ -289,9 +303,53 @@ jobs:
             utk_curio/frontend/urban-workflows/dist
           test -f utk_curio/frontend/urban-workflows/dist/index.html
 
+      - name: 🧩 Start the extra e2e shards inside the CI container
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Shards 1..N-1 are backend+sandbox pairs in the SAME container as the
+          # base stack (no extra compose stacks). Their ports were published at
+          # create time by docker-compose.ci-shards.yml. Inside the container
+          # shards.py derives container ports (5002+k / 2000+k) and a state dir
+          # under /app/.curio/shards/k, which the bind mount shares with the host
+          # worker that will drive it. `umask 000` for the same reason the base
+          # command has it: root-created files the host-side pytest must write.
+          for k in $(seq 1 $((CURIO_E2E_PARALLEL - 1))); do
+            echo "==> starting shard $k"
+            docker compose -p curio-ci exec -d -T curio sh -c '
+              umask 000
+              k="$1"
+              eval "$(env -u CURIO_E2E_BACKEND_PORT -u CURIO_E2E_SANDBOX_PORT \
+                          -u BACKEND_PORT -u SANDBOX_PORT \
+                          python -m utk_curio.backend.tests.shards "$k")"
+              mkdir -p "$CURIO_CATALOG_ROOT" "$CURIO_SHARED_DATA"
+              cp -r /app/datasets/. "$CURIO_CATALOG_ROOT/"
+              python curio.py start backend --auth --with-examples \
+                --backend-host 0.0.0.0 --backend-port "$BACKEND_PORT" \
+                --sandbox-host 0.0.0.0 --sandbox-port "$SANDBOX_PORT" \
+                > "$CURIO_STATE_DIR/launch-backend.out" 2>&1 &
+              python curio.py start sandbox \
+                --backend-host 0.0.0.0 --backend-port "$BACKEND_PORT" \
+                --sandbox-host 0.0.0.0 --sandbox-port "$SANDBOX_PORT" \
+                > "$CURIO_STATE_DIR/launch-sandbox.out" 2>&1 &
+              wait
+            ' sh "$k"
+          done
+          # Same shape as the base health gate: poll /live on each host port.
+          for k in $(seq 1 $((CURIO_E2E_PARALLEL - 1))); do
+            for port in $((CURIO_E2E_BACKEND_PORT + k)) $((CURIO_E2E_SANDBOX_PORT + k)); do
+              echo "==> waiting for shard $k on :$port"
+              timeout 240 bash -c "until curl -sf http://localhost:$port/live >/dev/null; do sleep 2; done" \
+                || { echo "::error::shard $k never answered on :$port" >&2
+                     docker compose -p curio-ci exec -T curio sh -c "tail -50 /app/.curio/shards/$k/launch-*.out" || true
+                     exit 1; }
+            done
+          done
+
       - name: 🎭 Run e2e tests (full matrix, hardware WebGPU)
         run: |
           bash scripts/test.sh --e2e-only --use-existing \
+            --parallel "$CURIO_E2E_PARALLEL" \
             --allure-dir "$GITHUB_WORKSPACE/allure-results"
 
       - name: 📊 Install Allure CLI

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -109,18 +109,16 @@ jobs:
       CURIO_PORT_2000: "2020"
       CURIO_PORT_5002: "5022"
       CURIO_PORT_8080: "8100"
-      # Extra e2e shards (docker-compose.ci-shards.yml): shard k's backend is
-      # container 5002+k on host 5022+k, its sandbox container 2000+k on host
-      # 2020+k -- the arithmetic backend/tests/shards.py does from
-      # CURIO_E2E_BACKEND_PORT / CURIO_E2E_SANDBOX_PORT below. Start at 2
-      # workers; raise once the pass set matches the serial run.
+      # Extra e2e shards (docker-compose.ci-shards.yml publishes pairs for up
+      # to 8 workers): shard k's backend is container 5002+k on host 5022+k,
+      # its sandbox container 2000+k on host 2020+k -- the arithmetic
+      # backend/tests/shards.py does from CURIO_E2E_BACKEND_PORT /
+      # CURIO_E2E_SANDBOX_PORT below. Each worker is a Chromium + backend +
+      # sandbox (~3 GiB) inside the one container, on a host that also runs
+      # the prod stacks, and no N beats the longest group (test_agent_runs_e2e,
+      # ~2 min here). Start at 2; raise once the pass set matches the serial
+      # run, watching memory and nvidia-smi.
       CURIO_E2E_PARALLEL: "2"
-      CURIO_PORT_5003: "5023"
-      CURIO_PORT_2001: "2021"
-      CURIO_PORT_5004: "5024"
-      CURIO_PORT_2002: "2022"
-      CURIO_PORT_5005: "5025"
-      CURIO_PORT_2003: "2023"
       BACKEND_URL: "http://localhost:5022"
       # Host-side Playwright targets the remapped ports (utils.py
       # e2e_existing_servers / _backend_base_url_for_config read these).

--- a/docker-compose.ci-shards.yml
+++ b/docker-compose.ci-shards.yml
@@ -5,7 +5,8 @@
 # pairs for shards 1..N-1 run INSIDE the same container as the base stack
 # (started with `docker compose exec -d`, see the workflow), on container ports
 # 5002+k / 2000+k. `docker compose exec` cannot publish ports, so they are
-# declared here at create time -- declaring more than a run uses costs nothing.
+# declared here at create time -- declaring more than a run uses costs nothing, so seven pairs
+# (up to 8 workers) are declared; raise CURIO_E2E_PARALLEL, not this file.
 # Compose APPENDS `ports` across overlays, so the base file's 5002/8080 and
 # docker-compose.ci.yml's sandbox publish survive.
 #
@@ -22,7 +23,15 @@ services:
     ports:
       - "127.0.0.1:${CURIO_PORT_5003:-5023}:5003"   # shard 1 backend
       - "127.0.0.1:${CURIO_PORT_2001:-2021}:2001"   # shard 1 sandbox
-      - "127.0.0.1:${CURIO_PORT_5004:-5024}:5004"   # shard 2
-      - "127.0.0.1:${CURIO_PORT_2002:-2022}:2002"
-      - "127.0.0.1:${CURIO_PORT_5005:-5025}:5005"   # shard 3
-      - "127.0.0.1:${CURIO_PORT_2003:-2023}:2003"
+      - "127.0.0.1:${CURIO_PORT_5004:-5024}:5004"   # shard 2 backend
+      - "127.0.0.1:${CURIO_PORT_2002:-2022}:2002"   # shard 2 sandbox
+      - "127.0.0.1:${CURIO_PORT_5005:-5025}:5005"   # shard 3 backend
+      - "127.0.0.1:${CURIO_PORT_2003:-2023}:2003"   # shard 3 sandbox
+      - "127.0.0.1:${CURIO_PORT_5006:-5026}:5006"   # shard 4 backend
+      - "127.0.0.1:${CURIO_PORT_2004:-2024}:2004"   # shard 4 sandbox
+      - "127.0.0.1:${CURIO_PORT_5007:-5027}:5007"   # shard 5 backend
+      - "127.0.0.1:${CURIO_PORT_2005:-2025}:2005"   # shard 5 sandbox
+      - "127.0.0.1:${CURIO_PORT_5008:-5028}:5008"   # shard 6 backend
+      - "127.0.0.1:${CURIO_PORT_2006:-2026}:2006"   # shard 6 sandbox
+      - "127.0.0.1:${CURIO_PORT_5009:-5029}:5009"   # shard 7 backend
+      - "127.0.0.1:${CURIO_PORT_2007:-2027}:2007"   # shard 7 sandbox

--- a/docker-compose.ci-shards.yml
+++ b/docker-compose.ci-shards.yml
@@ -1,0 +1,28 @@
+# CI overlay: publish the ports of the EXTRA e2e shards.
+#
+# `scripts/test.sh --parallel N` runs the e2e suite on N pytest-xdist workers,
+# each against its own backend+sandbox pair behind the one frontend. In CI the
+# pairs for shards 1..N-1 run INSIDE the same container as the base stack
+# (started with `docker compose exec -d`, see the workflow), on container ports
+# 5002+k / 2000+k. `docker compose exec` cannot publish ports, so they are
+# declared here at create time -- declaring more than a run uses costs nothing.
+# Compose APPENDS `ports` across overlays, so the base file's 5002/8080 and
+# docker-compose.ci.yml's sandbox publish survive.
+#
+# Loopback only, for the same reason docker-compose.ci.yml gives for the base
+# sandbox: these execute arbitrary code and only the host-side pytest needs
+# them. Host ports default to container+21 so that, unset, they land next to
+# the CI stack's remapped 5022/2020 rather than on prod's 5002/2000 block.
+#
+# Host-side workers find their pair through backend/tests/shards.py: base host
+# port (CURIO_E2E_BACKEND_PORT=5022) + k. The mappings below must keep that
+# arithmetic true: shard k's host port == 5022+k, container port == 5002+k.
+services:
+  curio:
+    ports:
+      - "127.0.0.1:${CURIO_PORT_5003:-5023}:5003"   # shard 1 backend
+      - "127.0.0.1:${CURIO_PORT_2001:-2021}:2001"   # shard 1 sandbox
+      - "127.0.0.1:${CURIO_PORT_5004:-5024}:5004"   # shard 2
+      - "127.0.0.1:${CURIO_PORT_2002:-2022}:2002"
+      - "127.0.0.1:${CURIO_PORT_5005:-5025}:5005"   # shard 3
+      - "127.0.0.1:${CURIO_PORT_2003:-2023}:2003"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -206,6 +206,9 @@ python curio.py test backend
 
 # watch the browser, specific workflows only
 python curio.py test e2e --use-existing --headed --workflows Vega.json,Regression.json
+
+# E2E on 4 xdist workers, one backend+sandbox pair each (see test_frontend/README.md, "Parallel")
+python curio.py test e2e --parallel 4
 ```
 
 See `python curio.py test --help` for all options, or read the sections below for

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -7,7 +7,7 @@ This guide deploys Curio under a `/curio` path prefix on a hostname you already 
 Assumed setup: a Linux server with the hostname already pointing at it, Docker + Compose installed, and [Caddy](https://caddyserver.com) installed as the reverse proxy.
 
 > [!IMPORTANT]
-> The frontend bundle is built **inside the Docker image** with `BACKEND_URL` and `PUBLIC_PATH` baked in at build time. Changing the public URL or path prefix means rebuilding the image, there is no runtime override.
+> The frontend bundle is built **inside the Docker image** with `BACKEND_URL` and `PUBLIC_PATH` baked in at build time. (The baked `BACKEND_URL` is the bundle's *default*: `src/utils/backendUrl.ts` prefers `window.__CURIO_BACKEND_URL__` when a page sets it, which is how the parallel e2e harness points one build at several backends. Deployments still bake the right default.) Changing the public URL or path prefix means rebuilding the image, there is no runtime override.
 
 ## Contents
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
   "pytest==9.0.3",
   "pytest-cov==7.1.0",
   "pytest-playwright==0.7.2",
+  "pytest-xdist==3.8.0",
   "pytest-flask==1.3.0",
   "allure-pytest==2.16.0"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,5 +56,6 @@ jsonschema>=4.18
 pytest==9.0.3
 pytest-cov==7.1.0
 pytest-playwright==0.7.2
+pytest-xdist==3.8.0
 pytest-flask==1.3.0
 allure-pytest==2.16.0

--- a/scripts/e2e_parallel_estimate.py
+++ b/scripts/e2e_parallel_estimate.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Estimate the parallel-e2e speedup from STRATIFIED SAMPLE runs.
+
+The full serial suite takes ~2.5h on a Windows dev box, so the Stage 1 gate is
+priced from two sample runs instead:
+
+    phase A  test_workflows.py, a few whole workflow groups (4 tests each)
+    phase B  a few whole files, chosen to cover both strata
+
+Phase B is stratified because its per-test cost is bimodal: test_examples,
+test_example_docs_parity and test_agent_runs_e2e never touch a browser (zero
+`page` references) and are ~an order of magnitude cheaper than the rest, so
+scaling phase B by test count alone badly overestimates it.
+
+Extrapolation, stated plainly:
+    total_A = mean(non-GPU group) * n_nonGPU_groups + mean(GPU group) * n_GPU_groups
+    total_B = mean(structural per-test) * n_structural + mean(browser per-test) * n_browser
+
+The makespan is computed on a synthetic population built by TILING the measured
+group times (not by using their mean), so real variance is preserved rather than
+flattened into an optimistic perfectly-balanced set.
+
+Usage:
+    python scripts/e2e_parallel_estimate.py e2e-A-sample.xml e2e-B-sample.xml
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from e2e_shard_plan import _GPU_RE, _fmt, _module_and_param, lpt_makespan  # noqa: E402
+
+#: Phase B files with zero `page`/`app_frontend`/`workflow_page` references.
+#: Measured, not guessed: grep over test_frontend/*.py.
+STRUCTURAL_MODULES = {
+    "test_example_docs_parity",
+    "test_examples",
+    "test_agent_runs_e2e",
+}
+
+
+def _cases(path: str):
+    """(module, param, seconds) per non-skipped testcase."""
+    for case in ET.parse(path).getroot().iter("testcase"):
+        if case.find("skipped") is not None:
+            continue
+        module, param = _module_and_param(case.get("classname") or "", case.get("name") or "")
+        yield module, param, float(case.get("time") or 0.0)
+
+
+def _tile(values: list[float], n: int) -> list[float]:
+    """n weights drawn cyclically from `values`, preserving its variance."""
+    if not values:
+        return []
+    return [values[i % len(values)] for i in range(n)]
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("phase_a_xml")
+    ap.add_argument("phase_b_xml")
+    # Population, measured from --collect-only. Defaults are this repo's numbers.
+    ap.add_argument("--groups-nongpu", type=int, default=21,
+                    help="running non-AUTK workflow groups (default 21)")
+    ap.add_argument("--groups-gpu", type=int, default=9,
+                    help="running AUTK/WebGPU workflow groups (default 9)")
+    ap.add_argument("--phaseb-structural", type=int, default=91,
+                    help="phase B tests in browser-free modules (default 91)")
+    ap.add_argument("--phaseb-browser", type=int, default=192,
+                    help="phase B tests that drive a browser (default 192)")
+    ap.add_argument("--max-workers", type=int, default=8)
+    args = ap.parse_args(argv)
+
+    # ---- phase A: group the sample by workflow ----
+    groups: dict[str, float] = collections.defaultdict(float)
+    gcount: dict[str, int] = collections.defaultdict(int)
+    for module, param, secs in _cases(args.phase_a_xml):
+        if not param:
+            continue
+        groups[param] += secs
+        gcount[param] += 1
+
+    gpu = {g: t for g, t in groups.items() if _GPU_RE.search(g)}
+    nongpu = {g: t for g, t in groups.items() if not _GPU_RE.search(g)}
+    if not gpu or not nongpu:
+        print("sample must include at least one AUTK and one non-AUTK workflow",
+              file=sys.stderr)
+        return 1
+
+    mean_gpu = sum(gpu.values()) / len(gpu)
+    mean_nongpu = sum(nongpu.values()) / len(nongpu)
+    total_a = mean_nongpu * args.groups_nongpu + mean_gpu * args.groups_gpu
+
+    # ---- phase B: split the sample into the two strata ----
+    struct, browser = [], []
+    for module, _param, secs in _cases(args.phase_b_xml):
+        (struct if module in STRUCTURAL_MODULES else browser).append(secs)
+    if not struct or not browser:
+        print("phase B sample must cover both strata", file=sys.stderr)
+        return 1
+
+    mean_struct = sum(struct) / len(struct)
+    mean_browser = sum(browser) / len(browser)
+    total_b = mean_struct * args.phaseb_structural + mean_browser * args.phaseb_browser
+    total = total_a + total_b
+
+    print("\n=== measured sample ===")
+    print(f"phase A  {len(groups)} workflow groups, {sum(gcount.values())} tests")
+    for g, t in sorted(groups.items(), key=lambda kv: -kv[1]):
+        print(f"    {_fmt(t):>8}  {gcount[g]}t  {g}{'  [GPU]' if _GPU_RE.search(g) else ''}")
+    print(f"    mean non-AUTK group {_fmt(mean_nongpu)}   mean AUTK group {_fmt(mean_gpu)}")
+    print(f"phase B  {len(struct)} structural tests (mean {mean_struct:5.1f}s), "
+          f"{len(browser)} browser tests (mean {mean_browser:5.1f}s)")
+
+    print("\n=== extrapolated population ===")
+    print(f"phase A  {args.groups_nongpu} non-AUTK + {args.groups_gpu} AUTK groups"
+          f"  -> {_fmt(total_a)}  ({total_a / total:.1%})")
+    print(f"phase B  {args.phaseb_structural} structural + {args.phaseb_browser} browser"
+          f"  -> {_fmt(total_b)}  ({total_b / total:.1%})")
+    print(f"serial total (est.)  {_fmt(total)}")
+
+    per_wf = _tile(sorted(nongpu.values()), args.groups_nongpu) + \
+        _tile(sorted(gpu.values()), args.groups_gpu)
+    gpu_sum = sum(_tile(sorted(gpu.values()), args.groups_gpu))
+    collapsed = _tile(sorted(nongpu.values()), args.groups_nongpu) + [gpu_sum]
+
+    print(f"\n=== projected total = makespan(phase A) + {_fmt(total_b)} serial phase B ===")
+    print(f"{'N':>3}  {'per-workflow groups':>25}  {'AUTK collapsed (1 GPU browser)':>32}")
+    print(f"{'':>3}  {'makespan   total  speedup':>25}  {'makespan   total  speedup':>32}")
+    verdict4 = None
+    for n in range(1, args.max_workers + 1):
+        m1, m2 = lpt_makespan(per_wf, n), lpt_makespan(collapsed, n)
+        s1, s2 = total / (m1 + total_b), total / (m2 + total_b)
+        if n == 4:
+            verdict4 = (s1, s2)
+        print(f"{n:>3}  {_fmt(m1):>9} {_fmt(m1 + total_b):>7} {s1:6.2f}x"
+              f"  {_fmt(m2):>14} {_fmt(m2 + total_b):>7} {s2:6.2f}x")
+
+    print(f"\nphase A serial floor: largest group {_fmt(max(per_wf))}; "
+          f"AUTK collapsed {_fmt(gpu_sum)}")
+    print(f"phase B is the Amdahl floor at {_fmt(total_b)} -- no worker count beats it.")
+    print(f"\nGATE (>= 2.00x at N=4): per-workflow {verdict4[0]:.2f}x "
+          f"{'PASS' if verdict4[0] >= 2 else 'FAIL'}"
+          f"   AUTK-collapsed {verdict4[1]:.2f}x "
+          f"{'PASS' if verdict4[1] >= 2 else 'FAIL'}")
+    print("\nAssumptions: unmeasured groups take their stratum's measured mean; "
+          "makespan\ntiles measured times to preserve variance; phase B scales "
+          "per-test within stratum.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/e2e_shard_plan.py
+++ b/scripts/e2e_shard_plan.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Price parallelising the e2e suite, from a serial run's junit XML.
+
+Read-only. Answers the one question that decides whether ``--parallel`` is worth
+building: what share of the wall clock does ``test_workflows.py`` actually own?
+
+The plan splits the suite into two phases against one stack, because the other
+test files truncate ``user``/``project``/``user_session`` globally between every
+test and would delete a workflow test's logged-in user mid-run:
+
+    phase A   test_workflows.py            parallel, N workers, --dist loadgroup
+    phase B   everything else              serial
+
+so ``total(N) = makespan_A(N) + total_B`` and phase B is the Amdahl floor.
+
+Usage:
+    python -m pytest tests/test_frontend/ --junitxml=e2e-timings.xml   # serial
+    python scripts/e2e_shard_plan.py e2e-timings.xml
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+# Workflows whose nodes drive hardware WebGPU. Grouping them together forces
+# loadgroup to run them on one worker, so at most one WebGPU Chromium exists at
+# a time -- the free mitigation for GPU contention, priced below.
+_GPU_RE = re.compile(r"autk|autark", re.IGNORECASE)
+
+_PARAM_RE = re.compile(r"\[(.+)\]$")
+
+
+def _module_and_param(classname: str, name: str) -> tuple[str, str | None]:
+    """('test_workflows', 'Vega.json') for a parametrized TestWorkflowCanvas case."""
+    module = ""
+    for part in classname.split("."):
+        if part.startswith("test_"):
+            module = part
+    m = _PARAM_RE.search(name)
+    return module, (m.group(1) if m else None)
+
+
+def _group_key(classname: str, name: str) -> tuple[str, str]:
+    """(phase, group). Phase 'A' is test_workflows.py; 'B' is everything else."""
+    module, param = _module_and_param(classname, name)
+    if module == "test_workflows" and param:
+        return "A", f"wf-{param}"
+    return "B", module or "unknown"
+
+
+def load(path: str) -> list[tuple[str, str, str, float]]:
+    """[(phase, group, nodeid, seconds)] for every non-skipped testcase."""
+    rows = []
+    for case in ET.parse(path).getroot().iter("testcase"):
+        # A skipped case contributes no wall clock and would deflate a group.
+        if case.find("skipped") is not None:
+            continue
+        classname = case.get("classname") or ""
+        name = case.get("name") or ""
+        phase, group = _group_key(classname, name)
+        rows.append((phase, group, f"{classname}::{name}", float(case.get("time") or 0.0)))
+    return rows
+
+
+def lpt_makespan(weights: list[float], workers: int) -> float:
+    """Longest-processing-time bin packing. Groups are atomic; xdist hands the
+    next group to whichever worker frees up first, which is what LPT models."""
+    if workers <= 1:
+        return sum(weights)
+    loads = [0.0] * workers
+    for w in sorted(weights, reverse=True):
+        i = min(range(workers), key=lambda k: loads[k])
+        loads[i] += w
+    return max(loads)
+
+
+def _fmt(seconds: float) -> str:
+    return f"{int(seconds) // 60:d}m{int(seconds) % 60:02d}s"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("junit_xml")
+    ap.add_argument("--max-workers", type=int, default=8)
+    ap.add_argument("--top", type=int, default=15, help="groups to list (default 15)")
+    args = ap.parse_args(argv)
+
+    rows = load(args.junit_xml)
+    if not rows:
+        print(f"no non-skipped testcases in {args.junit_xml}", file=sys.stderr)
+        return 1
+
+    groups: dict[tuple[str, str], float] = collections.defaultdict(float)
+    counts: dict[tuple[str, str], int] = collections.defaultdict(int)
+    for phase, group, _nodeid, secs in rows:
+        groups[(phase, group)] += secs
+        counts[(phase, group)] += 1
+
+    a = {g: t for (p, g), t in groups.items() if p == "A"}
+    b = {g: t for (p, g), t in groups.items() if p == "B"}
+    total_a, total_b = sum(a.values()), sum(b.values())
+    total = total_a + total_b
+
+    print(f"\n=== {args.junit_xml} ===")
+    print(f"{len(rows)} tests ran, {_fmt(total)} of measured test time\n")
+    print(f"  phase A  test_workflows.py        {_fmt(total_a):>8}  "
+          f"{total_a / total:5.1%}  {sum(counts[k] for k in groups if k[0]=='A'):3d} tests  "
+          f"{len(a)} groups")
+    print(f"  phase B  everything else          {_fmt(total_b):>8}  "
+          f"{total_b / total:5.1%}  {sum(counts[k] for k in groups if k[0]=='B'):3d} tests  "
+          f"{len(b)} files")
+
+    print(f"\n--- phase A groups, slowest {args.top} ---")
+    for group, secs in sorted(a.items(), key=lambda kv: -kv[1])[: args.top]:
+        gpu = " [GPU]" if _GPU_RE.search(group) else ""
+        print(f"  {_fmt(secs):>8}  {counts[('A', group)]}t  {group}{gpu}")
+
+    print(f"\n--- phase B files, slowest {args.top} ---")
+    for group, secs in sorted(b.items(), key=lambda kv: -kv[1])[: args.top]:
+        print(f"  {_fmt(secs):>8}  {counts[('B', group)]}t  {group}")
+
+    # Two groupings: per-workflow (max parallelism, N WebGPU Chromiums at once)
+    # and AUTK-collapsed (one WebGPU Chromium at a time, longer critical path).
+    per_wf = list(a.values())
+    gpu_total = sum(t for g, t in a.items() if _GPU_RE.search(g))
+    collapsed = [t for g, t in a.items() if not _GPU_RE.search(g)]
+    if gpu_total:
+        collapsed.append(gpu_total)
+
+    print(f"\n--- projected total = makespan(phase A) + {_fmt(total_b)} serial phase B ---")
+    print(f"{'N':>3}  {'per-workflow groups':>24}  {'AUTK collapsed to one group':>29}")
+    print(f"{'':>3}  {'makespan   total  speedup':>24}  {'makespan   total  speedup':>29}")
+    for n in range(1, args.max_workers + 1):
+        m1 = lpt_makespan(per_wf, n)
+        m2 = lpt_makespan(collapsed, n)
+        print(f"{n:>3}  {_fmt(m1):>8} {_fmt(m1 + total_b):>7} {total / (m1 + total_b):6.2f}x"
+              f"  {_fmt(m2):>11} {_fmt(m2 + total_b):>7} {total / (m2 + total_b):6.2f}x")
+
+    print(f"\n  phase A serial floor (longest group): "
+          f"per-workflow {_fmt(max(per_wf))}, AUTK-collapsed {_fmt(max(collapsed))}")
+    if gpu_total:
+        print(f"  AUTK/GPU workflows total {_fmt(gpu_total)} "
+              f"({gpu_total / total_a:.1%} of phase A) across "
+              f"{sum(1 for g in a if _GPU_RE.search(g))} workflows")
+    print("\n  Gate: 4 workers must buy >= 2.00x overall, or re-scope to making the "
+          "slowest\n  workflows faster instead of adding workers.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -24,6 +24,15 @@
 #   --e2e-only          Run only the E2E suite
 #   --unit-only         Run only backend, sandbox, and frontend unit tests (no E2E)
 #   --allure-dir DIR    Write Allure results to DIR (passed to E2E pytest)
+#   --parallel N        Run the E2E suite on N pytest-xdist workers, each against
+#                       its own backend+sandbox pair (one shared frontend).
+#                       N=auto picks min(4, cores/4). Default 1, or $CURIO_E2E_PARALLEL.
+#                       With --use-existing, pairs 1..N-1 must already be running
+#                       on the ports `python -m utk_curio.backend.tests.shards K` prints.
+#
+# Ports: the stack this script boots binds BACKEND_PORT / SANDBOX_PORT /
+# FRONTEND_PORT from the environment (defaults 5002 / 2000 / 8080), so a
+# checkout with its own .curio-ports.sh never fights a sibling's stack.
 
 set -uo pipefail
 
@@ -36,6 +45,7 @@ VIDEOS=0
 EXAMPLES=1
 E2E_WORKFLOWS=""
 ALLURE_DIR=""
+PARALLEL="${CURIO_E2E_PARALLEL:-1}"
 SUITE="all"   # all | backend | sandbox | jest | e2e | unit
 
 while [[ $# -gt 0 ]]; do
@@ -51,8 +61,9 @@ while [[ $# -gt 0 ]]; do
     --e2e-only)      SUITE="e2e";          shift ;;
     --unit-only)     SUITE="unit";         shift ;;
     --allure-dir)    ALLURE_DIR="$2";      shift 2 ;;
+    --parallel)      PARALLEL="$2";        shift 2 ;;
     --help|-h)
-      sed -n '2,26p' "$0"
+      sed -n '2,35p' "$0"
       exit 0 ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
@@ -60,6 +71,24 @@ done
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CURIO_PID=""
+SHARD_PIDS=()   # launchers of the extra backend+sandbox pairs (--parallel > 1)
+
+# Base ports for the stack this script boots and for shard 0.
+export BACKEND_PORT="${BACKEND_PORT:-5002}"
+export SANDBOX_PORT="${SANDBOX_PORT:-2000}"
+export FRONTEND_PORT="${FRONTEND_PORT:-8080}"
+export CURIO_E2E_HOST="${CURIO_E2E_HOST:-localhost}"
+export CURIO_E2E_BACKEND_PORT="${CURIO_E2E_BACKEND_PORT:-$BACKEND_PORT}"
+export CURIO_E2E_SANDBOX_PORT="${CURIO_E2E_SANDBOX_PORT:-$SANDBOX_PORT}"
+export CURIO_E2E_FRONTEND_PORT="${CURIO_E2E_FRONTEND_PORT:-$FRONTEND_PORT}"
+
+if [[ "$PARALLEL" == "auto" ]]; then
+  cores=$(python -c 'import os; print(os.cpu_count() or 4)')
+  PARALLEL=$(( cores / 4 )); (( PARALLEL < 1 )) && PARALLEL=1; (( PARALLEL > 4 )) && PARALLEL=4
+fi
+if ! [[ "$PARALLEL" =~ ^[0-9]+$ ]] || (( PARALLEL < 1 )); then
+  echo "ERROR: --parallel expects a positive integer or 'auto', got '$PARALLEL'" >&2; exit 1
+fi
 
 # This script NEVER lets pytest own the server lifecycle. It either attaches to
 # a stack someone else booted (--use-existing) or boots one itself below and
@@ -119,6 +148,7 @@ wait_for_port() {
     # Fail fast if the Curio process already exited
     if [[ -n "${CURIO_PID:-}" ]] && ! kill -0 "$CURIO_PID" 2>/dev/null; then
       echo "ERROR: Curio process (pid $CURIO_PID) exited unexpectedly while waiting for $name" >&2
+      RESULTS+=("  FAIL  stack boot ($name never came up; launcher exited)"); OVERALL=1
       exit 1
     fi
     if python -c "import socket; s=socket.socket(); s.settimeout(1); s.connect(('localhost', $port)); s.close()" 2>/dev/null; then
@@ -128,10 +158,90 @@ wait_for_port() {
     sleep 1
   done
   echo "ERROR: $name (port $port) did not start within 240 s" >&2
+  RESULTS+=("  FAIL  stack boot ($name on port $port timed out)"); OVERALL=1
   exit 1
 }
 
+# --parallel N: shards 1..N-1 are extra backend+sandbox pairs behind the ONE
+# frontend the base stack serves. Ports, state dir, DuckDB, dataset-catalog copy
+# and logs all come from backend/tests/shards.py -- the same module every xdist
+# worker uses to find ITS pair, so driver and worker cannot disagree. Shard 0 is
+# the base stack itself.
+shard_facts() {   # -> "<backend port> <sandbox port> <state dir>" for shard $1
+  PYTHONPATH="$REPO_ROOT" python -m utk_curio.backend.tests.shards "$1" --json \
+    | python -c 'import json,sys; d=json.load(sys.stdin); print(d["CURIO_E2E_BACKEND_PORT"], d["CURIO_E2E_SANDBOX_PORT"], d["CURIO_STATE_DIR"])'
+}
+start_extra_shards() {
+  local k bport sport state
+  for (( k = 1; k < PARALLEL; k++ )); do
+    read -r bport sport state < <(shard_facts "$k")
+    echo "==> Starting shard $k: backend $bport, sandbox $sport, state $state"
+    rm -rf "$state"
+    (
+      eval "$(PYTHONPATH="$REPO_ROOT" python -m utk_curio.backend.tests.shards "$k")"
+      mkdir -p "$CURIO_CATALOG_ROOT" "$CURIO_SHARED_DATA"
+      # A COPY, not an empty dir: the catalog tests assert the shipped datasets exist.
+      cp -r "$REPO_ROOT/datasets/." "$CURIO_CATALOG_ROOT/"
+      export CURIO_NO_OPEN=1 FLASK_USE_RELOADER=0 CURIO_DEV=1
+      python "$REPO_ROOT/curio.py" start backend --auth --with-examples \
+        --backend-port "$BACKEND_PORT" --sandbox-port "$SANDBOX_PORT" \
+        > "$CURIO_STATE_DIR/launch-backend.out" 2>&1 &
+      echo $! > "$CURIO_STATE_DIR/backend.pid"
+      python "$REPO_ROOT/curio.py" start sandbox \
+        --backend-port "$BACKEND_PORT" --sandbox-port "$SANDBOX_PORT" \
+        > "$CURIO_STATE_DIR/launch-sandbox.out" 2>&1 &
+      echo $! > "$CURIO_STATE_DIR/sandbox.pid"
+    )
+    SHARD_PIDS+=("$(cat "$state/backend.pid")" "$(cat "$state/sandbox.pid")")
+  done
+  for (( k = 1; k < PARALLEL; k++ )); do
+    read -r bport sport state < <(shard_facts "$k")
+    wait_for_port "shard $k backend" "$bport"
+    wait_for_port "shard $k sandbox" "$sport"
+  done
+}
+
+# Stop everything this script started -- and nothing else. Two mechanisms,
+# because on Windows/MSYS the `$!` of a backgrounded launcher is an MSYS pid
+# that taskkill does not know, so a PID-based kill silently leaves the whole
+# server tree running (observed: every port still serving after "cleanup").
+#   1. by PORT, through the launcher's own _kill_port (what `curio.py start`
+#      uses to claim a port), for the base triple and every shard pair;
+#   2. by COMMAND LINE scoped to THIS checkout's path, for the launcher
+#      processes themselves -- never by process name, which would take down a
+#      sibling checkout's stack on the same machine.
+stop_own_stacks() {
+  local ports=("$BACKEND_PORT" "$SANDBOX_PORT" "$FRONTEND_PORT") k bport sport state
+  for (( k = 1; k < PARALLEL; k++ )); do
+    read -r bport sport state < <(shard_facts "$k") && ports+=("$bport" "$sport")
+  done
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+      powershell -NoProfile -Command "
+        Get-CimInstance Win32_Process | Where-Object {
+          \$_.CommandLine -match [regex]::Escape('$(basename "$REPO_ROOT")') -and
+          ((\$_.Name -eq 'python.exe' -and \$_.CommandLine -match 'curio.py start') -or
+           (\$_.Name -eq 'node.exe' -and \$_.CommandLine -match 'webpack'))
+        } | ForEach-Object { Stop-Process -Id \$_.ProcessId -Force -ErrorAction SilentlyContinue }" >/dev/null 2>&1 || true
+      ;;
+    *)
+      pkill -f "$REPO_ROOT/curio.py start" 2>/dev/null || true
+      ;;
+  esac
+  PYTHONPATH="$REPO_ROOT" python - "${ports[@]}" <<'PY' >/dev/null 2>&1 || true
+import sys
+from utk_curio.main import _kill_port
+for port in sys.argv[1:]:
+    _kill_port(int(port))
+PY
+}
+
 cleanup() {
+  if [[ -n "$CURIO_PID" || ${#SHARD_PIDS[@]} -gt 0 ]]; then
+    echo ""
+    echo "==> Stopping the stack(s) this run started..."
+    stop_own_stacks
+  fi
   if [[ -n "$CURIO_PID" ]]; then
     echo ""
     echo "==> Stopping Curio (pid $CURIO_PID) and its server tree..."
@@ -158,7 +268,9 @@ cleanup() {
         kill -KILL "-$CURIO_PID" 2>/dev/null || true
         ;;
     esac
-    wait "$CURIO_PID" 2>/dev/null || true
+    # Bounded: the tree is already down; a launcher taskkill could not see
+    # would otherwise hang this wait forever.
+    for _ in $(seq 20); do kill -0 "$CURIO_PID" 2>/dev/null || break; sleep 0.5; done
   fi
 
   # Print summary
@@ -250,13 +362,16 @@ if [[ $USE_EXISTING -eq 0 ]]; then
   set -m
   CURIO_NO_OPEN=1 FLASK_USE_RELOADER=0 CURIO_DEV=1 CURIO_TESTING=1 \
   CURIO_LAUNCH_CWD="$REPO_ROOT" \
-    python "$REPO_ROOT/curio.py" start --auth --with-examples &
+    python "$REPO_ROOT/curio.py" start --auth --with-examples \
+      --backend-port "$BACKEND_PORT" --sandbox-port "$SANDBOX_PORT" \
+      --frontend-port "$FRONTEND_PORT" &
   CURIO_PID=$!
   set +m
 
-  wait_for_port "backend"  5002
-  wait_for_port "sandbox"  2000
-  wait_for_port "frontend" 8080
+  wait_for_port "backend"  "$BACKEND_PORT"
+  wait_for_port "sandbox"  "$SANDBOX_PORT"
+  wait_for_port "frontend" "$FRONTEND_PORT"
+  (( PARALLEL > 1 )) && start_extra_shards
 else
   trap cleanup EXIT INT TERM
 fi
@@ -312,6 +427,9 @@ if [[ $RUN_E2E -eq 1 ]]; then
 
   PYTEST_ARGS="-v"
   [[ $HEADED -eq 1 ]]    && PYTEST_ARGS="$PYTEST_ARGS --headed"
+  # One xdist worker per backend+sandbox pair; loadgroup keeps each workflow's
+  # four class-scoped tests (and each other file) on one worker.
+  (( PARALLEL > 1 ))     && PYTEST_ARGS="$PYTEST_ARGS -n $PARALLEL --dist loadgroup"
   [[ $VIDEOS -eq 1 ]]    && PYTEST_ARGS="$PYTEST_ARGS --videos"
   [[ $EXAMPLES -eq 1 ]]  && PYTEST_ARGS="$PYTEST_ARGS --with-examples"
   [[ -n "$ALLURE_DIR" ]] && PYTEST_ARGS="$PYTEST_ARGS --alluredir=$ALLURE_DIR"
@@ -327,7 +445,8 @@ if [[ $RUN_E2E -eq 1 ]]; then
   echo "==> Running E2E tests..."
   cd "$REPO_ROOT/utk_curio/backend"
   die "cd to utk_curio/backend" $?
-  env $E2E_ENV python -m pytest tests/test_frontend/ $PYTEST_ARGS
+  # CURIO_E2E_TARGETS narrows the run to specific files (smoke runs); default is the suite.
+  env $E2E_ENV python -m pytest ${CURIO_E2E_TARGETS:-tests/test_frontend/} $PYTEST_ARGS
   record "E2E tests" $?
 fi
 

--- a/utk_curio/backend/app/common/user_storage.py
+++ b/utk_curio/backend/app/common/user_storage.py
@@ -52,7 +52,13 @@ def curio_root() -> Path:
     """
     from utk_curio.backend.config import _is_testing
 
-    root = launch_dir() / ".curio"
+    # CURIO_STATE_DIR relocates the whole ``.curio`` tree without moving the
+    # DATA root (``launch_dir`` also anchors ``/file/`` and relative node paths,
+    # and ``safe_paths.is_within`` resolves symlinks, so those cannot be
+    # redirected). The parallel e2e harness gives each backend+sandbox pair
+    # its own; see backend/tests/shards.py.
+    override = os.environ.get("CURIO_STATE_DIR")
+    root = Path(override) if override else launch_dir() / ".curio"
     return root / "test" if _is_testing() else root
 
 

--- a/utk_curio/backend/config.py
+++ b/utk_curio/backend/config.py
@@ -128,7 +128,9 @@ def _resolve_database_uri() -> str:
         explicit = os.environ.get("DATABASE_URL_TEST")
         if explicit:
             return explicit
-        test_dir = os.path.join(_test_launch_dir(), ".curio", "test")
+        state_dir = (os.environ.get("CURIO_STATE_DIR")
+                     or os.path.join(_test_launch_dir(), ".curio"))
+        test_dir = os.path.join(state_dir, "test")
         os.makedirs(test_dir, exist_ok=True)
         return "sqlite:///" + os.path.join(test_dir, "urban_workflow_test.db")
     return os.environ.get("DATABASE_URL") or "sqlite:///urban_workflow.db"

--- a/utk_curio/backend/tests/conftest.py
+++ b/utk_curio/backend/tests/conftest.py
@@ -38,6 +38,12 @@ _REPO_ROOT = os.path.abspath(
 # CURIO_TEST_WORKSPACE / CURIO_E2E_USE_EXISTING let callers override the
 # workspace; in those cases the caller owns its lifecycle and we don't
 # clean anything up.
+# Under xdist every worker attaches to its own backend+sandbox pair. Derive this
+# worker's ports and state root before anything below (or any backend import)
+# reads the environment. A no-op in a serial run. See shards.py.
+from .shards import apply_shard_env  # noqa: E402
+apply_shard_env()
+
 _PERSISTENT_WS = os.environ.get("CURIO_TEST_WORKSPACE")
 _USE_EXISTING = os.environ.get("CURIO_E2E_USE_EXISTING")
 if _PERSISTENT_WS:
@@ -57,9 +63,13 @@ else:
     # ``.curio/users/``, and the live ``messages.log``. A blanket rmtree of
     # ``.curio/`` would yank the dev DuckDB out from under any concurrently
     # running dev sandbox and break its cached connection.
-    _TEST_OWNED_DIR = os.path.join(_REPO_ROOT, ".curio", "test")
+    _TEST_OWNED_DIR = os.path.join(
+        os.environ.get("CURIO_STATE_DIR") or os.path.join(_REPO_ROOT, ".curio"), "test")
 
-_TEST_DB_DIR = os.path.join(_TEST_WORKSPACE, ".curio", "test")
+# CURIO_STATE_DIR relocates ``.curio`` without moving the data root; it must
+# agree with config._resolve_database_uri and user_storage.curio_root.
+_STATE_DIR = os.environ.get("CURIO_STATE_DIR") or os.path.join(_TEST_WORKSPACE, ".curio")
+_TEST_DB_DIR = os.path.join(_STATE_DIR, "test")
 os.makedirs(_TEST_DB_DIR, exist_ok=True)
 
 _TEST_SQLA_DB = os.path.join(_TEST_DB_DIR, "urban_workflow_test.db")
@@ -79,9 +89,7 @@ os.environ["CURIO_LAUNCH_CWD"] = _TEST_WORKSPACE
 # Tests get their own DuckDB under .curio/test/data/, parallel to the
 # SQLite test DB in .curio/test/. The dev sandbox keeps using
 # .curio/data/, so a pytest run never clobbers dev artifacts.
-os.environ.setdefault("CURIO_SHARED_DATA", os.path.join(
-    _TEST_WORKSPACE, ".curio", "test", "data",
-))
+os.environ.setdefault("CURIO_SHARED_DATA", os.path.join(_TEST_DB_DIR, "data"))
 os.makedirs(os.environ["CURIO_SHARED_DATA"], exist_ok=True)
 
 # Point the backend (and any subprocess that inherits this env — e.g. the

--- a/utk_curio/backend/tests/conftest.py
+++ b/utk_curio/backend/tests/conftest.py
@@ -123,7 +123,12 @@ def _bootstrap_schemas() -> None:
         _db.engine.dispose()
 
 
-_bootstrap_schemas()
+# Under CURIO_E2E_USE_EXISTING the running backend owns the sqlite file and
+# ``prepare_backend_database`` has already migrated it, so this is redundant
+# even serially -- and under xdist it would run once in the controller and
+# once more in every worker, all against the same file.
+if not os.environ.get("CURIO_E2E_USE_EXISTING"):
+    _bootstrap_schemas()
 
 
 # ---------------------------------------------------------------------------

--- a/utk_curio/backend/tests/shards.py
+++ b/utk_curio/backend/tests/shards.py
@@ -164,6 +164,24 @@ def _base_of(environ) -> dict[str, str]:
     return base
 
 
+def sibling_backend_urls(environ=os.environ) -> list[tuple[int, str]]:
+    """``[(j, "http://host:port"), ...]`` for every OTHER shard of this run.
+
+    For the isolation canary: something minted on this shard must not be
+    visible on any of these. Works from a worker whose environment
+    ``apply_shard_env`` already shifted, by deriving siblings from the base.
+    """
+    base = _base_of(environ)
+    me = shard_index(environ)
+    out = []
+    for j in range(shard_count(environ)):
+        if j == me:
+            continue
+        env = shard_env(j, base)
+        out.append((j, f"http://{env['CURIO_E2E_HOST']}:{env['CURIO_E2E_BACKEND_PORT']}"))
+    return out
+
+
 def main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
     as_json = "--json" in args

--- a/utk_curio/backend/tests/shards.py
+++ b/utk_curio/backend/tests/shards.py
@@ -1,0 +1,184 @@
+"""One e2e worker, one backend+sandbox pair: the environment shard ``k`` runs in.
+
+Single source of truth for how a shard maps onto ports and directories. It is
+imported by ``tests/conftest.py`` before anything else reads the environment,
+and driven from the shell (``scripts/test.sh``, CI) through::
+
+    python -m utk_curio.backend.tests.shards 2          # export lines for shard 2
+    python -m utk_curio.backend.tests.shards 2 --json
+
+Why a shard is a whole backend+sandbox pair and not merely a pytest worker: the
+suite truncates ``user`` / ``project`` / ``user_session`` between tests through
+``POST /api/testing/reset-db``, so two workers on one backend delete each
+other's logged-in users mid-test (measured: every stubbed session 401s within
+seconds). Everything a pair writes therefore moves with it -- the sqlite test
+DB, the DuckDB artifact store (single writer across processes), the per-user
+stores under ``.curio/users/<id>/``, the dataset catalog it publishes to, and
+the launcher log. ``CURIO_STATE_DIR`` relocates all of that at once; see
+``backend/app/common/user_storage.py::curio_root``.
+
+What deliberately does NOT move:
+
+* ``CURIO_LAUNCH_CWD`` -- it is also the DATA root. ``GET /file/<path>`` serves
+  ``docs/examples/data/*.pbf`` relative to it, and ``safe_paths.is_within``
+  resolves symlinks before checking containment, so a per-shard copy or link
+  farm 403s every autark PBF fetch (issue #248 again). It stays the repo root.
+* the frontend -- one webpack build, one dev server. The bundle picks its
+  backend at runtime from ``window.__CURIO_BACKEND_URL__``, which the
+  ``browser`` fixture injects per context (``src/utils/backendUrl.ts``).
+* ``<repo>/packages/`` -- the package catalog root is not overridable, but no
+  e2e test writes it; the driver asserts that with ``git status`` afterwards.
+
+Ports are the workspace's base pair plus ``k`` (times
+``CURIO_E2E_SHARD_PORT_STRIDE``), so a checkout that pins its own triple in
+``.curio-ports.sh`` gets shards that stay clear of its siblings the same way.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_WORKER_RE = re.compile(r"^gw(\d+)$")
+_APPLIED = "CURIO_E2E_SHARD_APPLIED"
+
+
+def shard_index(environ=os.environ) -> int:
+    """This process's shard: xdist's ``gwN`` first, then ``CURIO_E2E_SHARD``, else 0."""
+    m = _WORKER_RE.match(environ.get("PYTEST_XDIST_WORKER", ""))
+    if m:
+        return int(m.group(1))
+    return int(environ.get("CURIO_E2E_SHARD") or 0)
+
+
+def shard_count(environ=os.environ) -> int:
+    return int(environ.get("PYTEST_XDIST_WORKER_COUNT") or environ.get("CURIO_E2E_SHARDS") or 1)
+
+
+def is_sharded(environ=os.environ) -> bool:
+    return (
+        "PYTEST_XDIST_WORKER" in environ
+        or "CURIO_E2E_SHARD" in environ
+        or shard_count(environ) > 1
+    )
+
+
+def shard_state_dir(k: int, environ=os.environ) -> Path:
+    root = environ.get("CURIO_E2E_SHARD_STATE_ROOT") or (REPO_ROOT / ".curio" / "shards")
+    # Keep ``.curio`` in the path: backend/server.py's reloader exclude and
+    # .gitignore both match on it.
+    return Path(root) / str(k)
+
+
+def shard_env(k: int, environ=os.environ) -> dict[str, str]:
+    """The environment for shard *k*, derived from the BASE values in *environ*.
+
+    Call it on the driver's environment (or a worker's inherited copy of it),
+    never on one this function already produced -- the ports would compound.
+    ``apply_shard_env`` guards against that.
+    """
+    base_backend = int(environ.get("CURIO_E2E_BACKEND_PORT") or environ.get("BACKEND_PORT") or 5002)
+    base_sandbox = int(environ.get("CURIO_E2E_SANDBOX_PORT") or environ.get("SANDBOX_PORT") or 2000)
+    stride = int(environ.get("CURIO_E2E_SHARD_PORT_STRIDE") or 1)
+    host = environ.get("CURIO_E2E_HOST") or "localhost"
+    backend = base_backend + k * stride
+    sandbox = base_sandbox + k * stride
+    common = {
+        "CURIO_E2E_USE_EXISTING": "1",
+        "CURIO_TESTING": "1",
+        "CURIO_LAUNCH_CWD": str(REPO_ROOT),
+        "CURIO_E2E_HOST": host,
+        "CURIO_E2E_BACKEND_PORT": str(backend),
+        "BACKEND_PORT": str(backend),
+        "CURIO_E2E_SANDBOX_PORT": str(sandbox),
+        "SANDBOX_PORT": str(sandbox),
+        # Second precedence tier of utils.sandbox_base_url(); the backend also
+        # reads these to dial its own sandbox.
+        "FLASK_SANDBOX_HOST": host,
+        "FLASK_SANDBOX_PORT": str(sandbox),
+        # The backend and ITS sandbox must agree; every shard may share one.
+        "CURIO_SANDBOX_TOKEN": environ.get("CURIO_SANDBOX_TOKEN") or "curio-e2e-shards",
+    }
+    if k == 0:
+        # Shard 0 IS the stack as configured -- the one ``curio.py start`` (or
+        # CI's compose container) already runs on the base ports with the
+        # default ``.curio/``. Relocating its state would point the worker at
+        # directories that backend never writes. Only k >= 1 get their own.
+        return common
+    state = shard_state_dir(k, environ)
+    test_dir = state / "test"
+    db = test_dir / "urban_workflow_test.db"
+    return {
+        **common,
+        "CURIO_STATE_DIR": str(state),
+        "CURIO_SHARED_DATA": str(test_dir / "data"),
+        "DATABASE_URL_TEST": f"sqlite:///{db}",
+        "DATABASE_URL": f"sqlite:///{db}",
+        "CURIO_CATALOG_ROOT": str(state / "datasets"),
+        # N launchers from one checkout must not pip/npm install concurrently;
+        # the driver warms the environment once beforehand.
+        "CURIO_SKIP_DEP_INSTALL": "1",
+        # N Flask processes must not rotate one utk_curio/logs/*.log file.
+        "LOG_TO_STDOUT": "1",
+    }
+
+
+def apply_shard_env(environ=os.environ) -> dict[str, str] | None:
+    """Put this process on its shard. No-op (returns None) in a serial run.
+
+    Idempotent: a second call in the same process returns the same mapping
+    without re-deriving ports from already-shifted values.
+    """
+    if not is_sharded(environ):
+        return None
+    k = shard_index(environ)
+    if environ.get(_APPLIED) == str(k):
+        return shard_env(k, _base_of(environ))
+    env = shard_env(k, environ)
+    for key in ("BACKEND_PORT", "SANDBOX_PORT"):
+        environ.setdefault(
+            f"CURIO_E2E_BASE_{key}",
+            environ.get(f"CURIO_E2E_{key}") or environ.get(key) or "",
+        )
+    environ.update(env)
+    environ[_APPLIED] = str(k)
+    for key in ("CURIO_SHARED_DATA", "CURIO_CATALOG_ROOT"):
+        if key in env:
+            Path(env[key]).mkdir(parents=True, exist_ok=True)
+    return env
+
+
+def _base_of(environ) -> dict[str, str]:
+    """Reconstruct the base ports a previous apply_shard_env shifted away from."""
+    base = dict(environ)
+    for key in ("BACKEND_PORT", "SANDBOX_PORT"):
+        saved = environ.get(f"CURIO_E2E_BASE_{key}")
+        if saved:
+            base[f"CURIO_E2E_{key}"] = saved
+            base[key] = saved
+    return base
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    as_json = "--json" in args
+    args = [a for a in args if a != "--json"]
+    if len(args) != 1 or not args[0].isdigit():
+        print("usage: python -m utk_curio.backend.tests.shards <k> [--json]", file=sys.stderr)
+        return 2
+    env = shard_env(int(args[0]))
+    if as_json:
+        print(json.dumps(env, indent=2))
+    else:
+        for key, value in env.items():
+            print(f"export {key}={json.dumps(value)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utk_curio/backend/tests/test_frontend/README.md
+++ b/utk_curio/backend/tests/test_frontend/README.md
@@ -19,6 +19,32 @@ pytest utk_curio/backend/tests/test_frontend/ --headed
 CURIO_E2E_USE_EXISTING=1 pytest utk_curio/backend/tests/test_frontend/
 ```
 
+### Parallel
+
+```bash
+python curio.py test e2e --parallel 4          # boots the stack + 3 extra pairs, runs 4 xdist workers
+bash scripts/test.sh --e2e-only --parallel auto # auto = min(4, cores/4)
+```
+
+Every worker gets its **own backend+sandbox pair** behind the one frontend. That
+is the unit of isolation, not the test: the suite truncates `user` / `project` /
+`user_session` between tests through `/api/testing/reset-db`, so two workers on
+one backend would delete each other's logged-in users mid-test. Shard 0 is the
+stack as configured; shards 1..N-1 get their ports, sqlite DB, DuckDB store,
+dataset-catalog copy and logs from `backend/tests/shards.py`, relocated under
+`.curio/shards/<k>/` through `CURIO_STATE_DIR`. The bundle picks its backend at
+runtime (`window.__CURIO_BACKEND_URL__`, injected per browser context by the
+`browser` fixture), so one webpack build serves all of them.
+
+Tests are scheduled with `--dist loadgroup`: one group per workflow in
+`test_workflows.py` (its four class-scoped methods share a browser and a login),
+one group per file everywhere else. A missing screenshot baseline **fails**
+under xdist instead of being minted -- see *Screenshot baselines*.
+
+With `--use-existing`, pairs 1..N-1 must already be running on the ports
+`python -m utk_curio.backend.tests.shards K` prints (that is what CI does,
+inside its one container).
+
 ### AUTK / WebGPU note
 
 Autark workflows use the single `AUTK_GRAMMAR` node type, which renders its map/plot via WebGPU. The `browser_type_launch_args` fixture in the **parent** [`../conftest.py`](../conftest.py) points `executable_path` at the system-installed Google Chrome and passes a minimal flag set (`--enable-unsafe-webgpu --enable-unsafe-swiftshader`). This is deliberate: Playwright's bundled Chromium on Windows ships without a working Dawn/WebGPU runtime (`requestAdapter()` returns null), whereas real Chrome 113+ returns an adapter. When Chrome can't be found it falls back to bundled Chromium.

--- a/utk_curio/backend/tests/test_frontend/conftest.py
+++ b/utk_curio/backend/tests/test_frontend/conftest.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pytest
@@ -20,13 +21,45 @@ from .fixtures import _clean_db
 # Re-launching Chromium between workflow classes drops it back to baseline
 # at the cost of ~5 s × workflow_count of startup overhead.
 
+class _BackendUrlBrowser:
+    """A ``Browser`` whose every new context knows this worker's backend.
+
+    The bundle resolves the backend address at runtime from
+    ``window.__CURIO_BACKEND_URL__`` (src/utils/backendUrl.ts), falling back to
+    the value baked at build time. Injecting it per context is what lets ONE
+    frontend build serve several backend+sandbox pairs at once under xdist.
+
+    Wrapped at the browser, not the ``context`` fixture: sixteen tests call
+    ``browser.new_context(...)`` themselves (two-user flows, share links, the
+    video tours), and pytest-playwright's own ``context`` fixture goes through
+    the same method. A context that missed the script would talk to whatever
+    backend the bundle was built for -- under xdist, some OTHER worker's -- and
+    pass against a stack the test does not own. ``__getattr__`` forwards
+    everything else; Playwright's ``Browser`` has no public constructor to
+    subclass.
+    """
+
+    def __init__(self, inner: "Browser", backend_url: str):
+        self._inner = inner
+        self._init_script = f"window.__CURIO_BACKEND_URL__ = {json.dumps(backend_url)};"
+
+    def new_context(self, **kwargs):
+        context = self._inner.new_context(**kwargs)
+        context.add_init_script(self._init_script)
+        return context
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
 @pytest.fixture(scope="class")
 def browser(
     browser_type: "BrowserType",
     browser_type_launch_args: dict,
+    current_server: str,
 ) -> "Browser":
     launched = browser_type.launch(**browser_type_launch_args)
-    yield launched
+    yield _BackendUrlBrowser(launched, current_server)
     launched.close()
 
 # ------------------------------------------------------------------ #

--- a/utk_curio/backend/tests/test_frontend/conftest.py
+++ b/utk_curio/backend/tests/test_frontend/conftest.py
@@ -161,12 +161,35 @@ def pytest_generate_tests(metafunc):
         params = []
         for f in files:
             basename = os.path.basename(f)
-            marks = []
+            # One xdist group per workflow. The four TestWorkflowCanvas
+            # methods share a class-scoped browser, page and login, so they
+            # must stay on one worker -- but different workflows are
+            # independent, so ``--dist loadgroup`` can spread the ~30 groups
+            # across workers instead of pinning the whole file to one.
+            marks = [pytest.mark.xdist_group(f"wf-{basename}")]
             if basename.startswith("10-") and not external:
-                marks = [pytest.mark.skip(reason=(
+                marks.append(pytest.mark.skip(reason=(
                     "example 10 (street-vision) needs external HuggingFace "
                     "inference + street-view APIs and the curio.streetvision "
                     "package; set CURIO_E2E_EXTERNAL=1 to run it"
-                ))]
+                )))
             params.append(pytest.param(f, marks=marks, id=basename))
         metafunc.parametrize("loaded_workflow", params, indirect=True)
+
+
+def pytest_itemcollected(item):
+    """Default every item without an explicit xdist group to its module.
+
+    Under ``--dist loadgroup`` a group runs on one worker in collection order,
+    so a per-file group preserves every module-scoped fixture and every
+    within-file ordering assumption a test may rely on. Only the workflow
+    matrix above is split finer (see ``pytest_generate_tests``).
+
+    This hook fires during collection, strictly before xdist's own
+    ``pytest_collection_modifyitems`` appends the ``@group`` suffix to node
+    ids -- doing it in that hook instead would race xdist's ``tryfirst``.
+    """
+    if item.get_closest_marker("xdist_group") is None:
+        module = getattr(item, "module", None)
+        if module is not None:
+            item.add_marker(pytest.mark.xdist_group(module.__name__.rsplit(".", 1)[-1]))

--- a/utk_curio/backend/tests/test_frontend/test_backend_url_runtime_e2e.py
+++ b/utk_curio/backend/tests/test_frontend/test_backend_url_runtime_e2e.py
@@ -1,0 +1,40 @@
+"""The bundle resolves the backend at RUNTIME, not at build time.
+
+``src/utils/backendUrl.ts`` prefers ``window.__CURIO_BACKEND_URL__`` over the
+value dotenv-webpack baked in, and the ``browser`` fixture injects that global
+into every context. This is the contract that lets one frontend build serve N
+backend+sandbox pairs under xdist; if it regresses, every worker but the one
+matching the baked port silently tests someone else's backend.
+"""
+
+from .utils import REPO_ROOT  # noqa: F401  (keeps the package import path warm)
+
+
+def test_the_page_sees_this_workers_backend_url(page, frontend_server, current_server):
+    page.goto(frontend_server)
+    # window.curio is created by src/registry/index.ts when the bundle loads.
+    page.wait_for_function(
+        "() => window.curio && typeof window.curio.backendUrl === 'string'",
+        timeout=30_000,
+    )
+    assert page.evaluate("window.__CURIO_BACKEND_URL__") == current_server
+    # The registry exposes a getter, so this reads the runtime value.
+    assert page.evaluate("window.curio.backendUrl") == current_server
+
+
+def test_the_injected_value_wins_over_the_baked_one(browser, frontend_server, current_server):
+    # A context whose init script names a DIFFERENT backend must see that one.
+    # Nothing is fetched from it; this only proves the resolution order.
+    context = browser.new_context()
+    try:
+        decoy = current_server.rstrip("/") + "9"
+        context.add_init_script(f"window.__CURIO_BACKEND_URL__ = {decoy!r};")
+        page = context.new_page()
+        page.goto(frontend_server)
+        page.wait_for_function(
+            "() => window.curio && typeof window.curio.backendUrl === 'string'",
+            timeout=30_000,
+        )
+        assert page.evaluate("window.curio.backendUrl") == decoy
+    finally:
+        context.close()

--- a/utk_curio/backend/tests/test_frontend/test_shard_isolation_e2e.py
+++ b/utk_curio/backend/tests/test_frontend/test_shard_isolation_e2e.py
@@ -1,0 +1,60 @@
+"""Under --parallel, a shard's state is invisible to every other shard.
+
+Positive proof of isolation, stronger than "the suite passed": a session token
+minted on THIS worker's backend must be rejected by every sibling backend. If
+two workers ever shared a sqlite file again (a mis-derived CURIO_STATE_DIR, a
+DATABASE_URL leaking through the environment), the sibling would accept the
+token and this fails -- long before the flaky-401 symptoms that first exposed
+the problem would.
+
+Skips in a serial run: with one shard there is nothing to be isolated from.
+"""
+
+import json
+import urllib.error
+import urllib.request
+
+import pytest
+
+from utk_curio.backend.tests.shards import shard_count, shard_index, sibling_backend_urls
+from .utils import stub_db_user
+
+
+def _get(url: str, token: str | None = None) -> int:
+    req = urllib.request.Request(url)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status
+    except urllib.error.HTTPError as exc:
+        return exc.code
+
+
+def test_a_token_from_this_shard_is_rejected_by_every_sibling(current_server):
+    if shard_count() < 2:
+        pytest.skip("needs --parallel: one shard has no siblings to be isolated from")
+    me = shard_index()
+    siblings = sibling_backend_urls()
+    assert siblings, "sharded run but no siblings derived"
+
+    login = stub_db_user(
+        current_server,
+        username=f"shard_canary_{me}",
+        name=f"Shard {me} canary",
+    )
+    token = login["token"]
+    # Sanity: the token is good HERE. Otherwise a 401 below would prove nothing.
+    assert _get(f"{current_server}/api/projects", token) == 200
+
+    leaks = []
+    for j, url in siblings:
+        # Up, so that the rejection below is a rejection and not a dead port.
+        assert _get(f"{url}/live") == 200, f"sibling shard {j} at {url} is not up"
+        code = _get(f"{url}/api/projects", token)
+        if code != 401:
+            leaks.append((j, url, code))
+    assert not leaks, (
+        f"shard {me}'s session token was accepted by sibling(s) {json.dumps(leaks)}: "
+        "those shards share a database with this one"
+    )

--- a/utk_curio/backend/tests/test_frontend/utils.py
+++ b/utk_curio/backend/tests/test_frontend/utils.py
@@ -1044,6 +1044,12 @@ def save_workflow_test_screenshot(
     correct, and eyeball the PNG before committing it. A baseline captured
     against a broken build enshrines the bug as expected output.
 
+    That minting happens in serial runs only. Under xdist (``PYTEST_XDIST_WORKER``
+    set), or whenever ``CURIO_E2E_REQUIRE_BASELINES=1``, a missing baseline is a
+    failure instead: with several workers a mis-derived environment or a grouping
+    bug can change what renders, and a silently written baseline would turn that
+    into a pass. Set ``CURIO_E2E_REQUIRE_BASELINES=0`` to mint anyway.
+
     Set *fit_reactflow* to ``False`` for pages with no canvas (the projects list,
     the catalog). The default path pins the ReactFlow viewport first, which waits
     on ``.react-flow__node`` and would otherwise spend its whole timeout waiting
@@ -1076,6 +1082,14 @@ def save_workflow_test_screenshot(
         return _capture_full_page(page)
 
     if not os.path.isfile(expected_path):
+        if env_flag("CURIO_E2E_REQUIRE_BASELINES",
+                    default=bool(os.environ.get("PYTEST_XDIST_WORKER"))):
+            raise AssertionError(
+                f"no baseline at {expected_path}. Parallel runs never mint "
+                "baselines: generate it with a serial run (or set "
+                "CURIO_E2E_REQUIRE_BASELINES=0) and eyeball the PNG before "
+                "committing it."
+            )
         _capture().save(expected_path)
 
     expected_img = Image.open(expected_path).convert("RGB")

--- a/utk_curio/backend/tests/test_frontend/utils.py
+++ b/utk_curio/backend/tests/test_frontend/utils.py
@@ -213,9 +213,19 @@ def resolve_widget_placeholders(code: str) -> str:
     return _WIDGET_RE.sub(_replace, code)
 
 
-PLAYWRIGHT_EXPECTED_DIR = os.path.join(
-    REPO_ROOT, ".curio", "playwright", "expected"
-)
+
+
+def state_root() -> str:
+    """``.curio/`` for this stack -- ``CURIO_STATE_DIR`` when set.
+
+    Per-shard under xdist (backend/tests/shards.py), so the Playwright scratch
+    artifacts below never interleave across workers. Mirrors
+    ``user_storage.curio_root`` minus the ``/test`` suffix.
+    """
+    return os.environ.get("CURIO_STATE_DIR") or os.path.join(REPO_ROOT, ".curio")
+
+
+PLAYWRIGHT_EXPECTED_DIR = os.path.join(state_root(), "playwright", "expected")
 
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _FALSE_VALUES = {"0", "false", "no", "off"}
@@ -1146,7 +1156,7 @@ def save_workflow_test_screenshot(
 def debug_log(location: str, message: str, data: dict = None, hypothesis_id: str = ""):
     """Write a single NDJSON debug entry to ``.curio/playwright.log``."""
     try:
-        log_path = os.path.join(REPO_ROOT, ".curio", "playwright.log")
+        log_path = os.path.join(state_root(), "playwright.log")
         entry = {
             "timestamp": int(time.time() * 1000),
             "location": location,

--- a/utk_curio/frontend/urban-workflows/src/JavaScriptInterpreter.ts
+++ b/utk_curio/frontend/urban-workflows/src/JavaScriptInterpreter.ts
@@ -2,6 +2,7 @@ import { NodeType } from "./constants";
 import { NodeTemplateId } from "./registry/types";
 import { formatDate, mapTypes } from "./utils/formatters";
 import { getToken } from "./utils/authApi";
+import { backendUrl } from "./utils/backendUrl";
 
 export class JavaScriptInterpreter {
     public interpretCode(
@@ -29,7 +30,7 @@ export class JavaScriptInterpreter {
         let startTime = formatDate(new Date());
 
         const _token = getToken();
-        const url = process.env.BACKEND_URL + "/processJavaScriptCode";
+        const url = backendUrl() + "/processJavaScriptCode";
         const fetchStartedAt = performance.now();
         const CLIENT_TIMEOUT_MS = 180_000;
         const controller = new AbortController();

--- a/utk_curio/frontend/urban-workflows/src/PythonInterpreter.ts
+++ b/utk_curio/frontend/urban-workflows/src/PythonInterpreter.ts
@@ -3,6 +3,7 @@ import { NodeTemplateId } from "./registry/types";
 import { formatDate, mapTypes } from "./utils/formatters";
 import { getToken } from "./utils/authApi";
 // import { pythonCode } from "./pythonWrapper";
+import { backendUrl } from "./utils/backendUrl";
 
 export class PythonInterpreter {
     // protected _pythonWrapperCode: string[];
@@ -60,7 +61,7 @@ export class PythonInterpreter {
         }
 
         const _token = getToken();
-        const url = process.env.BACKEND_URL + "/processPythonCode";
+        const url = backendUrl() + "/processPythonCode";
         const fetchStartedAt = performance.now();
         // Mirror the JavaScriptInterpreter: cap the wait so a stuck node fails
         // with a clear "execution timed out" message instead of hanging forever.
@@ -138,7 +139,7 @@ export class PythonInterpreter {
                     unresolvedUserCode
                 );
 
-                // fetch(process.env.BACKEND_URL+"/nodeExecProv", {
+                // fetch(backendUrl()+"/nodeExecProv", {
                 //     method: "POST",
                 //     body: JSON.stringify({
                 //         data: {

--- a/utk_curio/frontend/urban-workflows/src/adapters/node/autkGrammarBehavior.tsx
+++ b/utk_curio/frontend/urban-workflows/src/adapters/node/autkGrammarBehavior.tsx
@@ -7,6 +7,7 @@ import { useToastContext } from '../../providers/ToastProvider';
 import { autkGrammarAdapter } from '../../adapters/autkGrammarAdapter';
 import { VisInteractionType, NodeType } from '../../constants';
 import { JavaScriptInterpreter } from '../../JavaScriptInterpreter';
+import { backendUrl } from '../../utils/backendUrl';
 
 export const useAutkGrammarBehavior: NodeBehaviorHook = (data, nodeState) => {
     const { showToast } = useToastContext();
@@ -1863,9 +1864,9 @@ function resolveDataSourceUrls(spec: any, forBackend = false): any {
     // For the browser, the host-published URL the page itself talks to. For the
     // sandbox, the token above - deliberately not a URL. The /file/ route is
     // unauthenticated, so the node fetch needs no token of the auth kind.
-    const backendUrl = forBackend
+    const base = forBackend
         ? SANDBOX_BACKEND_URL_TOKEN
-        : (process.env.BACKEND_URL || 'http://localhost:5002').replace(/\/$/, '');
+        : (backendUrl() || 'http://localhost:5002');
     const urlFields = ['pbfFileUrl', 'csvFileUrl', 'jsonFileUrl', 'geojsonFileUrl'];
     const isAbsolute = (url: string) => /^[a-z][a-z\d+\-.]*:/i.test(url);
 
@@ -1874,7 +1875,7 @@ function resolveDataSourceUrls(spec: any, forBackend = false): any {
         for (const field of urlFields) {
             const val = source[field];
             if (typeof val === 'string' && !isAbsolute(val)) {
-                patch[field] = `${backendUrl}/file/${val.replace(/^\/+/, '')}`;
+                patch[field] = `${base}/file/${val.replace(/^\/+/, '')}`;
             }
         }
         return Object.keys(patch).length > 0 ? { ...source, ...patch } : source;

--- a/utk_curio/frontend/urban-workflows/src/adapters/node/spatialJoinBehavior.tsx
+++ b/utk_curio/frontend/urban-workflows/src/adapters/node/spatialJoinBehavior.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useEdges, Position } from 'reactflow';
 import { NodeBehaviorHook, HandleDef } from '../../registry/types';
+import { backendUrl } from '../../utils/backendUrl';
 
 /**
  * Spatial Join behavior — tag each point with the polygon it falls in.
@@ -24,7 +25,7 @@ import { NodeBehaviorHook, HandleDef } from '../../registry/types';
  */
 
 const NAME_PROPERTY = 'name';
-const API_BASE = `${process.env.BACKEND_URL || ''}/spatial_join`;
+const API_BASE = `${backendUrl()}/spatial_join`;
 
 // Heuristic for the single-handle fallback (when the framework hands us a
 // scalar instead of a slot-indexed array): polygons have Polygon /

--- a/utk_curio/frontend/urban-workflows/src/api/agentsApi.ts
+++ b/utk_curio/frontend/urban-workflows/src/api/agentsApi.ts
@@ -1,6 +1,7 @@
 import { apiFetch, getToken } from "../utils/authApi";
+import { backendUrl } from "../utils/backendUrl";
 
-const BACKEND_URL = process.env.BACKEND_URL || "";
+const BACKEND_URL = backendUrl();
 
 /**
  * REST client for ``/api/agents`` - the three-scope Agent Catalog and its

--- a/utk_curio/frontend/urban-workflows/src/api/packagesApi.ts
+++ b/utk_curio/frontend/urban-workflows/src/api/packagesApi.ts
@@ -1,4 +1,5 @@
 import { apiFetch, getToken } from "../utils/authApi";
+import { backendUrl } from "../utils/backendUrl";
 
 /**
  * REST client for ``/api/packages`` — catalog, factory, and resolver APIs.
@@ -15,7 +16,7 @@ import { apiFetch, getToken } from "../utils/authApi";
  *     reload. Implemented in ``registry/packageRegistryBootstrap.ts`` (also
  *     mounted on ``window.curio`` from ``index.tsx`` for legacy callers).
  */
-const BACKEND_URL = process.env.BACKEND_URL || "";
+const BACKEND_URL = backendUrl();
 
 export interface PortPayload {
   types: string[];

--- a/utk_curio/frontend/urban-workflows/src/components/VersionBadge.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/VersionBadge.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { backendUrl } from "../utils/backendUrl";
 
 /**
  * How node code is being executed, in the words the docs use.
@@ -41,7 +42,7 @@ const VersionBadge: React.FC = () => {
   const [isolation, setIsolation] = useState<string>("");
 
   useEffect(() => {
-    fetch(process.env.BACKEND_URL + "/version", { cache: "no-store" })
+    fetch(backendUrl() + "/version", { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => {
         if (!d) return;

--- a/utk_curio/frontend/urban-workflows/src/pages/projects/ProjectsList.tsx
+++ b/utk_curio/frontend/urban-workflows/src/pages/projects/ProjectsList.tsx
@@ -26,6 +26,7 @@ import styles from "./ProjectsBrowseLayout.module.css";
 import ConfirmDialog from "../../components/ConfirmDialog";
 import PromptDialog from "../../components/PromptDialog";
 import { UNREADABLE_FILE_MESSAGE } from "../../utils/dataflowImport";
+import { backendUrl } from "../../utils/backendUrl";
 
 type ViewMode = "grid" | "list";
 type FilterTab = "all" | "recent";
@@ -237,7 +238,7 @@ const ProjectsList: React.FC = () => {
         return;
       }
       try {
-        const trillSpec = await notebookToTrill(json, process.env.BACKEND_URL as string);
+        const trillSpec = await notebookToTrill(json, backendUrl());
         const name = file.name.replace(/\.ipynb$/i, "");
         await projectsApi.create({ name, spec: trillSpec as unknown as Record<string, unknown>, outputs: [] });
         loadProjects();

--- a/utk_curio/frontend/urban-workflows/src/providers/BackendHealthBanner.tsx
+++ b/utk_curio/frontend/urban-workflows/src/providers/BackendHealthBanner.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
+import { backendUrl } from "../utils/backendUrl";
 
-const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:5002";
+const BACKEND_URL = backendUrl() || "http://localhost:5002";
 
 /**
  * Pings the backend /live endpoint. If the backend is unreachable (e.g. not started),

--- a/utk_curio/frontend/urban-workflows/src/providers/CollaborationProvider.tsx
+++ b/utk_curio/frontend/urban-workflows/src/providers/CollaborationProvider.tsx
@@ -32,8 +32,9 @@ import {
     getCurrentProjectId,
     subscribe as subscribeProject,
 } from "../registry/projectPackagesStore";
+import { backendUrl } from "../utils/backendUrl";
 
-const BACKEND_URL = process.env.BACKEND_URL || "";
+const BACKEND_URL = backendUrl();
 const NAMESPACE = "/collab";
 
 export interface CollabUser {

--- a/utk_curio/frontend/urban-workflows/src/providers/starters.ts
+++ b/utk_curio/frontend/urban-workflows/src/providers/starters.ts
@@ -1,4 +1,5 @@
 import { getToken } from "../utils/authApi";
+import { backendUrl } from "../utils/backendUrl";
 
 export default async function useStarters() {
     try {
@@ -8,7 +9,7 @@ export default async function useStarters() {
         // token we'd only ever see the built-in presets, and a freshly-dropped
         // package node would have nothing in its starters dropdown.
         const token = getToken();
-        const response = await fetch(process.env.BACKEND_URL + '/starters', {
+        const response = await fetch(backendUrl() + '/starters', {
             headers: token ? { Authorization: `Bearer ${token}` } : undefined,
         });
         if (!response.ok) {

--- a/utk_curio/frontend/urban-workflows/src/registry/index.ts
+++ b/utk_curio/frontend/urban-workflows/src/registry/index.ts
@@ -29,13 +29,17 @@ if (typeof window !== 'undefined') {
   w.ReactFlow = ReactFlowNS;
   // ``backendUrl`` is the runtime resolution of the host's ``BACKEND_URL``
   // env var. Packages should read this instead of inlining
-  // ``process.env.BACKEND_URL`` at their own build time — that path bakes
+  // the env var at their own build time — that path bakes
   // the URL into the published catalog bundle and breaks for any
   // deployment that doesn't match the build host.
   w.curio = {
     ...(w.curio ?? {}),
     registerBehavior,
-    backendUrl: process.env.BACKEND_URL ?? '',
+    // A getter, like getAuthToken below: resolved on every read, so a
+    // package bundle sees the runtime value, never a string captured at load.
+    get backendUrl() {
+      return backendUrl();
+    },
     // A getter, not a value: a package bundle evaluates once at load, long
     // before sign-in, so a captured string would be stale forever. Packages
     // whose backend needs to know WHO is calling (the Street Vision node, for
@@ -96,3 +100,4 @@ export type {
 export type {
   GrammarAdapter,
 } from './grammarAdapter';
+import { backendUrl } from '../utils/backendUrl';

--- a/utk_curio/frontend/urban-workflows/src/registry/packagesClient.ts
+++ b/utk_curio/frontend/urban-workflows/src/registry/packagesClient.ts
@@ -50,6 +50,7 @@ import type {
   NodeDescriptor,
   PortDef,
 } from './types';
+import { backendUrl } from '../utils/backendUrl';
 
 interface RawPackageTemplate {
   id: string; // canonical "<packageId>/<templateId>@<major>"
@@ -336,7 +337,7 @@ export function registerPackageTemplates(packages: RawPackage[]): NodeDescriptor
 const inFlightBehaviorScripts = new Map<string, Promise<void>>();
 
 async function loadPackageBehaviorScripts(packages: RawPackage[]): Promise<void> {
-  const base = process.env.BACKEND_URL ?? '';
+  const base = backendUrl();
   const targets = packages.filter((p) => p.behaviorScript && p.dirName);
   if (targets.length === 0) return;
   const token = getToken();

--- a/utk_curio/frontend/urban-workflows/src/services/api.ts
+++ b/utk_curio/frontend/urban-workflows/src/services/api.ts
@@ -1,8 +1,9 @@
 import { getToken } from "../utils/authApi";
+import { backendUrl } from "../utils/backendUrl";
 
 export async function fetchData(fileName: string) {
     try {
-        const url = `${process.env.BACKEND_URL}/get?fileName=${encodeURIComponent(fileName)}`;
+        const url = `${backendUrl()}/get?fileName=${encodeURIComponent(fileName)}`;
         console.log(`Fetching ${url}`);
         const _token = getToken();
         const response = await fetch(url, {
@@ -37,8 +38,8 @@ export async function fetchData(fileName: string) {
 export async function fetchPreviewData(fileName: string) {
     try {
         // Use the correct backend URL
-        const backendUrl = process.env.BACKEND_URL || 'http://localhost:5002';
-        const url = `${backendUrl}/get-preview?fileName=${encodeURIComponent(fileName)}`;
+        const base = backendUrl() || 'http://localhost:5002';
+        const url = `${base}/get-preview?fileName=${encodeURIComponent(fileName)}`;
         console.log(`[fetchPreviewData] Fetching preview from ${url}`);
         const _token = getToken();
         const response = await fetch(url, {

--- a/utk_curio/frontend/urban-workflows/src/services/datasetCatalog/datasetCatalogApi.ts
+++ b/utk_curio/frontend/urban-workflows/src/services/datasetCatalog/datasetCatalogApi.ts
@@ -9,8 +9,9 @@ import {
   DatasetPreviewQuery,
   DatasetPreviewResponse,
 } from "./datasetCatalogTypes";
+import { backendUrl } from "../../utils/backendUrl";
 
-const BACKEND_URL = process.env.BACKEND_URL || "";
+const BACKEND_URL = backendUrl();
 
 /** Canonical file extension per dataset format (mirror of the backend map). */
 const DATASET_FORMAT_EXTENSIONS: Record<string, string> = {

--- a/utk_curio/frontend/urban-workflows/src/tests/backendUrl.test.ts
+++ b/utk_curio/frontend/urban-workflows/src/tests/backendUrl.test.ts
@@ -1,0 +1,41 @@
+import { backendUrl } from '../utils/backendUrl';
+
+const w = window as any;
+
+describe('backendUrl()', () => {
+    const originalEnv = process.env.BACKEND_URL;
+
+    afterEach(() => {
+        delete w.__CURIO_BACKEND_URL__;
+        if (originalEnv === undefined) delete process.env.BACKEND_URL;
+        else process.env.BACKEND_URL = originalEnv;
+    });
+
+    test('prefers the runtime value injected on window', () => {
+        process.env.BACKEND_URL = 'http://baked:5002';
+        w.__CURIO_BACKEND_URL__ = 'http://injected:5203';
+        expect(backendUrl()).toBe('http://injected:5203');
+    });
+
+    test('falls back to the build-time env var when nothing is injected', () => {
+        process.env.BACKEND_URL = 'http://baked:5002';
+        expect(backendUrl()).toBe('http://baked:5002');
+    });
+
+    test('an empty injection does not shadow the env var', () => {
+        process.env.BACKEND_URL = 'http://baked:5002';
+        w.__CURIO_BACKEND_URL__ = '';
+        expect(backendUrl()).toBe('http://baked:5002');
+    });
+
+    test('is same-origin (empty) when neither is set, so callers keep their own default', () => {
+        delete process.env.BACKEND_URL;
+        expect(backendUrl()).toBe('');
+        expect(backendUrl() || 'http://localhost:5002').toBe('http://localhost:5002');
+    });
+
+    test('strips a trailing slash so `${backendUrl()}/path` never doubles it', () => {
+        w.__CURIO_BACKEND_URL__ = 'http://injected:5203/';
+        expect(backendUrl()).toBe('http://injected:5203');
+    });
+});

--- a/utk_curio/frontend/urban-workflows/src/tests/backendUrlSingleSource.test.ts
+++ b/utk_curio/frontend/urban-workflows/src/tests/backendUrlSingleSource.test.ts
@@ -1,0 +1,43 @@
+/**
+ * `process.env.BACKEND_URL` may be read in exactly one place.
+ *
+ * dotenv-webpack inlines it at build time, so every direct read bakes one
+ * backend address into the bundle and silently breaks any stack on another
+ * port. Read it through utils/backendUrl.ts, which resolves at runtime. This
+ * test exists because the direct reads had regrown to nineteen sites.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC = path.resolve(__dirname, '..');
+
+// The helper itself, and tests that legitimately SET the variable.
+const ALLOWED = new Set([
+    'utils/backendUrl.ts',
+    'tests/backendUrl.test.ts',
+    'tests/backendUrlSingleSource.test.ts',
+    'tests/PythonInterpreter.test.ts',
+    'tests/JavaScriptInterpreter.test.ts',
+]);
+
+function walk(dir: string, out: string[] = []): string[] {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full, out);
+        else if (/\.(ts|tsx|js|jsx)$/.test(entry.name)) out.push(full);
+    }
+    return out;
+}
+
+test('process.env.BACKEND_URL is read only in utils/backendUrl.ts', () => {
+    const offenders: string[] = [];
+    for (const file of walk(SRC)) {
+        const rel = path.relative(SRC, file).split(path.sep).join('/');
+        if (ALLOWED.has(rel)) continue;
+        const lines = fs.readFileSync(file, 'utf8').split('\n');
+        lines.forEach((line, i) => {
+            if (line.includes('process.env.BACKEND_URL')) offenders.push(rel + ':' + (i + 1) + ': ' + line.trim());
+        });
+    }
+    expect(offenders).toEqual([]);
+});

--- a/utk_curio/frontend/urban-workflows/src/utils/authApi.ts
+++ b/utk_curio/frontend/urban-workflows/src/utils/authApi.ts
@@ -1,6 +1,7 @@
 import Cookies from "js-cookie";
+import { backendUrl } from "./backendUrl";
 
-const BACKEND_URL = process.env.BACKEND_URL || "";
+const BACKEND_URL = backendUrl();
 const TOKEN_KEY = "session_token";
 
 export function getToken(): string | undefined {

--- a/utk_curio/frontend/urban-workflows/src/utils/backendUrl.ts
+++ b/utk_curio/frontend/urban-workflows/src/utils/backendUrl.ts
@@ -1,0 +1,35 @@
+/**
+ * The backend's base URL, resolved at RUNTIME in the browser.
+ *
+ * Every other module must read the backend address through this function and
+ * never through `process.env.BACKEND_URL` directly. dotenv-webpack inlines that
+ * variable into bundle.js at BUILD time, so a bundle only ever knows the one
+ * backend it was compiled against -- which is why changing `--backend-port`
+ * used to force a frontend rebuild, and why a bundle built for the wrong port
+ * fails silently (the canvas loads, no node ever renders).
+ *
+ * This is the same reasoning as `SANDBOX_BACKEND_URL_TOKEN` in
+ * adapters/node/autkGrammarBehavior.tsx (#248): resolve the address in the
+ * process that performs the fetch. Resolution order:
+ *
+ *   1. `window.__CURIO_BACKEND_URL__` -- set by whoever serves or drives the
+ *      page. The e2e harness injects it per browser context so one frontend
+ *      build can talk to any of several backends at once.
+ *   2. `process.env.BACKEND_URL` -- the build-time value, kept as the fallback
+ *      so an ordinary `curio.py start` and every existing deployment behave
+ *      exactly as before.
+ *   3. `''` -- same-origin. Callers that want `http://localhost:5002` instead
+ *      write `backendUrl() || 'http://localhost:5002'`, so each call site keeps
+ *      the fallback it had before this helper existed.
+ *
+ * A trailing slash is stripped so `${backendUrl()}/path` never doubles it.
+ */
+export function backendUrl(): string {
+  const w = typeof window !== 'undefined' ? (window as any) : undefined;
+  const injected = w?.__CURIO_BACKEND_URL__;
+  const raw =
+    typeof injected === 'string' && injected !== ''
+      ? injected
+      : (process.env.BACKEND_URL ?? '');
+  return raw.replace(/\/+$/, '');
+}

--- a/utk_curio/main.py
+++ b/utk_curio/main.py
@@ -102,10 +102,13 @@ def set_environment_variables(backend_host, backend_port, sandbox_host, sandbox_
     os.environ["FLASK_BACKEND_PORT"] = str(backend_port)
     os.environ["FLASK_SANDBOX_HOST"] = sandbox_host
     os.environ["FLASK_SANDBOX_PORT"] = str(sandbox_port)
-    # The frontend bundle needs the backend's address baked in at BUILD time
+    # The frontend bundle's DEFAULT backend address is baked in at BUILD time
     # (webpack substitutes ``process.env.BACKEND_URL`` through dotenv-webpack).
     # Derive it from the same --backend-host/--backend-port the backend itself
-    # is started with, so the two cannot disagree.
+    # is started with, so the two cannot disagree. It is only the default:
+    # ``src/utils/backendUrl.ts`` prefers ``window.__CURIO_BACKEND_URL__`` when
+    # the page sets it, which is how one build serves several backends (the
+    # parallel e2e harness injects it per browser context).
     #
     # This used to come only from a hand-maintained
     # ``frontend/urban-workflows/.env``, which meant every port change was two

--- a/utk_curio/main.py
+++ b/utk_curio/main.py
@@ -37,10 +37,15 @@ verbosity = 1
 logger = logging.getLogger(__name__)
 
 
-def setup_logging():
-    log_dir = Path(".curio")
-    log_dir.mkdir(exist_ok=True)
-    log_file = log_dir / "messages.log"
+def setup_logging(server: str = "all"):
+    # CURIO_STATE_DIR relocates every per-stack file (backend/app/common/
+    # user_storage.py); the log follows so two stacks in one checkout do not
+    # truncate each other's -- ``filemode="w"`` below wipes the first
+    # launcher's log the moment a second one starts. A single-server start
+    # gets its own file for the same reason: an e2e shard is two launchers.
+    log_dir = Path(os.environ.get("CURIO_STATE_DIR") or ".curio")
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / ("messages.log" if server == "all" else f"messages-{server}.log")
 
     logging.basicConfig(
         filename=log_file,
@@ -515,7 +520,10 @@ def prepare_backend_database():
 
     testing = _is_testing()
     launch_dir = os.environ.get("CURIO_LAUNCH_CWD") or os.getcwd()
-    db_dir = os.path.join(launch_dir, ".curio", "test") if testing else os.path.join(launch_dir, ".curio")
+    # Must agree with config._resolve_database_uri, or the wipe below hits a
+    # file the backend never opens.
+    state_dir = os.environ.get("CURIO_STATE_DIR") or os.path.join(launch_dir, ".curio")
+    db_dir = os.path.join(state_dir, "test") if testing else state_dir
 
     if not os.path.exists(db_dir):
         os.makedirs(db_dir)
@@ -679,6 +687,18 @@ def start_backend(host, port, no_server=False):
     return process
 
 
+def _skip_dep_install() -> bool:
+    """``CURIO_SKIP_DEP_INSTALL=1``: trust the environment as it is.
+
+    The parallel e2e driver starts several backend+sandbox pairs from one
+    checkout. Without this every launcher would run ``pip install`` into the
+    same interpreter and ``npm install`` into the same ``node_modules`` at the
+    same time. The driver does one warm-up (``curio.py setup`` and a root
+    ``npm install``) before the first pair starts.
+    """
+    return os.environ.get("CURIO_SKIP_DEP_INSTALL", "").strip().lower() in ("1", "true", "yes", "on")
+
+
 def _ensure_root_node_modules(project_root: str) -> None:
     """Install the repo-root node_modules used by the sandbox's Node.js
     subprocess. ``@urban-toolkit/autk-db`` is declared in the root
@@ -728,7 +748,8 @@ def start_sandbox(host, port):
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
     project_root = os.path.abspath(os.path.join(script_dir, ".."))
-    _ensure_root_node_modules(project_root)
+    if not _skip_dep_install():
+        _ensure_root_node_modules(project_root)
     # sandbox_server = os.path.join(script_dir, "sandbox", "server.py")
     env = os.environ.copy()
     env = {**os.environ, "PYTHONPATH": project_root + os.pathsep + env.get("PYTHONPATH", "")}
@@ -1302,7 +1323,7 @@ def main():
 
     args = parser.parse_args()
 
-    setup_logging()
+    setup_logging(args.server)
     verbosity = int(args.verbose)
 
     set_environment_variables(
@@ -1363,7 +1384,7 @@ def main():
         # Framework first (gives us Flask + manifest-parsing deps), then
         # the manifest walk (covers builtin's data-ops libs + every other
         # installed package's declared python deps).
-        if args.server in ("all", "backend", "sandbox"):
+        if args.server in ("all", "backend", "sandbox") and not _skip_dep_install():
             install_framework_requirements()
             install_manifest_dependencies()
 

--- a/utk_curio/main.py
+++ b/utk_curio/main.py
@@ -995,6 +995,7 @@ def _parse_test_args(argv, command_prefix="curio"):
         {command_prefix} test backend               # one suite on its own
         {command_prefix} test e2e --use-existing    # E2E against servers already running
         {command_prefix} test e2e --headed --workflows Vega.json,Regression.json
+        {command_prefix} test e2e --parallel 4     # 4 xdist workers, one backend+sandbox pair each
     """,
     )
     parser.add_argument(
@@ -1020,6 +1021,13 @@ def _parse_test_args(argv, command_prefix="curio"):
         "--allure-dir", default=None, metavar="DIR",
         help="Write the E2E run's Allure results to DIR",
     )
+    parser.add_argument(
+        "--parallel", default=None, metavar="N",
+        help=(
+            "Run the E2E suite on N pytest-xdist workers, each against its own "
+            "backend+sandbox pair behind one shared frontend; 'auto' = min(4, cores/4)"
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -1036,6 +1044,8 @@ def _test_script_flags(args) -> list[str]:
         flags += ["--workflows", args.workflows]
     if args.allure_dir:
         flags += ["--allure-dir", args.allure_dir]
+    if args.parallel:
+        flags += ["--parallel", args.parallel]
     return flags
 
 


### PR DESCRIPTION
Runs the e2e suite on N xdist workers, each against its own backend+sandbox pair behind one shared frontend.

- The bundle resolves BACKEND_URL at runtime (window.__CURIO_BACKEND_URL__, injected per browser context); one webpack build serves every pair. The baked value stays the default.
- CURIO_STATE_DIR relocates .curio/ per pair (sqlite, DuckDB, per-user stores, catalog copy, logs). backend/tests/shards.py is the single source of truth for shard -> ports/dirs.
- xdist_group per workflow in test_workflows.py, per file elsewhere; --dist loadgroup.
- scripts/test.sh --parallel N / curio.py test e2e --parallel N. CI runs 4 workers inside the one container; docker-compose.ci-shards.yml publishes pairs for up to 8.
- A missing screenshot baseline fails under xdist instead of being minted silently.

Measured locally: the serial suite is ~90 min on a Windows box and test_workflows.py is only ~24% of it, which is why every worker gets a whole pair. Smoke (4 workflows + 3 files): 4m22s serial -> 2m36s on 2 workers.