### PR TITLE
backend: SQLite WAL + busy_timeout; e2e harness timeout for parallel load

### DIFF
--- a/utk_curio/backend/extensions.py
+++ b/utk_curio/backend/extensions.py
@@ -1,9 +1,47 @@
+import sqlite3
+
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
 
 
 db = SQLAlchemy()
 migrate = Migrate()
+
+
+@event.listens_for(Engine, "connect")
+def _sqlite_pragmas(dbapi_connection, _record):
+    """Make SQLite behave under concurrent requests.
+
+    Out of the box SQLite runs a rollback journal with a 5 s busy timeout: any
+    writer blocks every reader for the duration of its transaction, and a
+    reader that waits longer than 5 s gets ``OperationalError: database is
+    locked`` -- which the API surfaces as a 500. Under load (the parallel e2e
+    run measured 192 of them on one backend in ~25 minutes; ``GET /api/projects``
+    500ing is what turned whole workflow groups into setup errors) that is
+    routine, not exceptional.
+
+    WAL lets readers proceed while one writer commits; ``busy_timeout`` makes a
+    genuinely contended writer wait instead of failing; ``synchronous=NORMAL``
+    is the usual WAL companion (durable across process crashes, not power
+    loss -- the standard trade-off for a WAL database). This is NOT a test-only
+    setting: it is applied per connection on every engine this process creates,
+    so a deployed backend, a dev ``curio.py start``, the migrations and the test
+    rig all run the same way. A multi-tab or multi-user deployment on SQLite
+    hits exactly the same reader/writer contention.
+    A ``:memory:`` database answers ``journal_mode=WAL`` with ``memory`` and is
+    otherwise unaffected, so the unit suites keep their in-memory engines.
+    """
+    if not isinstance(dbapi_connection, sqlite3.Connection):
+        return
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA synchronous=NORMAL")
+        cursor.execute("PRAGMA busy_timeout=30000")
+    finally:
+        cursor.close()
 
 # Flask-SocketIO singleton, populated by init_socketio(app) when
 # ENABLE_COLLAB=True. Left as None otherwise so the flask-socketio package is

--- a/utk_curio/backend/reloader.py
+++ b/utk_curio/backend/reloader.py
@@ -1,0 +1,55 @@
+"""Dev-server reloader settings shared by the backend and the sandbox.
+
+A leaf module on purpose: ``sandbox/server.py`` used to import these two
+names from ``backend/server.py``, and importing THAT module builds the
+backend Flask app and queries the database -- so every sandbox boot
+constructed a second backend just to read two constants, and when the
+sandbox started before the backend had migrated a fresh DB (the parallel
+e2e driver starts both launchers at once) it logged
+``OperationalError: no such column: user.username`` tracebacks at boot.
+Nothing here imports Flask or touches a database.
+"""
+
+import os
+
+# fnmatch patterns the dev-server stat reloader must NEVER treat as
+# reload triggers (see :func:`werkzeug._reloader._find_stat_paths`).
+#
+# ``.curio/`` is user **runtime** data — package stores, staging dirs,
+# lockfiles, the SQLite DB — and must not restart the backend when
+# sources/starters are written during a package install.
+#
+# **Important:** Werkzeug's default ``reloader_type="auto"`` prefers
+# Watchdog, which applies ``exclude_patterns`` via ``pathlib.Path.match``
+# — that API does **not** reliably exclude deep paths under ``.curio/``
+# (e.g. ``…/.curio/users/…/packages/…/starters/foo.py``), so installs still
+# killed the worker with ``ERR_EMPTY_RESPONSE``. Curio therefore defaults
+# ``FLASK_RELOADER_TYPE`` to ``"stat"``, where excludes use :mod:`fnmatch`
+# on full paths and work for arbitrary depth. Set ``FLASK_RELOADER_TYPE=watchdog``
+# only if you accept that limitation.
+# `*starters*`: dynamically read per-request, not imported; also dodges
+# Windows atime-bump reload storms that drop in-flight /processPythonCode.
+RELOADER_EXCLUDE_PATTERNS = [
+    '*.duckdb', '*.duckdb.wal', '*.duckdb-shm', '*.duckdb-wal',
+    '*/.curio/*', '*/.curio', '*starters*',
+    # The Data Catalog writes computed dataset bundles (``manifest.json`` +
+    # ``data/*.parquet``) into ``<repo_root>/datasets/`` at node-execution
+    # time (catalog auto-install). Like ``.curio/`` above, these are runtime
+    # data writes, not source changes — without this exclude, a node that
+    # produces a dataset trips the stat reloader and SIGTERMs the worker
+    # mid-request, dropping the in-flight /processJavaScriptCode (the autk
+    # data node then falls back to an in-browser load that fails).
+    '*/datasets/*', '*\\datasets\\*',
+    '*/datasets', '*\\datasets',
+    # Synchronous catalog installs run ``pip install`` from inside the
+    # backend (see ``packages/pip_runner.py``); pip writes ~thousands of
+    # files into ``site-packages/`` for a heavy package like ``torch``,
+    # which would otherwise trip the stat reloader mid-install and SIGTERM
+    # the worker, dropping the in-flight install request. The sandbox
+    # shares this exclude list (sandbox/server.py imports it) so its
+    # equivalent ``/install`` endpoint is protected the same way.
+    '*/site-packages/*', '*\\site-packages\\*',
+    '*/site-packages', '*\\site-packages',
+]
+
+DEFAULT_RELOADER_TYPE = os.getenv('FLASK_RELOADER_TYPE', 'stat')

