### PR TITLE
Export catalog packages and built-in agents the account never installed (#275)

### DIFF
--- a/utk_curio/backend/app/agents/routes.py
+++ b/utk_curio/backend/app/agents/routes.py
@@ -293,9 +293,7 @@ def read_definition(coord: str):
     exactly the shape ``POST /api/agents/imports/upload`` consumes, so the two
     round-trip.
     """
-    from utk_curio.backend.app.agents import storage as agents_storage
-
-    bundle = agents_storage.read_definition_bundle(_user_dir_key(g.user), coord)
+    bundle = agents_services.read_definition_bundle_anywhere(_user_dir_key(g.user), coord)
     if bundle is None:
         return jsonify({"error": f"no agent definition {coord}"}), 404
     return jsonify(bundle), 200

--- a/utk_curio/backend/app/agents/services.py
+++ b/utk_curio/backend/app/agents/services.py
@@ -160,6 +160,48 @@ def _resolve_definition(user_key: str, coord: str) -> AgentManifest | None:
     return publications.get_published_manifest(coord)
 
 
+def builtin_definition_bundle(coord: str) -> dict | None:
+    """A built-in's ``{manifest, prompts}`` straight from the roster and
+    ``llm-prompts/``, without materializing anything into a store."""
+    spec = builtin.get_builtin_spec(coord)
+    if spec is None:
+        return None
+    manifest = builtin.build_builtin_manifest(spec)
+    prompts: dict[str, str] = {}
+    for key, asset in manifest["prompts"].items():
+        text = builtin.read_prompt_text(coord, key)
+        if text is not None:
+            prompts[asset["path"]] = text
+    return {"manifest": manifest, "prompts": prompts}
+
+
+def read_definition_bundle_anywhere(user_key: str, coord: str) -> dict | None:
+    """The exportable definition of *coord* from wherever it is (#275).
+
+    ``GET /api/agents/definitions/<coord>`` read the user store only, so
+    "View details -> Export" on the Agent Catalog page - which lists the whole
+    roster and the shared catalog - failed for any agent this account had not
+    imported or installed, including every built-in. The precedence here is
+    :func:`_resolve_definition`'s: an owned import shadows everything, then
+    the built-in roster (so a stale materialized copy does not win over the
+    current prompts), then a built-in's store copy, then the published catalog.
+    """
+    store = storage.read_definition_bundle(user_key, coord)
+    if store is not None:
+        trust = ((store.get("manifest") or {}).get("provenance") or {}).get("trust")
+        if trust != "built-in":
+            return store
+    roster = builtin_definition_bundle(coord)
+    if roster is not None:
+        return roster
+    if store is not None:
+        return store
+    try:
+        return storage.read_definition_bundle_from_dir(publications.published_agent_dir(coord))
+    except (AgentManifestError, PathTraversalError):
+        return None
+
+
 def _require_definition(user_key: str, coord: str) -> AgentManifest:
     m = _resolve_definition(user_key, coord)
     if m is None:

--- a/utk_curio/backend/app/agents/storage.py
+++ b/utk_curio/backend/app/agents/storage.py
@@ -113,7 +113,16 @@ def read_definition_bundle(user_key: str, dir_name: str) -> dict | None:
     ``write_definition`` and ``upload_import`` consume, so the two round-trip.
     ``None`` when there is no such definition.
     """
-    target = agent_definition_dir(user_key, dir_name)
+    return read_definition_bundle_from_dir(agent_definition_dir(user_key, dir_name))
+
+
+def read_definition_bundle_from_dir(target: Path) -> dict | None:
+    """The bundle for a definition directory wherever it lives.
+
+    Factored out of :func:`read_definition_bundle` so the shared published
+    catalog can be read the same way (#275); the user store is one location a
+    definition may be in, not the only one.
+    """
     manifest_path = target / "manifest.json"
     if not manifest_path.is_file():
         return None

--- a/utk_curio/backend/app/packages/installer.py
+++ b/utk_curio/backend/app/packages/installer.py
@@ -703,6 +703,18 @@ def install_packageage_from_directory(
     """
     if not source_dir.is_dir():
         raise InstallerError(f"catalog source {source_dir} is not a directory")
+    return install_packageage_from_archive(user_key, zip_package_tree(source_dir), replace=replace)
+
+
+def zip_package_tree(source_dir: Path) -> bytes:
+    """A deterministic ``.curio.zip`` of one package directory.
+
+    Sorted walk, deflate, ``integrity.json`` left out: that file is the
+    installer's own record of what it copied and is rewritten on every install,
+    so an archive must not carry one. Shared by the catalog install (which
+    re-zips a catalog directory to reuse the sideload validator) and the export
+    routes, so the two cannot drift apart in what they emit.
+    """
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
         for entry in sorted(source_dir.rglob("*")):
@@ -712,27 +724,36 @@ def install_packageage_from_directory(
                 continue
             rel = entry.relative_to(source_dir).as_posix()
             zf.write(entry, arcname=rel)
-    return install_packageage_from_archive(user_key, buf.getvalue(), replace=replace)
+    return buf.getvalue()
 
 
-def export_packageage_archive(user_key: str, dir_name: str) -> bytes:
-    """Repackage an installed package back into a deterministic ``.curio.zip`` zip.
+def export_packageage_archive(
+    user_key: str,
+    dir_name: str,
+    *,
+    catalog_root: Path | None = None,
+) -> bytes:
+    """Repackage a package back into a deterministic ``.curio.zip`` zip.
 
     Useful for the factory ("Export package" button) and for migrating an
     installed package from one user to another. The archive layout matches
     the one :func:`install_packageage_from_archive` accepts, so a round-trip
     install -> export -> install is lossless.
+
+    The user's own store copy is preferred. When the account has never
+    installed the package but it is in the committed catalog (*catalog_root*),
+    the catalog copy is exported instead: the Node Catalog page offers "View
+    details -> Export" on every row it lists, and a row the user had not added
+    answered ``package X is not installed`` - true, and useless from a page
+    whose whole point is that the package is right there (#275).
     """
     target = package_dir(user_key, dir_name)
-    if not target.is_dir():
-        raise InstallerError(f"package {dir_name} is not installed")
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
-        for entry in sorted(target.rglob("*")):
-            if not entry.is_file():
-                continue
-            if entry.name == "integrity.json":
-                continue
-            rel = entry.relative_to(target).as_posix()
-            zf.write(entry, arcname=rel)
-    return buf.getvalue()
+    if target.is_dir():
+        return zip_package_tree(target)
+    if catalog_root is not None:
+        base = catalog_root.resolve()
+        candidate = (base / dir_name).resolve()
+        if is_within(candidate, base) and (candidate / "manifest.json").is_file():
+            return zip_package_tree(candidate)
+        raise InstallerError(f"package {dir_name} is neither installed nor in the catalog")
+    raise InstallerError(f"package {dir_name} is not installed")

--- a/utk_curio/backend/app/packages/routes.py
+++ b/utk_curio/backend/app/packages/routes.py
@@ -686,7 +686,9 @@ def patch_package_metadata(dir_name: str):
 def download_packageage_archive(dir_name: str):
     user_key = _user_dir_key(g.user)
     try:
-        body = export_packageage_archive(user_key, dir_name)
+        # Falls back to the committed catalog copy for a package this account
+        # never installed - the catalog page exports every row it lists (#275).
+        body = export_packageage_archive(user_key, dir_name, catalog_root=_catalog_root())
     except (InstallerError, PackageIdError) as exc:
         return _error(str(exc), 404)
     response = Response(body, mimetype="application/zip")

--- a/utk_curio/backend/tests/test_agents/test_routes.py
+++ b/utk_curio/backend/tests/test_agents/test_routes.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
+import shutil
 
 import pytest
 
-from utk_curio.backend.app.agents import ledger, storage
+from utk_curio.backend.app.agents import ledger, publications, storage
 from utk_curio.backend.app.projects.services import _user_dir_key
 
 
@@ -8189,3 +8190,66 @@ class TestProviderModels:
     def test_requires_auth(self, client):
         assert client.post(self.URL, json={}).status_code == 401
 
+
+
+class TestReadDefinition:
+    """``GET /api/agents/definitions/<coord>`` reads from wherever the agent is (#275).
+
+    It read the user store only, so "View details -> Export" on the Agent
+    Catalog page - which lists the whole roster and the shared catalog - failed
+    for any agent this account had not imported, including every built-in, and
+    the page could only say "Export failed".
+    """
+
+    BUILTIN = "agent.node-researcher@1.0.0"
+
+    def test_a_builtin_is_readable_without_ever_importing_it(self, client, user_and_token, tmp_curio):
+        _, token = user_and_token
+        r = client.get(f"/api/agents/definitions/{self.BUILTIN}", headers=_auth(token))
+        assert r.status_code == 200, r.get_json()
+        body = r.get_json()
+        assert body["manifest"]["id"] == "agent.node-researcher"
+        assert body["manifest"]["provenance"]["trust"] == "built-in"
+        declared = {asset["path"] for asset in body["manifest"]["prompts"].values()}
+        assert declared, "a built-in declares its prompt files"
+        # Every declared prompt travels with its text, from llm-prompts/.
+        assert declared <= set(body["prompts"]), (declared, set(body["prompts"]))
+        assert all(body["prompts"][p].strip() for p in declared)
+
+    def test_an_owned_import_is_readable(self, client, user_and_token, tmp_curio):
+        user, token = user_and_token
+        coord = _write_def(user)
+        r = client.get(f"/api/agents/definitions/{coord}", headers=_auth(token))
+        assert r.status_code == 200
+        assert r.get_json()["manifest"]["id"] == "agent.node-explainer"
+
+    def test_a_published_only_definition_is_readable(self, client, user_and_token, tmp_curio):
+        user, token = user_and_token
+        coord = _write_def(user, agent_id="agent.shared-only")
+        src = storage.agent_definition_dir(_user_dir_key(user), coord)
+        publications.publish_from_dir(src, coord)
+        shutil.rmtree(src)  # this account no longer holds a copy
+
+        r = client.get(f"/api/agents/definitions/{coord}", headers=_auth(token))
+        assert r.status_code == 200, r.get_json()
+        assert r.get_json()["manifest"]["id"] == "agent.shared-only"
+
+    def test_an_unknown_coordinate_is_still_404(self, client, user_and_token, tmp_curio):
+        _, token = user_and_token
+        r = client.get("/api/agents/definitions/agent.nope@1.0.0", headers=_auth(token))
+        assert r.status_code == 404
+        assert "agent.nope@1.0.0" in r.get_json()["error"]
+
+    def test_an_exported_builtin_round_trips_through_upload(self, client, user_and_token, tmp_curio):
+        """What Export writes for a built-in, Import accepts - under a new id."""
+        _, token = user_and_token
+        bundle = client.get(f"/api/agents/definitions/{self.BUILTIN}", headers=_auth(token)).get_json()
+        manifest = dict(bundle["manifest"])
+        manifest["id"] = "agent.node-researcher-copy"
+        manifest["provenance"] = {"publisher": "alice", "trust": "imported"}
+        r = client.post(
+            "/api/agents/imports/upload",
+            json={"manifest": manifest, "prompts": bundle["prompts"]},
+            headers=_auth(token),
+        )
+        assert r.status_code in (200, 201), r.get_json()

--- a/utk_curio/backend/tests/test_frontend/test_catalog_detail_export_e2e.py
+++ b/utk_curio/backend/tests/test_frontend/test_catalog_detail_export_e2e.py
@@ -1,0 +1,94 @@
+"""Export from "View details" works for rows the account never installed (#275).
+
+The Node and Agent Catalog pages list the whole shipped catalog and the whole
+built-in roster, and every row's details view has an Export button. Both export
+paths read only this account's store, so a package the user had not added
+answered ``package X is not installed`` and a built-in agent never imported
+produced a bare ``Export failed.`` in the Prompts section. Nothing downloaded.
+
+Two rows are exported here, on a fresh account that has installed nothing: the
+package and the agent named in the report.
+"""
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+
+from playwright.sync_api import expect
+
+from .utils import (
+    require_project_page,
+    require_user_auth,
+    stub_db_login,
+)
+
+#: Shipped in packages/, referenced by no example, so no seeder installs it.
+PACKAGE_NAME = "Urban Heat Vulnerability Index"
+PACKAGE_DIR = "ai.urbanlab.uhvi@1"
+
+#: A built-in from the roster; readable without ever being imported.
+AGENT_NAME = "Node Researcher"
+AGENT_DIR = "agent.node-researcher@1.0.0"
+
+
+def _login(page, app_frontend, current_server):
+    require_project_page()
+    require_user_auth()
+    return stub_db_login(
+        page,
+        frontend_url=app_frontend.base_url,
+        backend_url=current_server,
+        username="catalog_export_user",
+        name="Catalog Export User",
+    )
+
+
+def _open_details(page, base: str, path: str, heading: str, name: str) -> None:
+    page.goto(f"{base}{path}")
+    expect(page.get_by_role("heading", name=heading, level=1)).to_be_visible(timeout=20000)
+    # A card is an <article> titled by an <h2>; its "View details" is a plain
+    # link-styled button, so scope by the card rather than by an aria-label.
+    card = page.locator("article").filter(
+        has=page.get_by_role("heading", name=name, level=2, exact=True),
+    )
+    card.first.wait_for(state="visible", timeout=20000)
+    card.first.get_by_role("button", name="View details").click(timeout=20000)
+    expect(page.get_by_role("dialog")).to_be_visible(timeout=10000)
+
+
+def test_a_catalog_only_package_exports_from_view_details(app_frontend, current_server, page):
+    _login(page, app_frontend, current_server)
+    _open_details(page, app_frontend.base_url, "/catalog/nodes", "Node Catalog", PACKAGE_NAME)
+
+    dialog = page.get_by_role("dialog")
+    with page.expect_download(timeout=30000) as info:
+        dialog.get_by_role("button", name="Export").click()
+    download = info.value
+
+    assert download.suggested_filename == f"{PACKAGE_DIR}.curio.zip"
+    with zipfile.ZipFile(download.path()) as zf:
+        names = zf.namelist()
+        manifest = json.loads(zf.read("manifest.json"))
+    assert manifest["id"] == "ai.urbanlab.uhvi", manifest
+    assert "integrity.json" not in names
+    # No error line appeared under the header.
+    assert dialog.locator("text=/is not installed|Export failed/i").count() == 0
+
+
+def test_a_builtin_agent_exports_from_view_details(app_frontend, current_server, page):
+    _login(page, app_frontend, current_server)
+    _open_details(page, app_frontend.base_url, "/catalog/agents", "Agent Catalog", AGENT_NAME)
+
+    dialog = page.get_by_role("dialog")
+    with page.expect_download(timeout=30000) as info:
+        dialog.get_by_role("button", name="Export").click()
+    download = info.value
+
+    assert download.suggested_filename == f"{AGENT_DIR}.curio-agent.json"
+    with open(download.path(), "rb") as fh:
+        bundle = json.load(io.TextIOWrapper(fh, encoding="utf-8"))
+    assert bundle["manifest"]["id"] == "agent.node-researcher", bundle["manifest"]
+    declared = {asset["path"] for asset in bundle["manifest"]["prompts"].values()}
+    assert declared and declared <= set(bundle["prompts"]), (declared, list(bundle["prompts"]))
+    assert dialog.locator("[data-curio-export-error]").count() == 0

--- a/utk_curio/backend/tests/test_packages/test_installer.py
+++ b/utk_curio/backend/tests/test_packages/test_installer.py
@@ -583,3 +583,22 @@ def test_validate_copy_lands_beside_the_tree_it_validates(tmp_curio, make_archiv
     assert seen, "the validate copy should declare an explicit parent dir"
     assert all(d and "package-staging" in d for d in seen), seen
 
+
+
+def test_zip_package_tree_is_what_both_install_and_export_emit(tmp_path):
+    """One zip writer for the catalog install and the export routes (#275).
+
+    The two loops were byte-for-byte copies; when export learned to read the
+    catalog they became one function, and this pins what it leaves out.
+    """
+    from utk_curio.backend.app.packages.installer import zip_package_tree
+
+    src = tmp_path / "pkg@1"
+    (src / "sources").mkdir(parents=True)
+    (src / "manifest.json").write_text("{}", encoding="utf-8")
+    (src / "sources" / "a.py").write_text("print(1)", encoding="utf-8")
+    (src / "integrity.json").write_text("{}", encoding="utf-8")
+
+    with zipfile.ZipFile(io.BytesIO(zip_package_tree(src))) as zf:
+        names = zf.namelist()
+    assert names == ["manifest.json", "sources/a.py"]

--- a/utk_curio/backend/tests/test_packages/test_routes.py
+++ b/utk_curio/backend/tests/test_packages/test_routes.py
@@ -1140,3 +1140,72 @@ def test_catalog_install_replace_refreshes_behavior_bundle(
 
     served = client.get(bundle_url, headers=_auth(token)).get_data(as_text=True)
     assert "build 2" in served
+
+
+# ---------------------------------------------------------------------------
+# GET /api/packages/<dir>/archive for a package this account never installed
+# ---------------------------------------------------------------------------
+
+class TestExportFromTheCatalog:
+    """The catalog page exports every row it lists (#275).
+
+    ``export_packageage_archive`` read the user's store only, so "View details
+    -> Export" on a catalog row the account had not added answered
+    ``package X is not installed`` - true, and useless from a page whose whole
+    point is that the package is right there. The route now falls back to the
+    committed catalog copy.
+    """
+
+    #: In the shipped catalog, referenced by no example, so no seeder installs
+    #: it for a fresh account - the exact package the issue was filed against.
+    CATALOG_ONLY = "ai.urbanlab.uhvi@1"
+
+    def test_catalog_only_package_exports_the_catalog_copy(self, client, user_and_token, tmp_curio):
+        _, token = user_and_token
+        r = client.get(f"/api/packages/{self.CATALOG_ONLY}/archive", headers=_auth(token))
+        assert r.status_code == 200, r.get_json()
+        assert r.mimetype == "application/zip"
+        assert f'filename="{self.CATALOG_ONLY}.curio.zip"' in r.headers["Content-Disposition"]
+        with zipfile.ZipFile(io.BytesIO(r.data)) as zf:
+            names = zf.namelist()
+            manifest = json.loads(zf.read("manifest.json"))
+        assert manifest["id"] == "ai.urbanlab.uhvi"
+        assert any(n.startswith("sources/") for n in names), names
+        # The installer's own record never travels in an archive.
+        assert "integrity.json" not in names
+
+    def test_an_installed_copy_still_wins(self, client, user_and_token, tmp_curio):
+        from utk_curio.backend.app.packages.installer import (
+            install_packageage_from_directory,
+            package_dir,
+        )
+        from utk_curio.backend.app.packages.routes import _catalog_root
+        from utk_curio.backend.app.projects.services import _user_dir_key
+
+        user, token = user_and_token
+        user_key = _user_dir_key(user)
+        install_packageage_from_directory(user_key, _catalog_root() / self.CATALOG_ONLY)
+        # Change the installed copy so the two sources are distinguishable.
+        readme = package_dir(user_key, self.CATALOG_ONLY) / "README.md"
+        readme.write_text("installed copy", encoding="utf-8")
+
+        r = client.get(f"/api/packages/{self.CATALOG_ONLY}/archive", headers=_auth(token))
+        assert r.status_code == 200
+        with zipfile.ZipFile(io.BytesIO(r.data)) as zf:
+            assert zf.read("README.md").decode("utf-8") == "installed copy"
+
+    def test_a_package_in_neither_place_is_still_404(self, client, user_and_token, tmp_curio):
+        _, token = user_and_token
+        r = client.get("/api/packages/me.missing@1/archive", headers=_auth(token))
+        assert r.status_code == 404
+        assert "neither installed nor in the catalog" in r.get_json()["error"]
+
+    def test_the_catalog_fallback_cannot_escape_the_catalog(self, client, user_and_token, tmp_curio):
+        _, token = user_and_token
+        # A dir name that fails the package grammar is refused before any path
+        # is built, so the fallback never resolves a path for it. (A literal
+        # ``../`` never reaches the route: the router rejects it first.)
+        for bad in ("..@1", ".@1", "..%5C..%5Cetc@1"):
+            r = client.get(f"/api/packages/{bad}/archive", headers=_auth(token))
+            assert r.status_code == 404, (bad, r.status_code)
+            assert "error" in (r.get_json() or {}), bad

--- a/utk_curio/frontend/urban-workflows/src/components/agents/catalog/AgentDetailModal.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/agents/catalog/AgentDetailModal.tsx
@@ -35,6 +35,11 @@ export const AgentDetailModal: React.FC<AgentDetailModalProps> = ({ agent, onClo
   } | null>(null);
   const [bundleError, setBundleError] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
+  // The export's own failure, shown beside the button that caused it. It used
+  // to be folded into ``bundleError`` as a bare "Export failed." rendered under
+  // the Prompts heading - nowhere near the button, and without the server's
+  // reason (#275).
+  const [exportError, setExportError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -60,6 +65,7 @@ export const AgentDetailModal: React.FC<AgentDetailModalProps> = ({ agent, onClo
   const onExport = async () => {
     if (exporting) return;
     setExporting(true);
+    setExportError(null);
     try {
       const b = bundle ?? (await agentsApi.readDefinition(agent.dirName));
       // One file, not a manifest plus loose prompt files in two directories.
@@ -67,8 +73,10 @@ export const AgentDetailModal: React.FC<AgentDetailModalProps> = ({ agent, onClo
       // Curio imports into another in a single pick.
       const blob = new Blob([JSON.stringify(b, null, 2)], { type: "application/json" });
       triggerBlobDownload(blob, `${agent.dirName}.curio-agent.json`);
-    } catch {
-      setBundleError("Export failed.");
+    } catch (err) {
+      // apiFetch throws with the server's own ``error`` text, which says what
+      // is actually wrong ("no agent definition x") rather than that something is.
+      setExportError(err instanceof Error && err.message ? err.message : "Export failed.");
     } finally {
       setExporting(false);
     }
@@ -109,6 +117,12 @@ export const AgentDetailModal: React.FC<AgentDetailModalProps> = ({ agent, onClo
 
       <div className={styles.body}>
         {agent.purpose ? <p className={styles.purpose}>{agent.purpose}</p> : null}
+
+        {exportError ? (
+          <p className={styles.purpose} role="alert" data-curio-export-error="true">
+            Export failed: {exportError}
+          </p>
+        ) : null}
 
 
         <section className={styles.section}>

--- a/utk_curio/frontend/urban-workflows/src/components/packages/publishing/PackageDetailModal.tsx
+++ b/utk_curio/frontend/urban-workflows/src/components/packages/publishing/PackageDetailModal.tsx
@@ -64,8 +64,9 @@ export const PackageDetailModal: React.FC<PackageDetailModalProps> = ({
 
   // `packagesApi.download` streams `GET /api/packages/<dir>/archive`, the same
   // `.curio.zip` the Node Catalog's import accepts - so a package exported from
-  // one Curio installs into another. It only exists for an INSTALLED package;
-  // a catalog row the user has not added has no archive to stream.
+  // one Curio installs into another. The route serves the account's installed
+  // copy, or the committed catalog copy for a row the user has not added
+  // (#275) - so every row this page lists can be exported.
   const onExport = async () => {
     if (exporting) return;
     setExporting(true);

--- a/utk_curio/frontend/urban-workflows/src/tests/catalog/catalogActionScope.test.tsx
+++ b/utk_curio/frontend/urban-workflows/src/tests/catalog/catalogActionScope.test.tsx
@@ -490,6 +490,15 @@ describe("all three catalogs have a details view, and it is the same shape", () 
     expect(src).toContain("styles.exportButton");
   });
 
+  test("an agent export failure says what the server said, beside the button (#275)", () => {
+    // It used to be a bare `catch {}` writing "Export failed." into the Prompts
+    // section - the reason discarded, the message nowhere near the button.
+    const src = read("components/agents/catalog/AgentDetailModal.tsx");
+    expect(src).toContain("err instanceof Error");
+    expect(src).toContain("data-curio-export-error");
+    expect(src).not.toMatch(/catch \{\s*setBundleError\("Export failed\."\)/);
+  });
+
   test("the agent details view shows the prompts, which ARE the agent", () => {
     // `AgentCard` is a summary and carries no prompt text, so the details
     // screen described an agent's behaviour without showing the prompts that

--- a/utk_curio/frontend/urban-workflows/src/tests/components/packageExportButton.test.ts
+++ b/utk_curio/frontend/urban-workflows/src/tests/components/packageExportButton.test.ts
@@ -96,11 +96,11 @@ describe("packagesApi.download", () => {
       ok: false,
       status: 404,
       headers: { get: () => null },
-      json: async () => ({ error: "package me.missing@1 is not installed" }),
+      json: async () => ({ error: "package me.missing@1 is neither installed nor in the catalog" }),
     }) as unknown as typeof fetch;
 
     await expect(packagesApi.download("me.missing@1")).rejects.toThrow(
-      "package me.missing@1 is not installed",
+      "package me.missing@1 is neither installed nor in the catalog",
     );
   });
 


### PR DESCRIPTION
Addresses #275.

"View details → Export" is offered on every row the Node and Agent Catalog pages list, but both export paths read only this account's store. A package the user had not added answered `package ai.urbanlab.uhvi@1 is not installed` — true, and useless from a page whose point is that the package is right there. A built-in agent never imported (Node Researcher) 404'd and the modal discarded the reason in a bare `catch`, printing "Export failed." under the Prompts heading.

## Backend

- `export_packageage_archive` falls back to the committed catalog copy (`<repo>/packages/<dir>`, containment-checked) when the user store has none; the two identical zip loops (catalog install, export) are one `zip_package_tree`.
- `GET /api/agents/definitions/<coord>` uses the precedence `_resolve_definition` already had: owned import → built-in roster (manifest + `llm-prompts/`, nothing materialised) → built-in store copy → published catalog.
- Unknown coordinates and unknown packages still 404.

## Frontend

- `AgentDetailModal` shows the server's reason beside the Export button (`Export failed: no agent definition …`) instead of a bare label in the Prompts section.

## Tests

- pytest: catalog-only package exports with `manifest.json` and no `integrity.json`; an installed copy still wins; unknown and malformed names 404; built-in, owned and published-only agents readable; an exported built-in round-trips through `POST /api/agents/imports/upload`.
- jest: export-button pin updated, source assertion that the modal surfaces `err.message`.
- e2e `test_catalog_detail_export_e2e.py`: a fresh account exports Urban Heat Vulnerability Index and Node Researcher from the catalog pages; both downloads verified. Passes live.
- Full frontend jest and the packages/agents backend suites green.