--- a/utk_curio/backend/server.py
+++ b/utk_curio/backend/server.py
@@ -5,47 +5,11 @@ from utk_curio.backend.config import CURIO_SEED_EXAMPLES
 app = create_app()
 
 
-# fnmatch patterns the dev-server stat reloader must NEVER treat as
-# reload triggers (see :func:`werkzeug._reloader._find_stat_paths`).
-#
-# ``.curio/`` is user **runtime** data — package stores, staging dirs,
-# lockfiles, the SQLite DB — and must not restart the backend when
-# sources/starters are written during a package install.
-#
-# **Important:** Werkzeug's default ``reloader_type="auto"`` prefers
-# Watchdog, which applies ``exclude_patterns`` via ``pathlib.Path.match``
-# — that API does **not** reliably exclude deep paths under ``.curio/``
-# (e.g. ``…/.curio/users/…/packages/…/starters/foo.py``), so installs still
-# killed the worker with ``ERR_EMPTY_RESPONSE``. Curio therefore defaults
-# ``FLASK_RELOADER_TYPE`` to ``"stat"``, where excludes use :mod:`fnmatch`
-# on full paths and work for arbitrary depth. Set ``FLASK_RELOADER_TYPE=watchdog``
-# only if you accept that limitation.
-# `*starters*`: dynamically read per-request, not imported; also dodges
-# Windows atime-bump reload storms that drop in-flight /processPythonCode.
-RELOADER_EXCLUDE_PATTERNS = [
-    '*.duckdb', '*.duckdb.wal', '*.duckdb-shm', '*.duckdb-wal',
-    '*/.curio/*', '*/.curio', '*starters*',
-    # The Data Catalog writes computed dataset bundles (``manifest.json`` +
-    # ``data/*.parquet``) into ``<repo_root>/datasets/`` at node-execution
-    # time (catalog auto-install). Like ``.curio/`` above, these are runtime
-    # data writes, not source changes — without this exclude, a node that
-    # produces a dataset trips the stat reloader and SIGTERMs the worker
-    # mid-request, dropping the in-flight /processJavaScriptCode (the autk
-    # data node then falls back to an in-browser load that fails).
-    '*/datasets/*', '*\\datasets\\*',
-    '*/datasets', '*\\datasets',
-    # Synchronous catalog installs run ``pip install`` from inside the
-    # backend (see ``packages/pip_runner.py``); pip writes ~thousands of
-    # files into ``site-packages/`` for a heavy package like ``torch``,
-    # which would otherwise trip the stat reloader mid-install and SIGTERM
-    # the worker, dropping the in-flight install request. The sandbox
-    # shares this exclude list (sandbox/server.py imports it) so its
-    # equivalent ``/install`` endpoint is protected the same way.
-    '*/site-packages/*', '*\\site-packages\\*',
-    '*/site-packages', '*\\site-packages',
-]
-
-DEFAULT_RELOADER_TYPE = os.getenv('FLASK_RELOADER_TYPE', 'stat')
+# Shared with sandbox/server.py; see utk_curio/backend/reloader.py.
+from utk_curio.backend.reloader import (  # noqa: E402,F401  (re-exported)
+    DEFAULT_RELOADER_TYPE,
+    RELOADER_EXCLUDE_PATTERNS,
+)
 
 with app.app_context():
     try:

--- a/utk_curio/backend/tests/conftest.py
+++ b/utk_curio/backend/tests/conftest.py
@@ -79,10 +79,11 @@ _TEST_SQLA_DB = os.path.join(_TEST_DB_DIR, "urban_workflow_test.db")
 # those own the DB lifecycle and the running backend is holding sqlite
 # connections we shouldn't yank.
 if _TEST_OWNED_DIR is not None:
-    try:
-        os.remove(_TEST_SQLA_DB)
-    except FileNotFoundError:
-        pass
+    for _suffix in ("", "-wal", "-shm"):   # the DB and its WAL sidecars
+        try:
+            os.remove(_TEST_SQLA_DB + _suffix)
+        except FileNotFoundError:
+            pass
 
 os.environ["CURIO_TESTING"] = "1"
 os.environ["CURIO_LAUNCH_CWD"] = _TEST_WORKSPACE

--- a/utk_curio/backend/tests/test_frontend/utils.py
+++ b/utk_curio/backend/tests/test_frontend/utils.py
@@ -1375,7 +1375,14 @@ def _request_json(
         return json.loads(body)
 
 
-def _post_json(url: str, payload: dict, timeout: float = 10.0) -> dict:
+# 60 s, not 10: under ``--parallel`` four backends share the CPU with four
+# Chromiums, and a stub-login that seeds the examples for a fresh user was
+# measured taking 15-48 s to answer. The server does finish; a client that
+# gives up at 10 s turns that into a class-wide setup error.
+HTTP_TIMEOUT_S = 60.0
+
+
+def _post_json(url: str, payload: dict, timeout: float = HTTP_TIMEOUT_S) -> dict:
     """POST *payload* as JSON to *url* and return the parsed JSON body."""
     return _request_json(url, method="POST", payload=payload, timeout=timeout)
 
@@ -1535,7 +1542,7 @@ def install_session_cookie(page, frontend_url: str, token: str) -> None:
     )
 
 
-def _await_session(backend_url: str, token: str, *, timeout: float = 10.0) -> None:
+def _await_session(backend_url: str, token: str, *, timeout: float = HTTP_TIMEOUT_S) -> None:
     """Block until *token* authenticates, or fail saying it never did.
 
     Not defensive padding - it closes a real race in this harness. The autouse

--- a/utk_curio/main.py
+++ b/utk_curio/main.py
@@ -550,10 +550,13 @@ def prepare_backend_database():
             env["DATABASE_URL"] = test_url
             # Testing wipes the SQLA file so every `curio start` lands on
             # an empty-but-migrated DB, like Django's TEST_RUNNER.
-            try:
-                os.remove(test_sqla)
-            except FileNotFoundError:
-                pass
+            # WAL sidecars too: a stale -wal next to a fresh file is ignored by
+            # SQLite but confuses anyone reading the directory.
+            for suffix in ("", "-wal", "-shm"):
+                try:
+                    os.remove(test_sqla + suffix)
+                except FileNotFoundError:
+                    pass
 
         # `flask db upgrade` is idempotent — alembic skips already-applied
         # revisions. Running it on every startup avoids the "schema is

--- a/utk_curio/sandbox/server.py
+++ b/utk_curio/sandbox/server.py
@@ -123,7 +123,9 @@ if __name__ == '__main__':
     # Reuse the backend's exclude list and default **stat** reloader so
     # Watchdog's pathlib-based ignores cannot miss deep ``.curio/`` paths
     # (same ``ERR_EMPTY_RESPONSE`` mid-install failure as the backend).
-    from utk_curio.backend.server import (
+    # The leaf module, not backend.server: importing that builds the backend
+    # app and hits its database (see utk_curio/backend/reloader.py).
+    from utk_curio.backend.reloader import (
         DEFAULT_RELOADER_TYPE,
         RELOADER_EXCLUDE_PATTERNS,
     )


### PR DESCRIPTION
Follow-ups from the first 4-worker runs.

- SQLite now runs in WAL mode with a 30 s busy_timeout on every connection the backend process opens (all modes, not only tests). Rollback-journal mode let one writer block every reader and the 5 s default timeout turned that into 500s under load: 192/20/12 'database is locked' errors across three backends in one 4-worker run, which made GET /api/projects 500 and whole workflow groups error at setup. Same run after the change: 0.
- sandbox/server.py imported two reloader constants from backend/server.py, which builds the backend Flask app and queries the DB on import; every sandbox boot constructed a backend. Constants moved to utk_curio/backend/reloader.py (re-exported from backend/server.py, so test_installer.py is unchanged).
- Wiping the test DB also removes its -wal/-shm sidecars.
- The e2e harness's HTTP timeout goes 10 s -> 60 s: under 4-way load a stub-login that seeds the examples for a new user was measured answering in 15-48 s.